### PR TITLE
Issue #4: コンテナ一覧・基本操作を実装

### DIFF
--- a/WslContainersDesktop.slnx
+++ b/WslContainersDesktop.slnx
@@ -9,5 +9,6 @@
     <Project Path="tests/WslContainersDesktop.App.Tests/WslContainersDesktop.App.Tests.csproj" />
     <Project Path="tests/WslContainersDesktop.Application.Tests/WslContainersDesktop.Application.Tests.csproj" />
     <Project Path="tests/WslContainersDesktop.Domain.Tests/WslContainersDesktop.Domain.Tests.csproj" />
+    <Project Path="tests/WslContainersDesktop.Infrastructure.Tests/WslContainersDesktop.Infrastructure.Tests.csproj" />
   </Folder>
 </Solution>

--- a/docs/adr/0009-wrap-wslc-cli-for-infrastructure-layer.md
+++ b/docs/adr/0009-wrap-wslc-cli-for-infrastructure-layer.md
@@ -1,0 +1,53 @@
+# 0009. Infrastructure層で`wslc` CLIのプロセス起動ラップ方式を採用する
+
+## Status
+
+Accepted
+
+## Context
+
+- [Issue #4 [0001] コンテナ一覧・基本操作](https://github.com/runceel/wsl-containers-desktop/issues/4)
+  の実装にあたり、Infrastructure層（[ADR-0005](0005-adopt-clean-architecture-layering.md)）で
+  実際にWSL Containersと通信する方式を決める必要があった。
+- [`docs/reference/wsl-containers-platform.md`](../reference/wsl-containers-platform.md)は、
+  「WSL Container API（NuGetパッケージ, C#/WinRTネイティブ）」を第一候補、
+  「`wslc.exe`プロセス起動によるラップ」を代替案としていた。
+- 実機検証の結果、以下の事実を確認した。
+  - NuGetパッケージ `Microsoft.WSL.Containers`（net8.0-windows対象, C#/WinRT projection）は
+    `Session`/`Container`クラスを提供するが、公開APIは`CreateContainer`（自セッション内での新規作成）や
+    `PullImage`等が中心で、**既存の全コンテナを列挙するAPI（`GetContainers`相当）が存在しない**。
+    セッション内で自分が作成したコンテナを操作する用途のSDKであり、CLIや他ツールが作成した
+    既存コンテナを一覧・監視する用途には向かない。
+  - 一方 `wslc.exe` CLI（WSL 2.9.3のプレインストール環境で動作確認済み）は、
+    `wslc list -a --format json` で全コンテナ（他ツール・CLI作成分を含む）をJSON配列として
+    取得でき、`container start`/`container stop`/`container remove`等のライフサイクル操作も揃っている。
+  - `wslc container remove`（`-f`無し）は実行中のコンテナに対して非0の終了コードと
+    `stderr`への明確なエラーメッセージ（エラーコード`WSLC_E_CONTAINER_IS_RUNNING`付き）を返す。
+  - `wslc`には`restart`サブコマンドが存在しない（`stop`→`start`の組み合わせで代替する必要がある）。
+- 本Issueの受け入れ基準は「一覧表示中に、実際の状態（他ツールやCLIからの変更を含む）が反映される」
+  ことを明示的に要求しており、SDKの`Session`ベースの設計ではこれを満たせない。
+
+## Decision
+
+`WslContainersDesktop.Infrastructure`層は、`Microsoft.WSL.Containers` NuGetパッケージ（C#/WinRT SDK）
+ではなく、**`wslc.exe` CLIをプロセス起動でラップする方式**を採用する。
+
+- コンテナの一覧取得・起動・停止・削除は、いずれも`System.Diagnostics.Process`で`wslc`を起動し、
+  標準出力（JSON、またはID等）・標準エラー（エラーメッセージ）・終了コードを介して結果を得る。
+- `restart`相当の操作は、Application層（`WslContainersDesktop.Application`）が
+  `stop`→`start`のオーケストレーションとして実装する（Infrastructure層はCLIの1コマンド1操作に留める）。
+- 将来、SDKが全コンテナ列挙APIを備える等仕様が変わった場合は、本ADRを覆す新しいADRを追加し、
+  Infrastructure層の実装を差し替えることを想定する（Application層の`IContainerRuntimeClient`抽象
+  自体は変更不要な設計とする）。
+
+## Consequences
+
+- 他ツール・CLIで作成/変更されたコンテナも一覧・操作の対象にでき、受け入れ基準を満たせる。
+- CLIプロセスの起動オーバーヘッド（起動コスト、JSON/テキストパース）が発生するが、
+  デスクトップGUIアプリのユーザー操作契機の頻度では許容範囲と判断する。
+- CLIの出力フォーマット（JSON構造、エラーメッセージ文言、終了コード）が
+  Public Preview中に変更される可能性がある。Infrastructure層にこれらの解析ロジックを閉じ込め、
+  Application/Domain層への影響を防ぐ（[ADR-0005](0005-adopt-clean-architecture-layering.md)の層分割方針通り）。
+- `restart`はCLIにネイティブな操作がないため、`stop`成功後`start`が失敗する等の部分失敗が
+  起こりうる。Application層で最新状態の事前検証を行い、UI側は操作結果に応じて実際の状態に
+  同期する設計とする（詳細は[`docs/design/`](../design/README.md)のコンテナ管理関連ドキュメントを参照）。

--- a/docs/adr/0010-adopt-di-container-for-presentation.md
+++ b/docs/adr/0010-adopt-di-container-for-presentation.md
@@ -1,0 +1,58 @@
+# 0010. PresentationにDIコンテナ(Microsoft.Extensions.DependencyInjection)を導入する
+
+## Status
+
+Accepted
+
+## Context
+
+- [`docs/design/presentation-navigation.md`](../design/presentation-navigation.md)は、
+  「`Application`/`Infrastructure`が空のためDIコンテナは未導入。`MainWindow`が
+  `NavigationViewModel`を直接`new`する。Infrastructureとの結合が必要になった時点で
+  `Microsoft.Extensions.DependencyInjection`等の導入を検討する」としていた。
+- [Issue #4 [0001] コンテナ一覧・基本操作](https://github.com/runceel/wsl-containers-desktop/issues/4)
+  により、初めてInfrastructure層（[ADR-0009](0009-wrap-wslc-cli-for-infrastructure-layer.md)）と
+  Application層に実装が入り、PresentationのViewModel（`ContainersViewModel`）が
+  `IContainerManagementService`（Application層の抽象）に依存する必要が生じた。
+- [ADR-0005](0005-adopt-clean-architecture-layering.md)は「ViewModelはInfrastructureの実装クラスを
+  直接`new`しない（Presentation層のDI構成でのみ具象を解決する）」と定めており、
+  Presentation側で具象クラス（`WslcCliRunner`、`WslcCliContainerRuntimeClient`、
+  `ContainerManagementService`）を組み立てて注入する仕組みが必要になった。
+- WinUI 3の`Frame.Navigate(Type)`によるページ遷移は、対象ページがパラメーターレスの
+  コンストラクタを持つことを要求する（[`NavigationPageRegistry`](../design/presentation-navigation.md)は
+  `Type`ベースの遷移を採用済み）。そのため、ページ自身が依存解決の起点（Service Locator的な参照）を
+  持つ必要がある。
+
+## Decision
+
+`WslContainersDesktop.App`（Presentation層）に`Microsoft.Extensions.DependencyInjection`を導入する。
+
+- `App`（`App.xaml.cs`）をComposition Rootとし、コンストラクタで`ServiceCollection`を構築して
+  以下を登録する。
+  - `IWslcCliRunner → WslcCliRunner`（Infrastructure）
+  - `IContainerRuntimeClient → WslcCliContainerRuntimeClient`（Infrastructure）
+  - `IContainerManagementService → ContainerManagementService`（Application）
+  - `ContainersViewModel`（Presentation、シングルトン。トップレベルページは`NavigationViewModel`と
+    同様にアプリケーションライフタイムで1インスタンスのため）
+  - 構築した`ServiceProvider`を`public IServiceProvider Services { get; }`として`App`に公開する。
+- `ContainersPage`はパラメーターレスのコンストラクタ内で
+  `((App)Application.Current).Services.GetRequiredService<ContainersViewModel>()`により
+  ViewModelを解決する。
+- `WslContainersDesktop.App.csproj`に`WslContainersDesktop.Infrastructure`への
+  プロジェクト参照を追加する。これはDI登録（Composition Root）のためであり、
+  ViewModelやView本体がInfrastructureの具象型を直接参照するわけではないため、
+  [ADR-0005](0005-adopt-clean-architecture-layering.md)の「DI経由の抽象参照はOK」に整合する。
+- `NavigationViewModel`（依存を持たないため`MainWindow`が直接`new`する既存方式）は、
+  本ADRの対象外とし、当面現状の実装のままとする。
+
+## Consequences
+
+- ViewModel（`ContainersViewModel`）は`IContainerManagementService`という抽象にのみ依存し、
+  MSTestでのフェイクによる単体テストが可能になる。
+- Composition Root（`App.xaml.cs`）に依存解決の詳細が集約され、Infrastructureの実装差し替え
+  （例: [ADR-0009](0009-wrap-wslc-cli-for-infrastructure-layer.md)が将来覆された場合）の影響範囲を
+  `App.xaml.cs`のDI登録部分に限定できる。
+- [`docs/design/presentation-navigation.md`](../design/presentation-navigation.md)の
+  「DIコンテナは未導入」という記述は本ADRの実装をもって古くなるため、
+  実装完了後に当該ドキュメントをスナップショットとして更新する
+  （[`design-doc-maintenance`](../../.github/skills/design-doc-maintenance/SKILL.md) skill使用）。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -59,5 +59,7 @@ docs/adr/NNNN-kebab-case-title.md
 | [0006](0006-adopt-slnx-solution-file-format.md) | C#ソリューションファイル形式として.slnxを採用する | Accepted |
 | [0007](0007-disable-windows-app-sdk-deployment-manager-auto-initialize.md) | WslContainersDesktop.AppでWindowsAppSdkDeploymentManagerInitializeを無効化する | Accepted |
 | [0008](0008-expand-model-routing-to-mechanical-workflow-steps.md) | モデルルーティング方針をワークフロー内の機械的ステップへ拡張する | Accepted |
+| [0009](0009-wrap-wslc-cli-for-infrastructure-layer.md) | Infrastructure層で`wslc` CLIのプロセス起動ラップ方式を採用する | Accepted |
+| [0010](0010-adopt-di-container-for-presentation.md) | PresentationにDIコンテナ(Microsoft.Extensions.DependencyInjection)を導入する | Accepted |
 
 新しいADRを追加したら、この表にも1行追加すること。

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -17,6 +17,7 @@
 |---|---|
 | [`architecture-overview.md`](architecture-overview.md) | システム全体のレイヤー構成・依存関係の現在のスナップショット |
 | [`presentation-navigation.md`](presentation-navigation.md) | Presentation層のナビゲーション基盤・ローカライズ基盤の現在のスナップショット |
+| [`containers-view.md`](containers-view.md) | コンテナ一覧ViewModel（`ContainersViewModel`）のbusy状態管理・stale row対策・削除の楽観的更新の現在のスナップショット |
 | (機能追加に応じて追加) | 個別機能の設計ドキュメントは `docs/design/<feature-name>.md` として追加していく |
 
 ## 更新のタイミング

--- a/docs/design/containers-view.md
+++ b/docs/design/containers-view.md
@@ -1,0 +1,68 @@
+# Presentation層: コンテナ一覧ViewModelの状態管理
+
+> このドキュメントは現時点のスナップショットです。経緯・検討過程は書きません。
+
+## 概要
+
+`ContainersViewModel`（`ViewModels/ContainersViewModel.cs`）は、コンテナ一覧の取得・起動・停止・
+再起動・削除を担うViewModel。各操作は非同期に実行され、`await` 中に一覧全体が再構築されるケース
+（ユーザーによる手動更新、他操作完了に伴うバックグラウンド再同期）を考慮した設計になっている。
+
+## 行インスタンスの非永続性と再検索
+
+- `Containers`（`ObservableCollection<ContainerRowViewModel>`）は `ReplaceContainers` によって
+  丸ごと作り直される。個々の `ContainerRowViewModel` インスタンスは再構築のたびに新しくなり、
+  以前のインスタンスは破棄される。
+- そのため、非同期操作の開始時にコマンド引数として受け取った行インスタンス（`row`）は、
+  `await` の後には既にライブの `Containers` に存在しない可能性がある。この行インスタンスは
+  操作対象の `Id` を得る以外の目的で使い続けない。
+- `FindLiveRow(string containerId)` が、その時点でのライブな `Containers` からIDで行を
+  再検索する唯一の手段。`await` をまたいだ後の状態反映（busy解除、`ApplyFrom` によるプロパティ
+  反映、削除時の `Containers.Remove`）は必ずこのメソッドで取得した行に対して行う。
+
+## busy状態の永続化
+
+- 行の `IsBusy` は `ContainerRowViewModel` インスタンスに紐づくプロパティだが、上記の通り
+  インスタンスは再構築で失われる。
+- `ContainersViewModel` はコンテナID単位でbusy中のIDを `_busyContainerIds`（`HashSet<string>`）
+  に保持し、`BeginBusy`/`EndBusy` で追加・削除する。`ReplaceContainers` は新しい行を作る際に
+  この集合を参照し、busy中のIDであれば新しい行にも `IsBusy = true` を復元する。
+- `EndBusy` は、対応する `TryRefreshSilentlyAsync`（内部で `ReplaceContainers` を呼ぶ）より
+  必ず前に呼び出す。順序を守らないと、再同期後の新しい行が古いbusy記録を見て、実際には完了した
+  操作のbusy表示を解除できなくなる。
+
+## 削除の楽観的更新とpending管理
+
+- `DeleteAsync` は、Start/Stop/Restartと異なりバックグラウンドでの全件再同期を行わず、
+  成功時にその場で対象行を `Containers` から取り除く。
+- `DeleteAsync` の実行中（`await` の開始からサーバー応答まで）、対象コンテナIDを
+  `_pendingDeleteContainerIds` に記録する。`ReplaceContainers` はこの集合に含まれるIDを
+  一覧の再構築から除外するため、削除中に他操作完了に伴うベストエフォート再同期やユーザーの
+  手動更新が走っても、サーバーからまだ削除完了前の状態が返り、削除中の行が一覧に再度現れる
+  ことを防ぐ。
+- `_busyContainerIds` と `_pendingDeleteContainerIds` は役割が異なる別々の集合として管理する。
+  前者はボタンの有効/無効制御、後者は一覧からの除外制御であり、削除操作中は両方に同じIDが
+  同時に含まれ得る。
+
+## 操作失敗時の復旧
+
+- 各操作（起動・停止・再起動・削除）が例外で失敗した場合は `HandleOperationFailureAsync` に
+  処理を委譲する。`EndBusy` でbusy状態を解除し、エラーメッセージを設定したうえで
+  `TryRefreshSilentlyAsync` によりベストエフォートで一覧をサーバー側の実際の状態に合わせ直す。
+- `TryRefreshSilentlyAsync` は例外を握りつぶすため、再同期に失敗しても直前の楽観的更新
+  （またはエラー表示）を維持する。`HandleOperationFailureAsync` はこの再同期の成否を
+  `bool` としてそのまま呼び出し元へ返す。
+
+## 削除失敗時の行復元
+
+- `DeleteAsync` は削除中、対象コンテナIDを `_pendingDeleteContainerIds` に記録し、
+  `ReplaceContainers` による再構築から除外し続ける（「削除の楽観的更新とpending管理」参照）。
+  そのため、削除が例外で失敗し、かつ `HandleOperationFailureAsync` 内の復旧用リフレッシュ
+  （`TryRefreshSilentlyAsync`）も失敗した場合、対象の行は一覧から消えたまま復元されない。
+- 実際にはサーバー側にまだ存在するコンテナのため、`RestoreRowIfDeleteFailedAndMissing` が
+  「復旧用リフレッシュが失敗している」かつ「対象行が一覧に見当たらない（`FindLiveRow` で
+  未検出）」の2条件を確認したうえで、削除開始時に受け取った行インスタンスをそのまま
+  `Containers` へ戻す。
+- 復旧用リフレッシュが成功していれば、その時点のサーバー側の実際の状態が既に一覧へ
+  反映されているため、この復元処理は行わない。
+

--- a/src/WslContainersDesktop.App/App.xaml.cs
+++ b/src/WslContainersDesktop.App/App.xaml.cs
@@ -1,9 +1,15 @@
-﻿using Microsoft.UI.Xaml;
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
+using WslContainersDesktop.Application.Ports;
+using WslContainersDesktop.Application.Services;
+using WslContainersDesktop.Infrastructure.Cli;
+using WslContainersDesktop.Infrastructure.Clients;
+using WslContainersDesktop_App.ViewModels;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -16,7 +22,15 @@ namespace WslContainersDesktop_App;
 public partial class App : Application
 {
     private Window? _window;
-    
+
+    /// <summary>
+    /// Composition Root（<see href="../../docs/adr/0010-adopt-di-container-for-presentation.md">ADR-0010</see>）
+    /// が構築したサービスプロバイダー。<c>Frame.Navigate(Type)</c>ベースの遷移ではページが
+    /// パラメーターレスコンストラクタを要求されるため、ページ側からこのプロパティ経由で
+    /// 依存を解決する。
+    /// </summary>
+    public IServiceProvider Services { get; }
+
     /// <summary>
     /// Initializes the singleton application object.  This is the first line of authored code
     /// executed, and as such is the logical equivalent of main() or WinMain().
@@ -24,6 +38,22 @@ public partial class App : Application
     public App()
     {
         InitializeComponent();
+        Services = ConfigureServices();
+    }
+
+    private static IServiceProvider ConfigureServices()
+    {
+        var services = new ServiceCollection();
+
+        services.AddSingleton<IWslcCliRunner, WslcCliRunner>();
+        services.AddSingleton<IContainerRuntimeClient, WslcCliContainerRuntimeClient>();
+        services.AddSingleton<IContainerManagementService, ContainerManagementService>();
+
+        // トップレベルページのViewModelはNavigationViewModelと同様、アプリケーション
+        // ライフタイムで1インスタンスとする。
+        services.AddSingleton<ContainersViewModel>();
+
+        return services.BuildServiceProvider();
     }
 
     /// <summary>

--- a/src/WslContainersDesktop.App/Converters/AutomationIdConverter.cs
+++ b/src/WslContainersDesktop.App/Converters/AutomationIdConverter.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.UI.Xaml.Data;
+
+namespace WslContainersDesktop_App.Converters;
+
+/// <summary>
+/// コンテナIDとConverterParameter(ボタンの用途を表すprefix)から、
+/// 行ごとに一意なAutomationIdを生成する（E2Eテストでの要素特定用）。
+/// </summary>
+public sealed class AutomationIdConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, string language) =>
+        $"{parameter}_{value}";
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language) =>
+        throw new NotSupportedException();
+}

--- a/src/WslContainersDesktop.App/Converters/ContainerStateToDisplayTextConverter.cs
+++ b/src/WslContainersDesktop.App/Converters/ContainerStateToDisplayTextConverter.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.UI.Xaml.Data;
+using Windows.ApplicationModel.Resources;
+using WslContainersDesktop.Domain;
+
+namespace WslContainersDesktop_App.Converters;
+
+/// <summary>
+/// <see cref="ContainerState"/> をローカライズされた表示テキストに変換する。
+/// ListView.ItemTemplate内のx:Bindはページ(名前付き要素)を直接参照できないため、
+/// 変換ロジックはコンバーターとして切り出している。
+/// </summary>
+public sealed class ContainerStateToDisplayTextConverter : IValueConverter
+{
+    private readonly ResourceLoader _resourceLoader = new();
+
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        if (value is not ContainerState state)
+        {
+            return string.Empty;
+        }
+
+        return state switch
+        {
+            ContainerState.Running => _resourceLoader.GetString("ContainerState_Running"),
+            ContainerState.Stopped => _resourceLoader.GetString("ContainerState_Stopped"),
+            _ => state.ToString(),
+        };
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language) =>
+        throw new NotSupportedException();
+}

--- a/src/WslContainersDesktop.App/Converters/DateTimeOffsetToLocalStringConverter.cs
+++ b/src/WslContainersDesktop.App/Converters/DateTimeOffsetToLocalStringConverter.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.UI.Xaml.Data;
+
+namespace WslContainersDesktop_App.Converters;
+
+/// <summary>
+/// <see cref="DateTimeOffset"/> をローカルタイムゾーンの表示テキストに変換する。
+/// </summary>
+public sealed class DateTimeOffsetToLocalStringConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, string language) =>
+        value is DateTimeOffset dateTimeOffset
+            ? dateTimeOffset.LocalDateTime.ToString("yyyy-MM-dd HH:mm")
+            : string.Empty;
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language) =>
+        throw new NotSupportedException();
+}

--- a/src/WslContainersDesktop.App/Pages/ContainersPage.xaml
+++ b/src/WslContainersDesktop.App/Pages/ContainersPage.xaml
@@ -1,19 +1,129 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Page
     x:Class="WslContainersDesktop_App.Pages.ContainersPage"
+    x:Name="RootPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:WslContainersDesktop_App.Pages"
+    xmlns:vm="using:WslContainersDesktop_App.ViewModels"
+    xmlns:conv="using:WslContainersDesktop_App.Converters"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <Grid Padding="24,16,24,16" RowSpacing="24">
+    <Page.Resources>
+        <conv:ContainerStateToDisplayTextConverter x:Key="StateToDisplayTextConverter" />
+        <conv:DateTimeOffsetToLocalStringConverter x:Key="CreatedAtConverter" />
+        <conv:AutomationIdConverter x:Key="AutomationIdConverter" />
+    </Page.Resources>
+
+    <Grid Padding="24,16,24,16" RowSpacing="16">
         <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <TextBlock x:Name="TxtPageTitle" x:Uid="ContainersPageTitle" Style="{StaticResource TitleTextBlockStyle}" />
-        <TextBlock x:Name="TxtPageDescription" x:Uid="ContainersPageDescription" Grid.Row="1" />
+
+        <Grid Grid.Row="0" ColumnSpacing="8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <StackPanel Grid.Column="0">
+                <TextBlock x:Name="TxtPageTitle" x:Uid="ContainersPageTitle" Style="{StaticResource TitleTextBlockStyle}" />
+                <TextBlock x:Name="TxtPageDescription" x:Uid="ContainersPageDescription" />
+            </StackPanel>
+            <Button
+                x:Name="BtnRefresh"
+                Grid.Column="1"
+                x:Uid="BtnRefresh"
+                VerticalAlignment="Bottom"
+                AutomationProperties.AutomationId="BtnRefresh"
+                Command="{x:Bind ViewModel.RefreshCommand}" />
+        </Grid>
+
+        <InfoBar
+            x:Name="InfoBarError"
+            Grid.Row="1"
+            Severity="Error"
+            IsClosable="False"
+            IsOpen="{x:Bind IsNotNullOrEmpty(ViewModel.ErrorMessage), Mode=OneWay}"
+            Message="{x:Bind ViewModel.ErrorMessage, Mode=OneWay}" />
+
+        <Grid Grid.Row="2" ColumnSpacing="16" Padding="12,8,12,8" Visibility="{x:Bind ToVisibleWhenFalse(ViewModel.IsEmpty), Mode=OneWay}">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="2*" />
+                <ColumnDefinition Width="2*" />
+                <ColumnDefinition Width="120" />
+                <ColumnDefinition Width="160" />
+                <ColumnDefinition Width="360" />
+            </Grid.ColumnDefinitions>
+            <TextBlock x:Name="TxtColumnHeaderName" x:Uid="TxtColumnHeaderName" Grid.Column="0" Style="{StaticResource BodyStrongTextBlockStyle}" />
+            <TextBlock x:Name="TxtColumnHeaderImage" x:Uid="TxtColumnHeaderImage" Grid.Column="1" Style="{StaticResource BodyStrongTextBlockStyle}" />
+            <TextBlock x:Name="TxtColumnHeaderState" x:Uid="TxtColumnHeaderState" Grid.Column="2" Style="{StaticResource BodyStrongTextBlockStyle}" />
+            <TextBlock x:Name="TxtColumnHeaderCreatedAt" x:Uid="TxtColumnHeaderCreatedAt" Grid.Column="3" Style="{StaticResource BodyStrongTextBlockStyle}" />
+        </Grid>
+
+        <ListView
+            x:Name="LstContainers"
+            Grid.Row="3"
+            AutomationProperties.AutomationId="LstContainers"
+            ItemsSource="{x:Bind ViewModel.Containers, Mode=OneWay}"
+            SelectionMode="None"
+            Visibility="{x:Bind ToVisibleWhenFalse(ViewModel.IsEmpty), Mode=OneWay}">
+            <ListView.ItemTemplate>
+                <DataTemplate x:DataType="vm:ContainerRowViewModel">
+                    <Grid ColumnSpacing="16" Padding="12,8,12,8">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="2*" />
+                            <ColumnDefinition Width="2*" />
+                            <ColumnDefinition Width="120" />
+                            <ColumnDefinition Width="160" />
+                            <ColumnDefinition Width="360" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Text="{x:Bind Name, Mode=OneWay}" VerticalAlignment="Center" />
+                        <TextBlock Grid.Column="1" Text="{x:Bind Image, Mode=OneWay}" VerticalAlignment="Center" />
+                        <TextBlock Grid.Column="2" Text="{x:Bind State, Mode=OneWay, Converter={StaticResource StateToDisplayTextConverter}}" VerticalAlignment="Center" />
+                        <TextBlock Grid.Column="3" Text="{x:Bind CreatedAt, Mode=OneWay, Converter={StaticResource CreatedAtConverter}}" VerticalAlignment="Center" />
+                        <StackPanel Grid.Column="4" Orientation="Horizontal" Spacing="8">
+                            <Button
+                                x:Uid="BtnStart"
+                                AutomationProperties.AutomationId="{x:Bind Id, Mode=OneWay, Converter={StaticResource AutomationIdConverter}, ConverterParameter=BtnStart}"
+                                IsEnabled="{x:Bind CanStart, Mode=OneWay}"
+                                Command="{Binding ElementName=RootPage, Path=ViewModel.StartCommand}"
+                                CommandParameter="{x:Bind}" />
+                            <Button
+                                x:Uid="BtnStop"
+                                AutomationProperties.AutomationId="{x:Bind Id, Mode=OneWay, Converter={StaticResource AutomationIdConverter}, ConverterParameter=BtnStop}"
+                                IsEnabled="{x:Bind CanStop, Mode=OneWay}"
+                                Command="{Binding ElementName=RootPage, Path=ViewModel.StopCommand}"
+                                CommandParameter="{x:Bind}" />
+                            <Button
+                                x:Uid="BtnRestart"
+                                AutomationProperties.AutomationId="{x:Bind Id, Mode=OneWay, Converter={StaticResource AutomationIdConverter}, ConverterParameter=BtnRestart}"
+                                IsEnabled="{x:Bind CanRestart, Mode=OneWay}"
+                                Command="{Binding ElementName=RootPage, Path=ViewModel.RestartCommand}"
+                                CommandParameter="{x:Bind}" />
+                            <Button
+                                x:Uid="BtnDelete"
+                                AutomationProperties.AutomationId="{x:Bind Id, Mode=OneWay, Converter={StaticResource AutomationIdConverter}, ConverterParameter=BtnDelete}"
+                                IsEnabled="{x:Bind CanDelete, Mode=OneWay}"
+                                Click="BtnDelete_Click" />
+                        </StackPanel>
+                    </Grid>
+                </DataTemplate>
+            </ListView.ItemTemplate>
+        </ListView>
+
+        <StackPanel
+            Grid.Row="3"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            Spacing="8"
+            Visibility="{x:Bind ToVisibleWhenTrue(ViewModel.IsEmpty), Mode=OneWay}">
+            <TextBlock x:Name="TxtEmptyStateTitle" x:Uid="TxtEmptyStateTitle" HorizontalAlignment="Center" Style="{StaticResource SubtitleTextBlockStyle}" />
+            <TextBlock x:Name="TxtEmptyStateDescription" x:Uid="TxtEmptyStateDescription" HorizontalAlignment="Center" />
+        </StackPanel>
     </Grid>
 </Page>

--- a/src/WslContainersDesktop.App/Pages/ContainersPage.xaml.cs
+++ b/src/WslContainersDesktop.App/Pages/ContainersPage.xaml.cs
@@ -1,14 +1,76 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using WslContainersDesktop_App.ViewModels;
+using Windows.ApplicationModel.Resources;
 
 namespace WslContainersDesktop_App.Pages;
 
 public sealed partial class ContainersPage : Page
 {
+    private readonly ResourceLoader _resourceLoader = new();
+
     public ContainersPage()
     {
+        // Frame.Navigate(Type)によるページ遷移はパラメーターレスコンストラクタを要求するため、
+        // ADR-0010に基づきCompositionRoot(App)のServiceProvider経由でViewModelを解決する。
+        ViewModel = ((App)Application.Current).Services.GetRequiredService<ContainersViewModel>();
+
         InitializeComponent();
+
+        Loaded += ContainersPage_Loaded;
     }
+
+    public ContainersViewModel ViewModel { get; }
+
+    private async void ContainersPage_Loaded(object sender, RoutedEventArgs e)
+    {
+        // ページ表示時に最新のコンテナ一覧を取得する（受け入れ基準:
+        // 「アプリ起動後、コンテナ一覧画面に遷移すると...コンテナがすべて表示される」）。
+        await ViewModel.RefreshCommand.ExecuteAsync(null);
+    }
+
+    private async void BtnDelete_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not FrameworkElement { DataContext: ContainerRowViewModel row })
+        {
+            return;
+        }
+
+        // 削除は取り消せない操作のため、実行前に確認ダイアログを表示する
+        // （受け入れ基準: 「誤操作を防ぐ確認の上でコンテナが削除され」）。
+        var dialog = new ContentDialog
+        {
+            XamlRoot = XamlRoot,
+            Title = _resourceLoader.GetString("DeleteConfirmationDialog_Title"),
+            Content = string.Format(_resourceLoader.GetString("DeleteConfirmationDialog_Message"), row.Name),
+            PrimaryButtonText = _resourceLoader.GetString("DeleteConfirmationDialog_PrimaryButtonText"),
+            CloseButtonText = _resourceLoader.GetString("DeleteConfirmationDialog_CloseButtonText"),
+            DefaultButton = ContentDialogButton.Close,
+        };
+
+        var result = await dialog.ShowAsync();
+        if (result == ContentDialogResult.Primary)
+        {
+            await ViewModel.DeleteCommand.ExecuteAsync(row);
+        }
+    }
+
+    /// <summary>
+    /// x:Bind用のbool→Visibility変換関数。値がtrueのとき表示する。
+    /// </summary>
+    public Visibility ToVisibleWhenTrue(bool value) => value ? Visibility.Visible : Visibility.Collapsed;
+
+    /// <summary>
+    /// x:Bind用のbool→Visibility変換関数。値がfalseのとき表示する。
+    /// </summary>
+    public Visibility ToVisibleWhenFalse(bool value) => value ? Visibility.Collapsed : Visibility.Visible;
+
+    /// <summary>
+    /// x:Bind用のnull/空判定関数。<see cref="InfoBar.IsOpen"/>の表示制御に使用する。
+    /// </summary>
+    public bool IsNotNullOrEmpty(string? value) => !string.IsNullOrEmpty(value);
 }

--- a/src/WslContainersDesktop.App/Strings/en-US/Resources.resw
+++ b/src/WslContainersDesktop.App/Strings/en-US/Resources.resw
@@ -133,7 +133,58 @@
     <value>Containers</value>
   </data>
   <data name="ContainersPageDescription.Text" xml:space="preserve">
-    <value>This is the Containers placeholder page</value>
+    <value>View and manage the WSL Containers currently on this machine.</value>
+  </data>
+  <data name="BtnRefresh.Content" xml:space="preserve">
+    <value>Refresh</value>
+  </data>
+  <data name="TxtEmptyStateTitle.Text" xml:space="preserve">
+    <value>No containers found</value>
+  </data>
+  <data name="TxtEmptyStateDescription.Text" xml:space="preserve">
+    <value>Containers you create will appear here.</value>
+  </data>
+  <data name="TxtColumnHeaderName.Text" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="TxtColumnHeaderImage.Text" xml:space="preserve">
+    <value>Image</value>
+  </data>
+  <data name="TxtColumnHeaderState.Text" xml:space="preserve">
+    <value>State</value>
+  </data>
+  <data name="TxtColumnHeaderCreatedAt.Text" xml:space="preserve">
+    <value>Created</value>
+  </data>
+  <data name="BtnStart.Content" xml:space="preserve">
+    <value>Start</value>
+  </data>
+  <data name="BtnStop.Content" xml:space="preserve">
+    <value>Stop</value>
+  </data>
+  <data name="BtnRestart.Content" xml:space="preserve">
+    <value>Restart</value>
+  </data>
+  <data name="BtnDelete.Content" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="ContainerState_Running" xml:space="preserve">
+    <value>Running</value>
+  </data>
+  <data name="ContainerState_Stopped" xml:space="preserve">
+    <value>Stopped</value>
+  </data>
+  <data name="DeleteConfirmationDialog_Title" xml:space="preserve">
+    <value>Delete container</value>
+  </data>
+  <data name="DeleteConfirmationDialog_Message" xml:space="preserve">
+    <value>Are you sure you want to delete '{0}'? This action cannot be undone.</value>
+  </data>
+  <data name="DeleteConfirmationDialog_PrimaryButtonText" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="DeleteConfirmationDialog_CloseButtonText" xml:space="preserve">
+    <value>Cancel</value>
   </data>
   <data name="SettingsPageTitle.Text" xml:space="preserve">
     <value>Settings</value>

--- a/src/WslContainersDesktop.App/ViewModels/ContainerRowViewModel.cs
+++ b/src/WslContainersDesktop.App/ViewModels/ContainerRowViewModel.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using WslContainersDesktop.Domain;
+
+namespace WslContainersDesktop_App.ViewModels;
+
+/// <summary>
+/// XAMLバインディング用に <see cref="Container"/> をラップする行ViewModel。
+/// </summary>
+public sealed partial class ContainerRowViewModel : ObservableObject
+{
+    /// <summary>
+    /// <see cref="ContainerRowViewModel"/> の新しいインスタンスを初期化する。
+    /// </summary>
+    /// <param name="container">初期状態の元となるコンテナ。</param>
+    public ContainerRowViewModel(Container container)
+    {
+        Id = container.Id;
+        Name = container.Name;
+        Image = container.Image;
+        CreatedAt = container.CreatedAt;
+        State = container.State;
+    }
+
+    public string Id { get; }
+
+    public string Name { get; }
+
+    public string Image { get; }
+
+    public DateTimeOffset CreatedAt { get; }
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanStart))]
+    [NotifyPropertyChangedFor(nameof(CanStop))]
+    [NotifyPropertyChangedFor(nameof(CanRestart))]
+    [NotifyPropertyChangedFor(nameof(CanDelete))]
+    public partial ContainerState State { get; set; }
+
+    /// <summary>
+    /// この行に対する操作（起動・停止・再起動・削除）が進行中かどうか。
+    /// <see langword="true"/> の間は二重操作を防ぐため <see cref="CanStart"/>・<see cref="CanStop"/>・
+    /// <see cref="CanRestart"/>・<see cref="CanDelete"/> がすべて <see langword="false"/> になる。
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanStart))]
+    [NotifyPropertyChangedFor(nameof(CanStop))]
+    [NotifyPropertyChangedFor(nameof(CanRestart))]
+    [NotifyPropertyChangedFor(nameof(CanDelete))]
+    public partial bool IsBusy { get; set; } = false;
+
+    /// <summary>
+    /// 「起動」操作を適用できるかどうか。
+    /// </summary>
+    public bool CanStart => State == ContainerState.Stopped && !IsBusy;
+
+    /// <summary>
+    /// 「停止」操作を適用できるかどうか。
+    /// </summary>
+    public bool CanStop => State == ContainerState.Running && !IsBusy;
+
+    /// <summary>
+    /// 「再起動」操作を適用できるかどうか。
+    /// </summary>
+    public bool CanRestart => State == ContainerState.Running && !IsBusy;
+
+    /// <summary>
+    /// 「削除」操作を適用できるかどうか。
+    /// </summary>
+    public bool CanDelete => State == ContainerState.Stopped && !IsBusy;
+
+    /// <summary>
+    /// 操作結果として得られた最新の <see cref="Container"/> の状態をこの行に反映する。
+    /// </summary>
+    /// <param name="container">反映元のコンテナ。</param>
+    public void ApplyFrom(Container container)
+    {
+        State = container.State;
+    }
+}

--- a/src/WslContainersDesktop.App/ViewModels/ContainersViewModel.cs
+++ b/src/WslContainersDesktop.App/ViewModels/ContainersViewModel.cs
@@ -1,0 +1,332 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using WslContainersDesktop.Application.Ports;
+using WslContainersDesktop.Domain;
+
+namespace WslContainersDesktop_App.ViewModels;
+
+/// <summary>
+/// コンテナ一覧の表示・操作を管理するViewModel。
+/// </summary>
+public sealed partial class ContainersViewModel(IContainerManagementService containerManagementService) : ObservableObject
+{
+    /// <summary>
+    /// 実行中の操作が対象としているコンテナIDの集合。
+    /// busy状態は本来 <see cref="ContainerRowViewModel.IsBusy"/> だけで表現できるが、
+    /// <see cref="RefreshAsync"/> や操作成功後のベストエフォート再同期（<see cref="TryRefreshSilentlyAsync"/>）
+    /// では <see cref="ReplaceContainers"/> によって行インスタンスそのものが作り直されるため、
+    /// 行インスタンスに紐付く <c>IsBusy</c> だけでは再構築後にbusy状態が失われてしまう。
+    /// そこでコンテナID単位で永続する記録をこの集合に持ち、再構築後の新しい行インスタンスへ
+    /// busy状態を復元できるようにしている。
+    /// </summary>
+    private readonly HashSet<string> _busyContainerIds = [];
+
+    /// <summary>
+    /// 削除操作が進行中（実行開始からサーバー側の応答待ちの間）のコンテナIDの集合。
+    /// 削除はUI上「すでに消えたもの」として楽観的に扱うため、この集合に含まれるコンテナIDは
+    /// <see cref="ReplaceContainers"/> による再構築時に一覧へ含めない
+    /// （<see cref="RefreshAsync"/> によるユーザー手動更新や、他の行の操作完了に伴う
+    /// ベストエフォート再同期でサーバーからまだ削除完了前の状態が返ってきても、
+    /// 削除中の行が一覧に再度現れて見えるのを防ぐため）。
+    /// </summary>
+    private readonly HashSet<string> _pendingDeleteContainerIds = [];
+
+    /// <summary>
+    /// 現在表示中のコンテナ一覧。
+    /// </summary>
+    public ObservableCollection<ContainerRowViewModel> Containers { get; } = [];
+
+    /// <summary>
+    /// 直近の操作で発生したエラーメッセージ。エラーがない場合は <see langword="null"/>。
+    /// </summary>
+    [ObservableProperty]
+    public partial string? ErrorMessage { get; private set; }
+
+    /// <summary>
+    /// <see cref="Containers"/> が空かどうか。
+    /// </summary>
+    [ObservableProperty]
+    public partial bool IsEmpty { get; private set; } = true;
+
+    /// <summary>
+    /// コンテナ一覧を手動で再取得する。
+    /// </summary>
+    [RelayCommand]
+    private async Task RefreshAsync()
+    {
+        try
+        {
+            var containers = await containerManagementService.GetContainersAsync();
+            ReplaceContainers(containers);
+            ErrorMessage = null;
+        }
+        catch (Exception ex)
+        {
+            // 失敗時は直前に表示していた一覧を保持したまま、エラーメッセージのみを表示する。
+            ErrorMessage = ex.Message;
+        }
+    }
+
+    /// <summary>
+    /// 指定したコンテナを起動する。
+    /// </summary>
+    /// <param name="row">対象の行。</param>
+    [RelayCommand]
+    private Task StartAsync(ContainerRowViewModel row)
+    {
+        return ExecuteRowOperationAsync(row, () => containerManagementService.StartAsync(row.Id));
+    }
+
+    /// <summary>
+    /// 指定したコンテナを停止する。
+    /// </summary>
+    /// <param name="row">対象の行。</param>
+    [RelayCommand]
+    private Task StopAsync(ContainerRowViewModel row)
+    {
+        return ExecuteRowOperationAsync(row, () => containerManagementService.StopAsync(row.Id));
+    }
+
+    /// <summary>
+    /// 指定したコンテナを再起動する。
+    /// </summary>
+    /// <param name="row">対象の行。</param>
+    [RelayCommand]
+    private Task RestartAsync(ContainerRowViewModel row)
+    {
+        return ExecuteRowOperationAsync(row, () => containerManagementService.RestartAsync(row.Id));
+    }
+
+    /// <summary>
+    /// 指定したコンテナを削除する。呼び出し前に削除確認はView側で完了している前提。
+    /// 実行中は二重操作を防ぐため <see cref="BeginBusy"/> でコンテナIDをbusy状態にし、
+    /// 成功・失敗いずれの分岐でも <see cref="EndBusy"/> を呼んでbusy状態を解除する
+    /// （呼び出し位置の制約は <see cref="EndBusy"/> のドキュメントを参照）。
+    /// 失敗時は、削除自体は例外で終わったにもかかわらず行が一覧から消えたままになる状況
+    /// （復旧用リフレッシュも失敗し、かつ他の経路でも行が復元されていない場合）に限り、
+    /// 削除開始時に受け取った行を一覧へ戻す（詳細は <see cref="RestoreRowIfDeleteFailedAndMissing"/>
+    /// のドキュメントを参照）。
+    /// </summary>
+    /// <param name="row">対象の行。</param>
+    [RelayCommand]
+    private async Task DeleteAsync(ContainerRowViewModel row)
+    {
+        var id = row.Id;
+        BeginBusy(id);
+        _pendingDeleteContainerIds.Add(id);
+        try
+        {
+            await containerManagementService.DeleteAsync(id);
+            EndBusy(id);
+            _pendingDeleteContainerIds.Remove(id);
+
+            // 削除は一覧から行を取り除くだけで完結する操作のため、Start/Stop/Restartと異なり
+            // バックグラウンドでの全件再同期は行わない（削除後の対象コンテナはサーバー側の
+            // 一覧からも消えている前提であり、再同期の必要性が薄いため）。
+            // 取り除く行は FindLiveRow で再検索したものを使う（理由は同メソッドのドキュメントを参照）。
+            var liveRow = FindLiveRow(id);
+            if (liveRow is not null)
+            {
+                Containers.Remove(liveRow);
+            }
+
+            IsEmpty = Containers.Count == 0;
+            ErrorMessage = null;
+        }
+        catch (Exception ex)
+        {
+            // 削除処理自体は例外で失敗しているが、行が実際には削除されている等の
+            // 可能性もあるため、ベストエフォートで実際のサーバー状態にUIを合わせ直す。
+            _pendingDeleteContainerIds.Remove(id);
+            var refreshSucceeded = await HandleOperationFailureAsync(id, ex);
+            RestoreRowIfDeleteFailedAndMissing(row, refreshSucceeded);
+        }
+    }
+
+    /// <summary>
+    /// 削除失敗後、行が一覧から消えたままになっている場合に、削除開始時の行を一覧へ戻す。
+    /// </summary>
+    /// <remarks>
+    /// 復旧用リフレッシュ（<see cref="TryRefreshSilentlyAsync"/>）が成功していれば、その時点の
+    /// サーバー側の実際の状態が既に <see cref="Containers"/> へ反映されており、対象コンテナが
+    /// まだ存在するなら一覧にも含まれているはずなので、このメソッドは何もしない。
+    /// 復旧用リフレッシュが失敗した場合のみ、削除中に <see cref="_pendingDeleteContainerIds"/>
+    /// によって <see cref="ReplaceContainers"/> から除外され続けていた行が一覧から消えたまま
+    /// になっている可能性があるため、<see cref="FindLiveRow"/> で確認したうえで、実際にはサーバー
+    /// 側にまだ存在するコンテナとして、削除開始時に捕まえていた行インスタンス（<paramref name="row"/>）
+    /// をそのまま一覧へ戻す。
+    /// </remarks>
+    /// <param name="row">削除開始時に受け取った行インスタンス。</param>
+    /// <param name="refreshSucceeded">削除失敗後の復旧用リフレッシュが成功したかどうか。</param>
+    private void RestoreRowIfDeleteFailedAndMissing(ContainerRowViewModel row, bool refreshSucceeded)
+    {
+        if (refreshSucceeded || FindLiveRow(row.Id) is not null)
+        {
+            return;
+        }
+
+        row.IsBusy = false;
+        Containers.Add(row);
+        IsEmpty = false;
+    }
+
+    /// <summary>
+    /// 指定した行に対する単一コンテナ操作（起動・停止・再起動）を実行する。
+    /// 実行中は二重操作を防ぐため <see cref="BeginBusy"/> でコンテナIDをbusy状態にし、
+    /// 成功・失敗いずれの分岐でも <see cref="EndBusy"/> を呼んでbusy状態を解除する
+    /// （呼び出し位置の制約は <see cref="EndBusy"/> のドキュメントを参照）。
+    /// </summary>
+    /// <param name="row">対象の行。</param>
+    /// <param name="operation">実行する操作。成功時は更新後の <see cref="Container"/> を返す。</param>
+    private async Task ExecuteRowOperationAsync(ContainerRowViewModel row, Func<Task<Container>> operation)
+    {
+        var id = row.Id;
+        BeginBusy(id);
+        try
+        {
+            var updated = await operation();
+            EndBusy(id);
+
+            // 操作成功後は、後続のバックグラウンド再同期を待たずに即座にUIへ反映する
+            // （楽観的更新）。詳細設計フェーズのラバーダックレビューで、再同期が失敗した
+            // 場合に古い状態へ巻き戻さないための対策として導入した。
+            // 反映先は FindLiveRow で再検索した行を使う（理由は同メソッドのドキュメントを参照）。
+            var liveRow = FindLiveRow(id);
+            liveRow?.ApplyFrom(updated);
+            ErrorMessage = null;
+
+            // 楽観的更新の直後にも、他クライアントによる変更等を取り込むためベストエフォートで
+            // 一覧全体を再同期する。
+            await TryRefreshSilentlyAsync();
+        }
+        catch (Exception ex)
+        {
+            // 操作自体は例外で失敗しているが、実際にはサーバー側の状態が変化している
+            // 可能性もあるため、ベストエフォートで実際のサーバー状態にUIを合わせ直す。
+            // 戻り値（再同期の成否）は使わない。DeleteAsyncと異なり、Start/Stop/Restartの
+            // 失敗時には「一覧から消えたままの行を復元する」といった復旧処理が不要なため。
+            await HandleOperationFailureAsync(id, ex);
+        }
+    }
+
+    /// <summary>
+    /// 行操作（起動・停止・再起動・削除）が例外で失敗した場合の共通後処理。
+    /// <see cref="EndBusy"/> で対象行のbusy状態を解除し、エラーメッセージを設定したうえで、
+    /// ベストエフォートの再同期（<see cref="TryRefreshSilentlyAsync"/>）を行う。
+    /// <see cref="EndBusy"/> を再同期より前に呼ぶ理由は <see cref="EndBusy"/> 自体のドキュメントを参照。
+    /// </summary>
+    /// <param name="containerId">対象のコンテナID。</param>
+    /// <param name="exception">発生した例外。</param>
+    /// <returns>
+    /// <see cref="TryRefreshSilentlyAsync"/> の戻り値をそのまま返す。すなわち再同期が成功し
+    /// <see cref="Containers"/> がサーバー側の実際の状態に合わせ直された場合は
+    /// <see langword="true"/>、再同期にも失敗し何も変更されなかった場合は <see langword="false"/>。
+    /// </returns>
+    private async Task<bool> HandleOperationFailureAsync(string containerId, Exception exception)
+    {
+        EndBusy(containerId);
+        ErrorMessage = exception.Message;
+        return await TryRefreshSilentlyAsync();
+    }
+
+    /// <summary>
+    /// 直前の操作成功後、ベストエフォートで一覧全体を再同期する。
+    /// 失敗した場合は直前に適用した楽観的更新を維持するため、例外を握りつぶす。
+    /// </summary>
+    /// <returns>
+    /// 再同期に成功し <see cref="Containers"/> をサーバー側の実際の状態に置き換えられた場合は
+    /// <see langword="true"/>。例外を捕捉した場合は <see langword="false"/> を返し、この場合
+    /// <see cref="Containers"/> や <see cref="_busyContainerIds"/> 等の状態は一切変更しない。
+    /// </returns>
+    private async Task<bool> TryRefreshSilentlyAsync()
+    {
+        try
+        {
+            var containers = await containerManagementService.GetContainersAsync();
+            ReplaceContainers(containers);
+            return true;
+        }
+        catch
+        {
+            // ベストエフォートの再同期。失敗してもUIには何も表示しない。
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// 指定したコンテナIDをbusy状態にする。<see cref="_busyContainerIds"/> にIDを記録することで、
+    /// 操作の完了前に <see cref="ReplaceContainers"/> が呼ばれて行インスタンスが再生成されても
+    /// busy状態を復元できるようにする。あわせて、その時点でのライブの <see cref="Containers"/> に
+    /// 該当行が存在すれば、その行の <see cref="ContainerRowViewModel.IsBusy"/> も直接設定する。
+    /// </summary>
+    /// <param name="containerId">busy状態にするコンテナID。</param>
+    private void BeginBusy(string containerId)
+    {
+        _busyContainerIds.Add(containerId);
+        var liveRow = FindLiveRow(containerId);
+        if (liveRow is not null)
+        {
+            liveRow.IsBusy = true;
+        }
+    }
+
+    /// <summary>
+    /// <see cref="BeginBusy"/> で立てたbusy状態を解除する。
+    /// </summary>
+    /// <remarks>
+    /// 呼び出し側は、成功・失敗どちらの分岐であっても、この呼び出しを <c>finally</c> 節ではなく
+    /// 各分岐の中で <see cref="TryRefreshSilentlyAsync"/>（内部で行インスタンスを再生成する
+    /// <see cref="ReplaceContainers"/> を呼ぶ）より前に行う必要がある。もし <c>finally</c> で
+    /// （＝再同期の後で）解除すると、再同期によって作られた新しい行インスタンスは
+    /// <see cref="_busyContainerIds"/> に残ったままの古いIDを見てbusy状態を復元してしまい、
+    /// 実際には完了した操作のbusy表示が解除されなくなる。
+    /// </remarks>
+    /// <param name="containerId">busy状態を解除するコンテナID。</param>
+    private void EndBusy(string containerId)
+    {
+        _busyContainerIds.Remove(containerId);
+        var liveRow = FindLiveRow(containerId);
+        if (liveRow is not null)
+        {
+            liveRow.IsBusy = false;
+        }
+    }
+
+    /// <summary>
+    /// その時点でのライブの <see cref="Containers"/> から、コンテナIDに一致する行インスタンスを探す。
+    /// <see cref="ReplaceContainers"/> によって行インスタンスが再生成された後は、操作開始時に
+    /// 捕まえていた行インスタンスがすでにライブのコレクションに存在しない場合があるため、
+    /// await をまたいだ後の行操作は必ずこのメソッドで再検索した行に対して行う。
+    /// </summary>
+    /// <param name="containerId">検索するコンテナID。</param>
+    /// <returns>見つかった行。存在しない場合は <see langword="null"/>。</returns>
+    private ContainerRowViewModel? FindLiveRow(string containerId) => Containers.FirstOrDefault(r => r.Id == containerId);
+
+    private void ReplaceContainers(IReadOnlyList<Container> containers)
+    {
+        Containers.Clear();
+        foreach (var container in containers)
+        {
+            if (_pendingDeleteContainerIds.Contains(container.Id))
+            {
+                // 削除操作が進行中のコンテナは、サーバーからまだ削除完了前の状態が
+                // 返ってきていても一覧に含めない（削除の楽観的更新）。
+                continue;
+            }
+
+            var row = new ContainerRowViewModel(container);
+            if (_busyContainerIds.Contains(container.Id))
+            {
+                row.IsBusy = true;
+            }
+
+            Containers.Add(row);
+        }
+
+        IsEmpty = Containers.Count == 0;
+    }
+}

--- a/src/WslContainersDesktop.App/WslContainersDesktop.App.csproj
+++ b/src/WslContainersDesktop.App/WslContainersDesktop.App.csproj
@@ -61,6 +61,7 @@
   -->
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.2270" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.2.0" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="0.4.0" />
@@ -68,6 +69,7 @@
   <ItemGroup>
     <ProjectReference Include="..\WslContainersDesktop.Application\WslContainersDesktop.Application.csproj" />
     <ProjectReference Include="..\WslContainersDesktop.Domain\WslContainersDesktop.Domain.csproj" />
+    <ProjectReference Include="..\WslContainersDesktop.Infrastructure\WslContainersDesktop.Infrastructure.csproj" />
   </ItemGroup>
 
   <!--

--- a/src/WslContainersDesktop.Application/Exceptions/ContainerManagementException.cs
+++ b/src/WslContainersDesktop.Application/Exceptions/ContainerManagementException.cs
@@ -1,0 +1,17 @@
+namespace WslContainersDesktop.Application.Exceptions;
+
+/// <summary>
+/// コンテナ管理ユースケースで発生する例外の基底クラス。
+/// </summary>
+public abstract class ContainerManagementException : Exception
+{
+    /// <summary>
+    /// <see cref="ContainerManagementException"/> の新しいインスタンスを初期化する。
+    /// </summary>
+    /// <param name="message">エラーメッセージ。</param>
+    /// <param name="innerException">内部例外（存在する場合）。</param>
+    protected ContainerManagementException(string message, Exception? innerException = null)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/WslContainersDesktop.Application/Exceptions/ContainerNotFoundException.cs
+++ b/src/WslContainersDesktop.Application/Exceptions/ContainerNotFoundException.cs
@@ -1,0 +1,22 @@
+namespace WslContainersDesktop.Application.Exceptions;
+
+/// <summary>
+/// 指定されたIDのコンテナが見つからなかったことを表す例外。
+/// </summary>
+public sealed class ContainerNotFoundException : ContainerManagementException
+{
+    /// <summary>
+    /// <see cref="ContainerNotFoundException"/> の新しいインスタンスを初期化する。
+    /// </summary>
+    /// <param name="containerId">見つからなかったコンテナのID。</param>
+    public ContainerNotFoundException(string containerId)
+        : base($"コンテナー '{containerId}' が見つかりませんでした。")
+    {
+        ContainerId = containerId;
+    }
+
+    /// <summary>
+    /// 見つからなかったコンテナのID。
+    /// </summary>
+    public string ContainerId { get; }
+}

--- a/src/WslContainersDesktop.Application/Exceptions/ContainerRuntimeException.cs
+++ b/src/WslContainersDesktop.Application/Exceptions/ContainerRuntimeException.cs
@@ -1,0 +1,31 @@
+namespace WslContainersDesktop.Application.Exceptions;
+
+/// <summary>
+/// コンテナランタイム（wslc CLI）呼び出しが失敗したことを表す例外。
+/// </summary>
+public sealed class ContainerRuntimeException : ContainerManagementException
+{
+    /// <summary>
+    /// <see cref="ContainerRuntimeException"/> の新しいインスタンスを初期化する。
+    /// </summary>
+    /// <param name="command">実行したコマンド（診断用）。</param>
+    /// <param name="exitCode">プロセスの終了コード。</param>
+    /// <param name="message">エラーメッセージ。</param>
+    /// <param name="innerException">内部例外（存在する場合）。</param>
+    public ContainerRuntimeException(string command, int exitCode, string message, Exception? innerException = null)
+        : base(message, innerException)
+    {
+        Command = command;
+        ExitCode = exitCode;
+    }
+
+    /// <summary>
+    /// 実行したコマンド（診断用）。
+    /// </summary>
+    public string Command { get; }
+
+    /// <summary>
+    /// プロセスの終了コード。
+    /// </summary>
+    public int ExitCode { get; }
+}

--- a/src/WslContainersDesktop.Application/Exceptions/InvalidContainerOperationException.cs
+++ b/src/WslContainersDesktop.Application/Exceptions/InvalidContainerOperationException.cs
@@ -1,0 +1,29 @@
+namespace WslContainersDesktop.Application.Exceptions;
+
+/// <summary>
+/// コンテナの現在の状態に対して許可されない操作が要求されたことを表す例外。
+/// </summary>
+public sealed class InvalidContainerOperationException : ContainerManagementException
+{
+    /// <summary>
+    /// <see cref="InvalidContainerOperationException"/> の新しいインスタンスを初期化する。
+    /// </summary>
+    /// <param name="containerId">対象コンテナのID。</param>
+    /// <param name="operationName">要求された操作名（例: "Start"）。</param>
+    public InvalidContainerOperationException(string containerId, string operationName)
+        : base($"コンテナー '{containerId}' に対して操作 '{operationName}' は現在の状態では実行できません。")
+    {
+        ContainerId = containerId;
+        OperationName = operationName;
+    }
+
+    /// <summary>
+    /// 対象コンテナのID。
+    /// </summary>
+    public string ContainerId { get; }
+
+    /// <summary>
+    /// 要求された操作名。
+    /// </summary>
+    public string OperationName { get; }
+}

--- a/src/WslContainersDesktop.Application/Ports/IContainerManagementService.cs
+++ b/src/WslContainersDesktop.Application/Ports/IContainerManagementService.cs
@@ -1,0 +1,51 @@
+using WslContainersDesktop.Domain;
+
+namespace WslContainersDesktop.Application.Ports;
+
+/// <summary>
+/// コンテナ管理ユースケースを提供するインバウンドポート。
+/// </summary>
+public interface IContainerManagementService
+{
+    /// <summary>
+    /// 現在存在するすべてのコンテナを取得する。
+    /// </summary>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    Task<IReadOnlyList<Container>> GetContainersAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 指定したコンテナを起動する。停止中でない場合は
+    /// <see cref="Exceptions.InvalidContainerOperationException"/> をスローする。
+    /// </summary>
+    /// <param name="containerId">対象コンテナのID。</param>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    /// <returns>起動後のコンテナ。</returns>
+    Task<Container> StartAsync(string containerId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 指定したコンテナを停止する。実行中でない場合は
+    /// <see cref="Exceptions.InvalidContainerOperationException"/> をスローする。
+    /// </summary>
+    /// <param name="containerId">対象コンテナのID。</param>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    /// <returns>停止後のコンテナ。</returns>
+    Task<Container> StopAsync(string containerId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 指定したコンテナを再起動する。実行中でない場合は
+    /// <see cref="Exceptions.InvalidContainerOperationException"/> をスローする
+    /// （停止中のコンテナに対しては「起動」にすり替えない）。
+    /// </summary>
+    /// <param name="containerId">対象コンテナのID。</param>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    /// <returns>再起動後のコンテナ。</returns>
+    Task<Container> RestartAsync(string containerId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 指定したコンテナを削除する。停止中でない場合は
+    /// <see cref="Exceptions.InvalidContainerOperationException"/> をスローする。
+    /// </summary>
+    /// <param name="containerId">対象コンテナのID。</param>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    Task DeleteAsync(string containerId, CancellationToken cancellationToken = default);
+}

--- a/src/WslContainersDesktop.Application/Ports/IContainerRuntimeClient.cs
+++ b/src/WslContainersDesktop.Application/Ports/IContainerRuntimeClient.cs
@@ -1,0 +1,37 @@
+using WslContainersDesktop.Domain;
+
+namespace WslContainersDesktop.Application.Ports;
+
+/// <summary>
+/// コンテナランタイム（wslc CLI）との通信を抽象化するアウトバウンドポート。
+/// Infrastructure層で実装される。
+/// </summary>
+public interface IContainerRuntimeClient
+{
+    /// <summary>
+    /// 現在存在するすべてのコンテナを取得する。
+    /// </summary>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    Task<IReadOnlyList<Container>> ListContainersAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 指定したコンテナを起動する。
+    /// </summary>
+    /// <param name="containerId">対象コンテナのID。</param>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    Task StartAsync(string containerId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 指定したコンテナを停止する。
+    /// </summary>
+    /// <param name="containerId">対象コンテナのID。</param>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    Task StopAsync(string containerId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 指定したコンテナを削除する。
+    /// </summary>
+    /// <param name="containerId">対象コンテナのID。</param>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    Task DeleteAsync(string containerId, CancellationToken cancellationToken = default);
+}

--- a/src/WslContainersDesktop.Application/Services/ContainerManagementService.cs
+++ b/src/WslContainersDesktop.Application/Services/ContainerManagementService.cs
@@ -1,0 +1,83 @@
+using WslContainersDesktop.Application.Exceptions;
+using WslContainersDesktop.Application.Ports;
+using WslContainersDesktop.Domain;
+
+namespace WslContainersDesktop.Application.Services;
+
+/// <summary>
+/// <see cref="IContainerManagementService"/> の実装。
+/// 各操作の前に最新の一覧を取得してコンテナの現在状態を検証してから
+/// <see cref="IContainerRuntimeClient"/> を呼び出す。
+/// </summary>
+public sealed class ContainerManagementService(IContainerRuntimeClient runtimeClient) : IContainerManagementService
+{
+    public Task<IReadOnlyList<Container>> GetContainersAsync(CancellationToken cancellationToken = default)
+    {
+        return runtimeClient.ListContainersAsync(cancellationToken);
+    }
+
+    public async Task<Container> StartAsync(string containerId, CancellationToken cancellationToken = default)
+    {
+        var container = await FindContainerAsync(containerId, cancellationToken);
+        if (!container.CanStart)
+        {
+            throw new InvalidContainerOperationException(containerId, nameof(StartAsync));
+        }
+
+        await runtimeClient.StartAsync(containerId, cancellationToken);
+        return container with { State = ContainerState.Running };
+    }
+
+    public async Task<Container> StopAsync(string containerId, CancellationToken cancellationToken = default)
+    {
+        var container = await FindContainerAsync(containerId, cancellationToken);
+        if (!container.CanStop)
+        {
+            throw new InvalidContainerOperationException(containerId, nameof(StopAsync));
+        }
+
+        await runtimeClient.StopAsync(containerId, cancellationToken);
+        return container with { State = ContainerState.Stopped };
+    }
+
+    public async Task<Container> RestartAsync(string containerId, CancellationToken cancellationToken = default)
+    {
+        var container = await FindContainerAsync(containerId, cancellationToken);
+        if (!container.CanRestart)
+        {
+            // wslcにはrestartサブコマンドが存在しないため stop→start で代替するが、
+            // 事前に実行中であることを検証しないと、既に停止済みのコンテナに対しては
+            // 「起動」にすり替わって成功してしまう（ADR-0009参照）。
+            throw new InvalidContainerOperationException(containerId, nameof(RestartAsync));
+        }
+
+        await runtimeClient.StopAsync(containerId, cancellationToken);
+        await runtimeClient.StartAsync(containerId, cancellationToken);
+        return container with { State = ContainerState.Running };
+    }
+
+    public async Task DeleteAsync(string containerId, CancellationToken cancellationToken = default)
+    {
+        var container = await FindContainerAsync(containerId, cancellationToken);
+        if (!container.CanDelete)
+        {
+            throw new InvalidContainerOperationException(containerId, nameof(DeleteAsync));
+        }
+
+        await runtimeClient.DeleteAsync(containerId, cancellationToken);
+    }
+
+    private async Task<Container> FindContainerAsync(string containerId, CancellationToken cancellationToken)
+    {
+        var containers = await runtimeClient.ListContainersAsync(cancellationToken);
+        foreach (var container in containers)
+        {
+            if (container.Id == containerId)
+            {
+                return container;
+            }
+        }
+
+        throw new ContainerNotFoundException(containerId);
+    }
+}

--- a/src/WslContainersDesktop.Domain/Container.cs
+++ b/src/WslContainersDesktop.Domain/Container.cs
@@ -1,0 +1,32 @@
+namespace WslContainersDesktop.Domain;
+
+/// <summary>
+/// WSL Containers上のコンテナを表すエンティティ。
+/// </summary>
+/// <param name="Id">コンテナID。</param>
+/// <param name="Name">コンテナ名。</param>
+/// <param name="Image">使用イメージ名。</param>
+/// <param name="State">現在の状態。</param>
+/// <param name="CreatedAt">作成日時。</param>
+public sealed record Container(string Id, string Name, string Image, ContainerState State, DateTimeOffset CreatedAt)
+{
+    /// <summary>
+    /// 「起動」操作を適用できるかどうか。
+    /// </summary>
+    public bool CanStart => State == ContainerState.Stopped;
+
+    /// <summary>
+    /// 「停止」操作を適用できるかどうか。
+    /// </summary>
+    public bool CanStop => State == ContainerState.Running;
+
+    /// <summary>
+    /// 「再起動」操作を適用できるかどうか。
+    /// </summary>
+    public bool CanRestart => State == ContainerState.Running;
+
+    /// <summary>
+    /// 「削除」操作を適用できるかどうか（停止中のコンテナのみ削除可能）。
+    /// </summary>
+    public bool CanDelete => State == ContainerState.Stopped;
+}

--- a/src/WslContainersDesktop.Domain/ContainerState.cs
+++ b/src/WslContainersDesktop.Domain/ContainerState.cs
@@ -1,0 +1,17 @@
+namespace WslContainersDesktop.Domain;
+
+/// <summary>
+/// コンテナの状態を表す。
+/// </summary>
+public enum ContainerState
+{
+    /// <summary>
+    /// 停止中（未起動を含む）。
+    /// </summary>
+    Stopped,
+
+    /// <summary>
+    /// 実行中。
+    /// </summary>
+    Running,
+}

--- a/src/WslContainersDesktop.Infrastructure/Cli/CliResult.cs
+++ b/src/WslContainersDesktop.Infrastructure/Cli/CliResult.cs
@@ -1,0 +1,9 @@
+namespace WslContainersDesktop.Infrastructure.Cli;
+
+/// <summary>
+/// CLIプロセスの実行結果。
+/// </summary>
+/// <param name="ExitCode">プロセスの終了コード。</param>
+/// <param name="StandardOutput">標準出力の内容。</param>
+/// <param name="StandardError">標準エラー出力の内容。</param>
+public sealed record CliResult(int ExitCode, string StandardOutput, string StandardError);

--- a/src/WslContainersDesktop.Infrastructure/Cli/IWslcCliRunner.cs
+++ b/src/WslContainersDesktop.Infrastructure/Cli/IWslcCliRunner.cs
@@ -1,0 +1,15 @@
+namespace WslContainersDesktop.Infrastructure.Cli;
+
+/// <summary>
+/// 外部CLIプロセスを起動する処理を抽象化する。テストで <c>wslc.exe</c> の実体に
+/// 依存せず検証できるようにするための抽象。
+/// </summary>
+public interface IWslcCliRunner
+{
+    /// <summary>
+    /// 指定した引数でCLIプロセスを実行し、結果を返す。
+    /// </summary>
+    /// <param name="arguments">コマンドライン引数（シェル解釈を経ないargvとして渡される）。</param>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    Task<CliResult> RunAsync(IReadOnlyList<string> arguments, CancellationToken cancellationToken = default);
+}

--- a/src/WslContainersDesktop.Infrastructure/Cli/WslcCliRunner.cs
+++ b/src/WslContainersDesktop.Infrastructure/Cli/WslcCliRunner.cs
@@ -1,0 +1,52 @@
+using System.Diagnostics;
+using System.Text;
+
+namespace WslContainersDesktop.Infrastructure.Cli;
+
+/// <summary>
+/// <c>wslc</c> CLI（既定）または任意の実行可能ファイルをプロセスとして起動する
+/// <see cref="IWslcCliRunner"/> の実装。
+/// </summary>
+public sealed class WslcCliRunner(string executablePath = "wslc") : IWslcCliRunner
+{
+    /// <summary>
+    /// 実行対象の実行可能ファイルパス（既定は <c>"wslc"</c>）。
+    /// </summary>
+    public string ExecutablePath { get; } = executablePath;
+
+    public async Task<CliResult> RunAsync(IReadOnlyList<string> arguments, CancellationToken cancellationToken = default)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = ExecutablePath,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            // wslcは日本語メッセージをUTF-8で出力するため、標準出力/標準エラーの
+            // デコードにもUTF-8を明示的に使用する。
+            StandardOutputEncoding = Encoding.UTF8,
+            StandardErrorEncoding = Encoding.UTF8,
+        };
+
+        // シェル解釈を経由せず、各引数をargvとしてそのまま渡すことで
+        // スペースや特殊文字を含む値でもコマンドインジェクションの懸念なく渡せる。
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        using var process = new Process { StartInfo = startInfo };
+        process.Start();
+
+        var standardOutputTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var standardErrorTask = process.StandardError.ReadToEndAsync(cancellationToken);
+
+        await process.WaitForExitAsync(cancellationToken);
+
+        var standardOutput = await standardOutputTask;
+        var standardError = await standardErrorTask;
+
+        return new CliResult(process.ExitCode, standardOutput, standardError);
+    }
+}

--- a/src/WslContainersDesktop.Infrastructure/Clients/ContainerListItemDto.cs
+++ b/src/WslContainersDesktop.Infrastructure/Clients/ContainerListItemDto.cs
@@ -1,0 +1,28 @@
+using System.Text.Json.Serialization;
+
+namespace WslContainersDesktop.Infrastructure.Clients;
+
+/// <summary>
+/// <c>wslc list -a --format json</c> の1要素に対応するJSON DTO。
+/// </summary>
+internal sealed class ContainerListItemDto
+{
+    [JsonPropertyName("Id")]
+    public string Id { get; set; } = string.Empty;
+
+    [JsonPropertyName("Name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("Image")]
+    public string Image { get; set; } = string.Empty;
+
+    /// <summary>
+    /// wslc SDKの <c>ContainerState</c> 列挙体の数値
+    /// （Invalid=0, Created=1, Running=2, Exited=3, Deleted=4）。
+    /// </summary>
+    [JsonPropertyName("State")]
+    public int State { get; set; }
+
+    [JsonPropertyName("CreatedAt")]
+    public long CreatedAt { get; set; }
+}

--- a/src/WslContainersDesktop.Infrastructure/Clients/WslcCliContainerRuntimeClient.cs
+++ b/src/WslContainersDesktop.Infrastructure/Clients/WslcCliContainerRuntimeClient.cs
@@ -1,0 +1,86 @@
+using System.Text.Json;
+using WslContainersDesktop.Application.Exceptions;
+using WslContainersDesktop.Application.Ports;
+using WslContainersDesktop.Domain;
+using WslContainersDesktop.Infrastructure.Cli;
+
+namespace WslContainersDesktop.Infrastructure.Clients;
+
+/// <summary>
+/// <c>wslc</c> CLIをプロセスとして呼び出すことで <see cref="IContainerRuntimeClient"/> を実装する。
+/// ネイティブSDK（Microsoft.WSL.Containers）はコンテナ一覧の取得APIを提供していないため、
+/// CLIのstdoutをJSONとしてパースする方式を採用している（ADR-0009参照）。
+/// </summary>
+public sealed class WslcCliContainerRuntimeClient(IWslcCliRunner cliRunner) : IContainerRuntimeClient
+{
+    /// <summary>
+    /// wslc SDKの <c>ContainerState.Running</c> に対応する数値。
+    /// </summary>
+    private const int RunningStateValue = 2;
+
+    public async Task<IReadOnlyList<Container>> ListContainersAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await RunAsync(["list", "-a", "--format", "json"], cancellationToken);
+
+        List<ContainerListItemDto>? items;
+        try
+        {
+            items = JsonSerializer.Deserialize<List<ContainerListItemDto>>(result.StandardOutput);
+        }
+        catch (JsonException ex)
+        {
+            throw new ContainerRuntimeException(
+                command: "list -a --format json",
+                exitCode: result.ExitCode,
+                message: "コンテナ一覧の解析に失敗しました。",
+                innerException: ex);
+        }
+
+        if (items is null)
+        {
+            return [];
+        }
+
+        return items
+            .Select(item => new Container(
+                Id: item.Id,
+                Name: item.Name,
+                Image: item.Image,
+                State: item.State == RunningStateValue ? ContainerState.Running : ContainerState.Stopped,
+                CreatedAt: DateTimeOffset.FromUnixTimeSeconds(item.CreatedAt)))
+            .ToList();
+    }
+
+    public Task StartAsync(string containerId, CancellationToken cancellationToken = default)
+    {
+        return RunAsync(["container", "start", containerId], cancellationToken);
+    }
+
+    public Task StopAsync(string containerId, CancellationToken cancellationToken = default)
+    {
+        return RunAsync(["container", "stop", containerId], cancellationToken);
+    }
+
+    public Task DeleteAsync(string containerId, CancellationToken cancellationToken = default)
+    {
+        // -f（強制削除）を付けない。これにより実行中のコンテナに対する削除はwslc自体が
+        // 拒否するため、Application層での事前検証と合わせて二重に安全性が確保される
+        // （ADR-0009参照）。
+        return RunAsync(["container", "remove", containerId], cancellationToken);
+    }
+
+    private async Task<CliResult> RunAsync(IReadOnlyList<string> arguments, CancellationToken cancellationToken)
+    {
+        var result = await cliRunner.RunAsync(arguments, cancellationToken);
+        if (result.ExitCode != 0)
+        {
+            var command = string.Join(' ', arguments);
+            var message = string.IsNullOrWhiteSpace(result.StandardError)
+                ? $"コマンド '{command}' がエラーコード {result.ExitCode} で終了しました。"
+                : result.StandardError.Trim();
+            throw new ContainerRuntimeException(command, result.ExitCode, message);
+        }
+
+        return result;
+    }
+}

--- a/tests/WslContainersDesktop.App.Tests/Fakes/FakeContainerManagementService.cs
+++ b/tests/WslContainersDesktop.App.Tests/Fakes/FakeContainerManagementService.cs
@@ -1,0 +1,113 @@
+using WslContainersDesktop.Application.Ports;
+using WslContainersDesktop.Domain;
+
+namespace WslContainersDesktop_App_Tests.Fakes;
+
+/// <summary>
+/// <see cref="IContainerManagementService"/> のテスト用フェイク実装。
+/// 呼び出し回数に応じて異なる結果を返せるよう <see cref="GetContainersResults"/> をキューとして保持する。
+/// </summary>
+internal sealed class FakeContainerManagementService : IContainerManagementService
+{
+    /// <summary>
+    /// <see cref="GetContainersAsync"/> の呼び出しごとに順番に消費される結果。
+    /// 空になった後は <see cref="DefaultContainers"/> を返す。
+    /// </summary>
+    public Queue<Func<Task<IReadOnlyList<Container>>>> GetContainersResults { get; } = new();
+
+    public IReadOnlyList<Container> DefaultContainers { get; set; } = [];
+
+    public Exception? StartException { get; set; }
+
+    public Exception? StopException { get; set; }
+
+    public Exception? RestartException { get; set; }
+
+    public Exception? DeleteException { get; set; }
+
+    public TaskCompletionSource<Container>? StartAsyncGate { get; set; }
+
+    public TaskCompletionSource<Container>? StopAsyncGate { get; set; }
+
+    public TaskCompletionSource<Container>? RestartAsyncGate { get; set; }
+
+    public TaskCompletionSource<bool>? DeleteAsyncGate { get; set; }
+
+    public Container? StartResult { get; set; }
+
+    public Container? StopResult { get; set; }
+
+    public Container? RestartResult { get; set; }
+
+    public List<string> DeleteCalls { get; } = [];
+
+    public Task<IReadOnlyList<Container>> GetContainersAsync(CancellationToken cancellationToken = default)
+    {
+        if (GetContainersResults.Count > 0)
+        {
+            return GetContainersResults.Dequeue()();
+        }
+
+        return Task.FromResult(DefaultContainers);
+    }
+
+    public async Task<Container> StartAsync(string containerId, CancellationToken cancellationToken = default)
+    {
+        if (StartAsyncGate is not null)
+        {
+            await StartAsyncGate.Task;
+        }
+
+        if (StartException is not null)
+        {
+            throw StartException;
+        }
+
+        return StartResult!;
+    }
+
+    public async Task<Container> StopAsync(string containerId, CancellationToken cancellationToken = default)
+    {
+        if (StopAsyncGate is not null)
+        {
+            await StopAsyncGate.Task;
+        }
+
+        if (StopException is not null)
+        {
+            throw StopException;
+        }
+
+        return StopResult!;
+    }
+
+    public async Task<Container> RestartAsync(string containerId, CancellationToken cancellationToken = default)
+    {
+        if (RestartAsyncGate is not null)
+        {
+            await RestartAsyncGate.Task;
+        }
+
+        if (RestartException is not null)
+        {
+            throw RestartException;
+        }
+
+        return RestartResult!;
+    }
+
+    public async Task DeleteAsync(string containerId, CancellationToken cancellationToken = default)
+    {
+        DeleteCalls.Add(containerId);
+
+        if (DeleteAsyncGate is not null)
+        {
+            await DeleteAsyncGate.Task;
+        }
+
+        if (DeleteException is not null)
+        {
+            throw DeleteException;
+        }
+    }
+}

--- a/tests/WslContainersDesktop.App.Tests/ViewModels/ContainerRowViewModelTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/ViewModels/ContainerRowViewModelTests.cs
@@ -1,0 +1,88 @@
+using WslContainersDesktop.Domain;
+using WslContainersDesktop_App.ViewModels;
+
+namespace WslContainersDesktop_App_Tests.ViewModels;
+
+[TestClass]
+public sealed class ContainerRowViewModelTests
+{
+    private static Container CreateContainer(ContainerState state) => new(
+        Id: "c1",
+        Name: "web",
+        Image: "nginx:latest",
+        State: state,
+        CreatedAt: new DateTimeOffset(2026, 7, 2, 9, 0, 0, TimeSpan.Zero));
+
+    [TestMethod]
+    public void Constructor_FromContainer_PropertiesAreMappedFromContainer()
+    {
+        // Arrange
+        var container = CreateContainer(ContainerState.Running);
+
+        // Act
+        var sut = new ContainerRowViewModel(container);
+
+        // Assert
+        Assert.AreEqual("c1", sut.Id);
+        Assert.AreEqual("web", sut.Name);
+        Assert.AreEqual("nginx:latest", sut.Image);
+        Assert.AreEqual(ContainerState.Running, sut.State);
+        Assert.AreEqual(container.CreatedAt, sut.CreatedAt);
+        Assert.IsTrue(sut.CanStop);
+        Assert.IsFalse(sut.CanStart);
+    }
+
+    [TestMethod]
+    public void ApplyFrom_ContainerWithDifferentState_UpdatesStateAndCanFlags()
+    {
+        // Arrange
+        var sut = new ContainerRowViewModel(CreateContainer(ContainerState.Stopped));
+        var updated = CreateContainer(ContainerState.Running);
+
+        // Act
+        sut.ApplyFrom(updated);
+
+        // Assert
+        Assert.AreEqual(ContainerState.Running, sut.State);
+        Assert.IsTrue(sut.CanStop);
+        Assert.IsTrue(sut.CanRestart);
+        Assert.IsFalse(sut.CanStart);
+        Assert.IsFalse(sut.CanDelete);
+    }
+
+    [TestMethod]
+    public void ApplyFrom_ContainerWithDifferentState_RaisesPropertyChangedForCanFlags()
+    {
+        // Arrange
+        var sut = new ContainerRowViewModel(CreateContainer(ContainerState.Stopped));
+        var raisedProperties = new List<string>();
+        sut.PropertyChanged += (_, e) => raisedProperties.Add(e.PropertyName!);
+
+        // Act
+        sut.ApplyFrom(CreateContainer(ContainerState.Running));
+
+        // Assert
+        CollectionAssert.Contains(raisedProperties, nameof(ContainerRowViewModel.CanStart));
+        CollectionAssert.Contains(raisedProperties, nameof(ContainerRowViewModel.CanStop));
+        CollectionAssert.Contains(raisedProperties, nameof(ContainerRowViewModel.CanRestart));
+        CollectionAssert.Contains(raisedProperties, nameof(ContainerRowViewModel.CanDelete));
+    }
+
+    [TestMethod]
+    public void IsBusy_WhenTrue_DisablesAllCanFlags()
+    {
+        // Arrange
+        var stoppedRow = new ContainerRowViewModel(CreateContainer(ContainerState.Stopped));
+        var runningRow = new ContainerRowViewModel(CreateContainer(ContainerState.Running));
+
+        // Act
+        stoppedRow.IsBusy = true;
+        runningRow.IsBusy = true;
+
+        // Assert
+        Assert.IsFalse(stoppedRow.CanStart);
+        Assert.IsFalse(stoppedRow.CanDelete);
+        Assert.IsFalse(runningRow.CanStop);
+        Assert.IsFalse(runningRow.CanRestart);
+    }
+}

--- a/tests/WslContainersDesktop.App.Tests/ViewModels/ContainersViewModelTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/ViewModels/ContainersViewModelTests.cs
@@ -1,0 +1,535 @@
+using WslContainersDesktop.Application.Exceptions;
+using WslContainersDesktop.Domain;
+using WslContainersDesktop_App.ViewModels;
+using WslContainersDesktop_App_Tests.Fakes;
+
+namespace WslContainersDesktop_App_Tests.ViewModels;
+
+[TestClass]
+public sealed class ContainersViewModelTests
+{
+    private static Container CreateContainer(string id, ContainerState state) => new(
+        Id: id,
+        Name: $"name-{id}",
+        Image: "nginx:latest",
+        State: state,
+        CreatedAt: new DateTimeOffset(2026, 7, 2, 9, 0, 0, TimeSpan.Zero));
+
+    [TestMethod]
+    public async Task RefreshAsync_ServiceReturnsContainers_PopulatesRowsAndClearsErrorAndIsEmptyIsFalse()
+    {
+        // Arrange
+        var service = new FakeContainerManagementService
+        {
+            DefaultContainers = [CreateContainer("c1", ContainerState.Running), CreateContainer("c2", ContainerState.Stopped)],
+        };
+        var sut = new ContainersViewModel(service);
+
+        // Act
+        await sut.RefreshCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.HasCount(2, sut.Containers);
+        Assert.AreEqual("c1", sut.Containers[0].Id);
+        Assert.AreEqual(ContainerState.Running, sut.Containers[0].State);
+        Assert.AreEqual("c2", sut.Containers[1].Id);
+        Assert.IsFalse(sut.IsEmpty);
+        Assert.IsNull(sut.ErrorMessage);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_ServiceReturnsEmptyList_ContainersIsEmptyAndIsEmptyIsTrue()
+    {
+        // Arrange
+        var service = new FakeContainerManagementService { DefaultContainers = [] };
+        var sut = new ContainersViewModel(service);
+
+        // Act
+        await sut.RefreshCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.IsEmpty(sut.Containers);
+        Assert.IsTrue(sut.IsEmpty);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_ServiceThrowsOnSecondCall_ErrorMessageIsSetAndExistingContainersArePreserved()
+    {
+        // Arrange
+        var service = new FakeContainerManagementService();
+        service.GetContainersResults.Enqueue(() => Task.FromResult<IReadOnlyList<Container>>([CreateContainer("c1", ContainerState.Running)]));
+        service.GetContainersResults.Enqueue(() => Task.FromException<IReadOnlyList<Container>>(new ContainerRuntimeException("list", 1, "一覧の取得に失敗しました。")));
+        var sut = new ContainersViewModel(service);
+        await sut.RefreshCommand.ExecuteAsync(null);
+
+        // Act
+        await sut.RefreshCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.AreEqual("一覧の取得に失敗しました。", sut.ErrorMessage);
+        Assert.HasCount(1, sut.Containers);
+        Assert.AreEqual("c1", sut.Containers[0].Id);
+    }
+
+    [TestMethod]
+    public async Task StartAsync_ContainerIsStopped_RowStateBecomesRunningAndErrorIsCleared()
+    {
+        // Arrange
+        var service = new FakeContainerManagementService { DefaultContainers = [CreateContainer("c1", ContainerState.Stopped)] };
+        var sut = new ContainersViewModel(service);
+        await sut.RefreshCommand.ExecuteAsync(null);
+        var row = sut.Containers[0];
+        service.StartResult = CreateContainer("c1", ContainerState.Running);
+
+        // Act
+        await sut.StartCommand.ExecuteAsync(row);
+
+        // Assert
+        Assert.AreEqual(ContainerState.Running, row.State);
+        Assert.IsNull(sut.ErrorMessage);
+    }
+
+    [TestMethod]
+    public async Task StartAsync_ServiceThrowsInvalidContainerOperationException_ErrorMessageIsSetAndRowStateUnchanged()
+    {
+        // Arrange
+        var service = new FakeContainerManagementService { DefaultContainers = [CreateContainer("c1", ContainerState.Running)] };
+        var sut = new ContainersViewModel(service);
+        await sut.RefreshCommand.ExecuteAsync(null);
+        var row = sut.Containers[0];
+        service.StartException = new InvalidContainerOperationException("c1", "StartAsync");
+
+        // Act
+        await sut.StartCommand.ExecuteAsync(row);
+
+        // Assert
+        Assert.AreEqual(service.StartException.Message, sut.ErrorMessage);
+        Assert.AreEqual(ContainerState.Running, row.State);
+    }
+
+    [TestMethod]
+    public async Task StartAsync_OperationIsStillRunning_RowIsBusyBecomesTrueAndThenFalse()
+    {
+        // Arrange
+        var service = new FakeContainerManagementService { DefaultContainers = [CreateContainer("c1", ContainerState.Stopped)] };
+        var gate = new TaskCompletionSource<Container>(TaskCreationOptions.RunContinuationsAsynchronously);
+        service.StartAsyncGate = gate;
+        service.StartResult = CreateContainer("c1", ContainerState.Running);
+        var sut = new ContainersViewModel(service);
+        await sut.RefreshCommand.ExecuteAsync(null);
+        var row = sut.Containers[0];
+
+        // Act
+        var operationTask = sut.StartCommand.ExecuteAsync(row);
+
+        // Assert
+        Assert.IsTrue(row.IsBusy);
+        gate.SetResult(service.StartResult!);
+        await operationTask;
+        Assert.IsFalse(row.IsBusy);
+    }
+
+    [TestMethod]
+    public async Task StartAsync_OperationSucceeds_RowInLiveCollectionIsNotBusyAfterCompletion()
+    {
+        // Arrange
+        var service = new FakeContainerManagementService { DefaultContainers = [CreateContainer("c1", ContainerState.Stopped)] };
+        service.StartResult = CreateContainer("c1", ContainerState.Running);
+        var sut = new ContainersViewModel(service);
+        await sut.RefreshCommand.ExecuteAsync(null);
+        var row = sut.Containers[0];
+
+        // Act
+        await sut.StartCommand.ExecuteAsync(row);
+
+        // Assert
+        var refreshedRow = sut.Containers.Single(c => c.Id == "c1");
+        Assert.IsFalse(refreshedRow.IsBusy);
+    }
+
+    [TestMethod]
+    public async Task StartAsync_OperationSucceedsAfterBackgroundRefresh_SilentRefreshFailureAppliesOptimisticUpdateToLiveRow()
+    {
+        // Arrange
+        var service = new FakeContainerManagementService
+        {
+            DefaultContainers = [CreateContainer("c1", ContainerState.Stopped), CreateContainer("c2", ContainerState.Stopped)],
+        };
+        var gate = new TaskCompletionSource<Container>(TaskCreationOptions.RunContinuationsAsynchronously);
+        service.StartAsyncGate = gate;
+        service.StartResult = CreateContainer("c1", ContainerState.Running);
+        var sut = new ContainersViewModel(service);
+        await sut.RefreshCommand.ExecuteAsync(null);
+        service.GetContainersResults.Enqueue(() => Task.FromResult<IReadOnlyList<Container>>([CreateContainer("c1", ContainerState.Stopped), CreateContainer("c2", ContainerState.Stopped)]));
+        service.GetContainersResults.Enqueue(() => Task.FromException<IReadOnlyList<Container>>(new ContainerRuntimeException("list", 1, "一覧の取得に失敗しました。")));
+        var row1 = sut.Containers.Single(c => c.Id == "c1");
+
+        // Act
+        var operationTask = sut.StartCommand.ExecuteAsync(row1);
+        await sut.RefreshCommand.ExecuteAsync(null);
+        var liveRow = sut.Containers.Single(c => c.Id == "c1");
+        Assert.AreNotSame(row1, liveRow);
+        gate.SetResult(service.StartResult!);
+        await operationTask;
+
+        // Assert
+        Assert.AreEqual(ContainerState.Running, liveRow.State);
+        Assert.IsFalse(liveRow.IsBusy);
+    }
+
+    [TestMethod]
+    public async Task StartAsync_OperationFailsAfterBackgroundRefresh_LiveRowIsNotBusyAfterFailure()
+    {
+        // Arrange
+        var service = new FakeContainerManagementService
+        {
+            DefaultContainers = [CreateContainer("c1", ContainerState.Stopped), CreateContainer("c2", ContainerState.Stopped)],
+        };
+        var gate = new TaskCompletionSource<Container>(TaskCreationOptions.RunContinuationsAsynchronously);
+        service.StartAsyncGate = gate;
+        var exception = new InvalidContainerOperationException("c1", "StartAsync");
+        service.StartException = exception;
+        var sut = new ContainersViewModel(service);
+        await sut.RefreshCommand.ExecuteAsync(null);
+        service.GetContainersResults.Enqueue(() => Task.FromResult<IReadOnlyList<Container>>([CreateContainer("c1", ContainerState.Stopped), CreateContainer("c2", ContainerState.Stopped)]));
+        service.GetContainersResults.Enqueue(() => Task.FromException<IReadOnlyList<Container>>(new ContainerRuntimeException("list", 1, "一覧の取得に失敗しました。")));
+        var row1 = sut.Containers.Single(c => c.Id == "c1");
+
+        // Act
+        var operationTask = sut.StartCommand.ExecuteAsync(row1);
+        await sut.RefreshCommand.ExecuteAsync(null);
+        var liveRow = sut.Containers.Single(c => c.Id == "c1");
+        Assert.AreNotSame(row1, liveRow);
+        gate.SetException(exception);
+        await operationTask;
+
+        // Assert
+        Assert.IsFalse(liveRow.IsBusy);
+    }
+
+    [TestMethod]
+    public async Task StartAsync_OperationThrows_RowIsBusyBecomesFalseAfterFailure()
+    {
+        // Arrange
+        var service = new FakeContainerManagementService { DefaultContainers = [CreateContainer("c1", ContainerState.Stopped)] };
+        var gate = new TaskCompletionSource<Container>(TaskCreationOptions.RunContinuationsAsynchronously);
+        service.StartAsyncGate = gate;
+        var exception = new InvalidContainerOperationException("c1", "StartAsync");
+        service.StartException = exception;
+        var sut = new ContainersViewModel(service);
+        await sut.RefreshCommand.ExecuteAsync(null);
+        var row = sut.Containers[0];
+
+        // Act
+        var operationTask = sut.StartCommand.ExecuteAsync(row);
+
+        // Assert
+        Assert.IsTrue(row.IsBusy);
+        gate.SetException(exception);
+        await operationTask;
+        Assert.IsFalse(row.IsBusy);
+    }
+
+    [TestMethod]
+    public async Task StartAsync_OperationThrows_RowInLiveCollectionIsNotBusyAfterFailure()
+    {
+        // Arrange
+        var service = new FakeContainerManagementService { DefaultContainers = [CreateContainer("c1", ContainerState.Stopped)] };
+        var exception = new InvalidContainerOperationException("c1", "StartAsync");
+        service.StartException = exception;
+        var sut = new ContainersViewModel(service);
+        await sut.RefreshCommand.ExecuteAsync(null);
+        var row = sut.Containers[0];
+
+        // Act
+        await sut.StartCommand.ExecuteAsync(row);
+
+        // Assert
+        var refreshedRow = sut.Containers.Single(c => c.Id == "c1");
+        Assert.IsFalse(refreshedRow.IsBusy);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_OperationIsStillRunning_BusyStateIsPreservedAfterRefresh()
+    {
+        // Arrange
+        var service = new FakeContainerManagementService { DefaultContainers = [CreateContainer("c1", ContainerState.Stopped)] };
+        var gate = new TaskCompletionSource<Container>(TaskCreationOptions.RunContinuationsAsynchronously);
+        service.StartAsyncGate = gate;
+        service.StartResult = CreateContainer("c1", ContainerState.Running);
+        var sut = new ContainersViewModel(service);
+        await sut.RefreshCommand.ExecuteAsync(null);
+        var row = sut.Containers[0];
+
+        // Act
+        var operationTask = sut.StartCommand.ExecuteAsync(row);
+
+        try
+        {
+            await sut.RefreshCommand.ExecuteAsync(null);
+
+            // Assert
+            ContainerRowViewModel? refreshedRow = null;
+            foreach (var candidate in sut.Containers)
+            {
+                if (candidate.Id == "c1")
+                {
+                    refreshedRow = candidate;
+                    break;
+                }
+            }
+
+            Assert.IsNotNull(refreshedRow);
+            Assert.IsTrue(refreshedRow!.IsBusy);
+        }
+        finally
+        {
+            gate.SetResult(service.StartResult!);
+            await operationTask;
+        }
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_SecondOperationIsStillRunning_BusyStateForFirstOperationIsPreservedAfterRefresh()
+    {
+        // Arrange
+        var service = new FakeContainerManagementService
+        {
+            DefaultContainers = [CreateContainer("c1", ContainerState.Stopped), CreateContainer("c2", ContainerState.Stopped)],
+        };
+        var gate = new TaskCompletionSource<Container>(TaskCreationOptions.RunContinuationsAsynchronously);
+        service.StartAsyncGate = gate;
+        service.StartResult = CreateContainer("c2", ContainerState.Running);
+        var sut = new ContainersViewModel(service);
+        await sut.RefreshCommand.ExecuteAsync(null);
+        var c1Row = sut.Containers[0];
+        var c2Row = sut.Containers[1];
+
+        // Act
+        var c1OperationTask = sut.StartCommand.ExecuteAsync(c1Row);
+        service.StartAsyncGate = null;
+        var c2OperationTask = sut.StartCommand.ExecuteAsync(c2Row);
+
+        try
+        {
+            await c2OperationTask;
+
+            // Assert
+            ContainerRowViewModel? refreshedC1Row = null;
+            foreach (var candidate in sut.Containers)
+            {
+                if (candidate.Id == "c1")
+                {
+                    refreshedC1Row = candidate;
+                    break;
+                }
+            }
+
+            Assert.IsNotNull(refreshedC1Row);
+            Assert.IsTrue(refreshedC1Row!.IsBusy);
+        }
+        finally
+        {
+            gate.SetResult(service.StartResult!);
+            await c1OperationTask;
+        }
+    }
+
+    [TestMethod]
+    public async Task StopAsync_ContainerIsRunning_RowStateBecomesStopped()
+    {
+        // Arrange
+        var service = new FakeContainerManagementService { DefaultContainers = [CreateContainer("c1", ContainerState.Running)] };
+        var sut = new ContainersViewModel(service);
+        await sut.RefreshCommand.ExecuteAsync(null);
+        var row = sut.Containers[0];
+        service.StopResult = CreateContainer("c1", ContainerState.Stopped);
+
+        // Act
+        await sut.StopCommand.ExecuteAsync(row);
+
+        // Assert
+        Assert.AreEqual(ContainerState.Stopped, row.State);
+        Assert.IsNull(sut.ErrorMessage);
+    }
+
+    [TestMethod]
+    public async Task RestartAsync_ContainerIsRunning_RowStateRemainsRunningAndErrorIsCleared()
+    {
+        // Arrange
+        var service = new FakeContainerManagementService { DefaultContainers = [CreateContainer("c1", ContainerState.Running)] };
+        var sut = new ContainersViewModel(service);
+        await sut.RefreshCommand.ExecuteAsync(null);
+        var row = sut.Containers[0];
+        service.RestartResult = CreateContainer("c1", ContainerState.Running);
+
+        // Act
+        await sut.RestartCommand.ExecuteAsync(row);
+
+        // Assert
+        Assert.AreEqual(ContainerState.Running, row.State);
+        Assert.IsNull(sut.ErrorMessage);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_ContainerIsStopped_RowIsRemovedAndIsEmptyBecomesTrue()
+    {
+        // Arrange
+        var service = new FakeContainerManagementService { DefaultContainers = [CreateContainer("c1", ContainerState.Stopped)] };
+        var sut = new ContainersViewModel(service);
+        await sut.RefreshCommand.ExecuteAsync(null);
+        var row = sut.Containers[0];
+
+        // Act
+        await sut.DeleteCommand.ExecuteAsync(row);
+
+        // Assert
+        Assert.IsEmpty(sut.Containers);
+        Assert.IsTrue(sut.IsEmpty);
+        CollectionAssert.Contains(service.DeleteCalls, "c1");
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_OperationSucceedsAfterBackgroundRefresh_RemovesLiveRowFromCollection()
+    {
+        // Arrange
+        var service = new FakeContainerManagementService
+        {
+            DefaultContainers = [CreateContainer("c1", ContainerState.Stopped), CreateContainer("c2", ContainerState.Stopped)],
+        };
+        var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        service.DeleteAsyncGate = gate;
+        var sut = new ContainersViewModel(service);
+        await sut.RefreshCommand.ExecuteAsync(null);
+        var row1 = sut.Containers.Single(c => c.Id == "c1");
+
+        // Act
+        var operationTask = sut.DeleteCommand.ExecuteAsync(row1);
+        await sut.RefreshCommand.ExecuteAsync(null);
+        var liveRow = sut.Containers.SingleOrDefault(c => c.Id == "c1");
+        Assert.AreNotSame(row1, liveRow);
+        gate.SetResult(true);
+        await operationTask;
+
+        // Assert
+        Assert.IsNull(liveRow);
+        Assert.IsFalse(sut.Containers.Any(c => c.Id == "c1"));
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_OperationFailsAfterBackgroundRefreshAndRecoveryRefreshFails_RestoresRowToCollection()
+    {
+        // Arrange
+        var service = new FakeContainerManagementService
+        {
+            DefaultContainers = [CreateContainer("c1", ContainerState.Stopped), CreateContainer("c2", ContainerState.Stopped)],
+        };
+        var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        service.DeleteAsyncGate = gate;
+        var exception = new InvalidContainerOperationException("c1", "DeleteAsync");
+        service.DeleteException = exception;
+        var sut = new ContainersViewModel(service);
+        await sut.RefreshCommand.ExecuteAsync(null);
+        service.GetContainersResults.Enqueue(() => Task.FromResult<IReadOnlyList<Container>>([CreateContainer("c1", ContainerState.Stopped), CreateContainer("c2", ContainerState.Stopped)]));
+        service.GetContainersResults.Enqueue(() => Task.FromException<IReadOnlyList<Container>>(new ContainerRuntimeException("list", 1, "一覧の取得に失敗しました。")));
+        var row1 = sut.Containers.Single(c => c.Id == "c1");
+
+        // Act
+        var operationTask = sut.DeleteCommand.ExecuteAsync(row1);
+        await sut.RefreshCommand.ExecuteAsync(null);
+        Assert.IsFalse(sut.Containers.Any(c => c.Id == "c1"));
+        gate.SetException(exception);
+        await operationTask;
+
+        // Assert
+        var restoredRow = sut.Containers.SingleOrDefault(c => c.Id == "c1");
+        Assert.IsNotNull(restoredRow);
+        Assert.IsFalse(restoredRow!.IsBusy);
+        Assert.AreEqual(service.DeleteException!.Message, sut.ErrorMessage);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_ServiceThrowsInvalidContainerOperationException_ErrorMessageIsSetAndRowRemains()
+    {
+        // Arrange
+        var service = new FakeContainerManagementService { DefaultContainers = [CreateContainer("c1", ContainerState.Running)] };
+        var sut = new ContainersViewModel(service);
+        await sut.RefreshCommand.ExecuteAsync(null);
+        var row = sut.Containers[0];
+        service.DeleteException = new InvalidContainerOperationException("c1", "DeleteAsync");
+
+        // Act
+        await sut.DeleteCommand.ExecuteAsync(row);
+
+        // Assert
+        Assert.AreEqual(service.DeleteException.Message, sut.ErrorMessage);
+        Assert.HasCount(1, sut.Containers);
+    }
+
+    [TestMethod]
+    public async Task RestartAsync_ServiceThrowsAfterRefresh_ErrorMessageIsSetAndRowStateIsSynchronized()
+    {
+        // Arrange
+        var service = new FakeContainerManagementService
+        {
+            DefaultContainers = [CreateContainer("c1", ContainerState.Running)],
+        };
+        service.RestartException = new InvalidContainerOperationException("c1", "RestartAsync");
+        var sut = new ContainersViewModel(service);
+        await sut.RefreshCommand.ExecuteAsync(null);
+        service.GetContainersResults.Enqueue(() => Task.FromResult<IReadOnlyList<Container>>([CreateContainer("c1", ContainerState.Stopped)]));
+
+        // Act
+        await sut.RestartCommand.ExecuteAsync(sut.Containers[0]);
+
+        // Assert
+        Assert.AreEqual(service.RestartException.Message, sut.ErrorMessage);
+        Assert.AreEqual(ContainerState.Stopped, sut.Containers[0].State);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_ServiceThrowsAfterRefresh_ContainersAreSynchronizedAndIsEmptyBecomesTrue()
+    {
+        // Arrange
+        var service = new FakeContainerManagementService
+        {
+            DefaultContainers = [CreateContainer("c1", ContainerState.Stopped)],
+        };
+        service.DeleteException = new InvalidContainerOperationException("c1", "DeleteAsync");
+        var sut = new ContainersViewModel(service);
+        await sut.RefreshCommand.ExecuteAsync(null);
+        service.GetContainersResults.Enqueue(() => Task.FromResult<IReadOnlyList<Container>>([]));
+
+        // Act
+        await sut.DeleteCommand.ExecuteAsync(sut.Containers[0]);
+
+        // Assert
+        Assert.AreEqual(service.DeleteException.Message, sut.ErrorMessage);
+        Assert.IsTrue(sut.IsEmpty);
+        Assert.IsEmpty(sut.Containers);
+    }
+
+    [TestMethod]
+    public async Task StartAsync_SucceedsButBackgroundRefreshFails_OptimisticStateIsPreservedAndErrorMessageIsNotSet()
+    {
+        // Arrange
+        // 直前の操作が成功した後にバックグラウンドの全件更新が失敗しても、
+        // 楽観的更新済みの状態を古い状態へ巻き戻してはならない（詳細設計フェーズの
+        // ラバーダックレビューで指摘された論点）。
+        var service = new FakeContainerManagementService();
+        service.GetContainersResults.Enqueue(() => Task.FromResult<IReadOnlyList<Container>>([CreateContainer("c1", ContainerState.Stopped)]));
+        service.GetContainersResults.Enqueue(() => Task.FromException<IReadOnlyList<Container>>(new ContainerRuntimeException("list", 1, "一覧の取得に失敗しました。")));
+        var sut = new ContainersViewModel(service);
+        await sut.RefreshCommand.ExecuteAsync(null);
+        var row = sut.Containers[0];
+        service.StartResult = CreateContainer("c1", ContainerState.Running);
+
+        // Act
+        await sut.StartCommand.ExecuteAsync(row);
+
+        // Assert
+        Assert.AreEqual(ContainerState.Running, row.State);
+        Assert.HasCount(1, sut.Containers);
+        Assert.IsNull(sut.ErrorMessage);
+    }
+}

--- a/tests/WslContainersDesktop.Application.Tests/Exceptions/ContainerManagementExceptionsTests.cs
+++ b/tests/WslContainersDesktop.Application.Tests/Exceptions/ContainerManagementExceptionsTests.cs
@@ -1,0 +1,66 @@
+using WslContainersDesktop.Application.Exceptions;
+
+namespace WslContainersDesktop.Application.Tests.Exceptions;
+
+[TestClass]
+public sealed class ContainerManagementExceptionsTests
+{
+    [TestMethod]
+    public void ContainerRuntimeException_ConstructedWithDetails_PropertiesAreSet()
+    {
+        // Arrange & Act
+        var sut = new ContainerRuntimeException(
+            command: "container start c1",
+            exitCode: 1,
+            message: "コンテナーを開始できませんでした。");
+
+        // Assert
+        Assert.AreEqual("container start c1", sut.Command);
+        Assert.AreEqual(1, sut.ExitCode);
+        Assert.AreEqual("コンテナーを開始できませんでした。", sut.Message);
+        Assert.IsInstanceOfType<ContainerManagementException>(sut);
+    }
+
+    [TestMethod]
+    public void ContainerRuntimeException_ConstructedWithInnerException_InnerExceptionIsSet()
+    {
+        // Arrange
+        var inner = new InvalidOperationException("JSON解析エラー");
+
+        // Act
+        var sut = new ContainerRuntimeException(
+            command: "list -a --format json",
+            exitCode: 0,
+            message: "コンテナ一覧の解析に失敗しました。",
+            innerException: inner);
+
+        // Assert
+        Assert.AreSame(inner, sut.InnerException);
+    }
+
+    [TestMethod]
+    public void InvalidContainerOperationException_ConstructedWithDetails_PropertiesAreSet()
+    {
+        // Arrange & Act
+        var sut = new InvalidContainerOperationException(containerId: "c1", operationName: "Start");
+
+        // Assert
+        Assert.AreEqual("c1", sut.ContainerId);
+        Assert.AreEqual("Start", sut.OperationName);
+        StringAssert.Contains(sut.Message, "c1");
+        StringAssert.Contains(sut.Message, "Start");
+        Assert.IsInstanceOfType<ContainerManagementException>(sut);
+    }
+
+    [TestMethod]
+    public void ContainerNotFoundException_ConstructedWithContainerId_PropertyIsSetAndMessageContainsId()
+    {
+        // Arrange & Act
+        var sut = new ContainerNotFoundException(containerId: "c1");
+
+        // Assert
+        Assert.AreEqual("c1", sut.ContainerId);
+        StringAssert.Contains(sut.Message, "c1");
+        Assert.IsInstanceOfType<ContainerManagementException>(sut);
+    }
+}

--- a/tests/WslContainersDesktop.Application.Tests/Fakes/FakeContainerRuntimeClient.cs
+++ b/tests/WslContainersDesktop.Application.Tests/Fakes/FakeContainerRuntimeClient.cs
@@ -1,0 +1,59 @@
+using WslContainersDesktop.Application.Ports;
+using WslContainersDesktop.Domain;
+
+namespace WslContainersDesktop.Application.Tests.Fakes;
+
+/// <summary>
+/// <see cref="IContainerRuntimeClient"/> のテスト用フェイク実装。
+/// 呼び出された引数を記録し、任意の例外をスローできる。
+/// </summary>
+internal sealed class FakeContainerRuntimeClient : IContainerRuntimeClient
+{
+    public IReadOnlyList<Container> Containers { get; set; } = [];
+
+    public Exception? ExceptionToThrow { get; set; }
+
+    public List<string> StartCalls { get; } = [];
+
+    public List<string> StopCalls { get; } = [];
+
+    public List<string> DeleteCalls { get; } = [];
+
+    public Task<IReadOnlyList<Container>> ListContainersAsync(CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(Containers);
+    }
+
+    public Task StartAsync(string containerId, CancellationToken cancellationToken = default)
+    {
+        StartCalls.Add(containerId);
+        if (ExceptionToThrow is not null)
+        {
+            throw ExceptionToThrow;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(string containerId, CancellationToken cancellationToken = default)
+    {
+        StopCalls.Add(containerId);
+        if (ExceptionToThrow is not null)
+        {
+            throw ExceptionToThrow;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteAsync(string containerId, CancellationToken cancellationToken = default)
+    {
+        DeleteCalls.Add(containerId);
+        if (ExceptionToThrow is not null)
+        {
+            throw ExceptionToThrow;
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/tests/WslContainersDesktop.Application.Tests/Services/ContainerManagementServiceTests.cs
+++ b/tests/WslContainersDesktop.Application.Tests/Services/ContainerManagementServiceTests.cs
@@ -1,0 +1,206 @@
+using WslContainersDesktop.Application.Exceptions;
+using WslContainersDesktop.Application.Ports;
+using WslContainersDesktop.Application.Services;
+using WslContainersDesktop.Application.Tests.Fakes;
+using WslContainersDesktop.Domain;
+
+namespace WslContainersDesktop.Application.Tests.Services;
+
+[TestClass]
+public sealed class ContainerManagementServiceTests
+{
+    private static Container CreateContainer(string id, ContainerState state) => new(
+        Id: id,
+        Name: $"name-{id}",
+        Image: "nginx:latest",
+        State: state,
+        CreatedAt: new DateTimeOffset(2026, 7, 2, 9, 0, 0, TimeSpan.Zero));
+
+    [TestMethod]
+    public async Task GetContainersAsync_ClientReturnsContainers_ReturnsSameContainers()
+    {
+        // Arrange
+        var expected = new[] { CreateContainer("c1", ContainerState.Running), CreateContainer("c2", ContainerState.Stopped) };
+        var client = new FakeContainerRuntimeClient { Containers = expected };
+        var sut = new ContainerManagementService(client);
+
+        // Act
+        var actual = await sut.GetContainersAsync();
+
+        // Assert
+        CollectionAssert.AreEqual(expected, actual.ToList());
+    }
+
+    [TestMethod]
+    public async Task StartAsync_ContainerIsStopped_CallsClientStartAndReturnsRunningContainer()
+    {
+        // Arrange
+        var client = new FakeContainerRuntimeClient { Containers = [CreateContainer("c1", ContainerState.Stopped)] };
+        var sut = new ContainerManagementService(client);
+
+        // Act
+        var result = await sut.StartAsync("c1");
+
+        // Assert
+        CollectionAssert.AreEqual(new[] { "c1" }, client.StartCalls);
+        Assert.AreEqual(ContainerState.Running, result.State);
+        Assert.AreEqual("c1", result.Id);
+    }
+
+    [TestMethod]
+    public async Task StartAsync_ContainerIsAlreadyRunning_ThrowsInvalidContainerOperationExceptionAndDoesNotCallClient()
+    {
+        // Arrange
+        var client = new FakeContainerRuntimeClient { Containers = [CreateContainer("c1", ContainerState.Running)] };
+        var sut = new ContainerManagementService(client);
+
+        // Act & Assert
+        await Assert.ThrowsExactlyAsync<InvalidContainerOperationException>(() => sut.StartAsync("c1"));
+        Assert.IsEmpty(client.StartCalls);
+    }
+
+    [TestMethod]
+    public async Task StartAsync_ContainerIdNotFound_ThrowsContainerNotFoundException()
+    {
+        // Arrange
+        var client = new FakeContainerRuntimeClient { Containers = [] };
+        var sut = new ContainerManagementService(client);
+
+        // Act & Assert
+        await Assert.ThrowsExactlyAsync<ContainerNotFoundException>(() => sut.StartAsync("missing"));
+    }
+
+    [TestMethod]
+    public async Task StopAsync_ContainerIsRunning_CallsClientStopAndReturnsStoppedContainer()
+    {
+        // Arrange
+        var client = new FakeContainerRuntimeClient { Containers = [CreateContainer("c1", ContainerState.Running)] };
+        var sut = new ContainerManagementService(client);
+
+        // Act
+        var result = await sut.StopAsync("c1");
+
+        // Assert
+        CollectionAssert.AreEqual(new[] { "c1" }, client.StopCalls);
+        Assert.AreEqual(ContainerState.Stopped, result.State);
+    }
+
+    [TestMethod]
+    public async Task StopAsync_ContainerIsAlreadyStopped_ThrowsInvalidContainerOperationExceptionAndDoesNotCallClient()
+    {
+        // Arrange
+        var client = new FakeContainerRuntimeClient { Containers = [CreateContainer("c1", ContainerState.Stopped)] };
+        var sut = new ContainerManagementService(client);
+
+        // Act & Assert
+        await Assert.ThrowsExactlyAsync<InvalidContainerOperationException>(() => sut.StopAsync("c1"));
+        Assert.IsEmpty(client.StopCalls);
+    }
+
+    [TestMethod]
+    public async Task StopAsync_ContainerIdNotFound_ThrowsContainerNotFoundException()
+    {
+        // Arrange
+        var client = new FakeContainerRuntimeClient { Containers = [] };
+        var sut = new ContainerManagementService(client);
+
+        // Act & Assert
+        await Assert.ThrowsExactlyAsync<ContainerNotFoundException>(() => sut.StopAsync("missing"));
+    }
+
+    [TestMethod]
+    public async Task RestartAsync_ContainerIsRunning_CallsClientStopThenStartAndReturnsRunningContainer()
+    {
+        // Arrange
+        var client = new FakeContainerRuntimeClient { Containers = [CreateContainer("c1", ContainerState.Running)] };
+        var sut = new ContainerManagementService(client);
+
+        // Act
+        var result = await sut.RestartAsync("c1");
+
+        // Assert
+        CollectionAssert.AreEqual(new[] { "c1" }, client.StopCalls);
+        CollectionAssert.AreEqual(new[] { "c1" }, client.StartCalls);
+        Assert.AreEqual(ContainerState.Running, result.State);
+    }
+
+    [TestMethod]
+    public async Task RestartAsync_ContainerIsStopped_ThrowsInvalidContainerOperationExceptionAndDoesNotCallClient()
+    {
+        // Arrange
+        // 既に外部から停止済みのコンテナに再起動を要求した場合、Stop→Startへすり替わって
+        // 「起動」として成功してしまうことを防ぐため、事前検証で必ず失敗させる。
+        var client = new FakeContainerRuntimeClient { Containers = [CreateContainer("c1", ContainerState.Stopped)] };
+        var sut = new ContainerManagementService(client);
+
+        // Act & Assert
+        await Assert.ThrowsExactlyAsync<InvalidContainerOperationException>(() => sut.RestartAsync("c1"));
+        Assert.IsEmpty(client.StopCalls);
+        Assert.IsEmpty(client.StartCalls);
+    }
+
+    [TestMethod]
+    public async Task RestartAsync_ContainerIdNotFound_ThrowsContainerNotFoundException()
+    {
+        // Arrange
+        var client = new FakeContainerRuntimeClient { Containers = [] };
+        var sut = new ContainerManagementService(client);
+
+        // Act & Assert
+        await Assert.ThrowsExactlyAsync<ContainerNotFoundException>(() => sut.RestartAsync("missing"));
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_ContainerIsStopped_CallsClientDelete()
+    {
+        // Arrange
+        var client = new FakeContainerRuntimeClient { Containers = [CreateContainer("c1", ContainerState.Stopped)] };
+        var sut = new ContainerManagementService(client);
+
+        // Act
+        await sut.DeleteAsync("c1");
+
+        // Assert
+        CollectionAssert.AreEqual(new[] { "c1" }, client.DeleteCalls);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_ContainerIsRunning_ThrowsInvalidContainerOperationExceptionAndDoesNotCallClient()
+    {
+        // Arrange
+        var client = new FakeContainerRuntimeClient { Containers = [CreateContainer("c1", ContainerState.Running)] };
+        var sut = new ContainerManagementService(client);
+
+        // Act & Assert
+        await Assert.ThrowsExactlyAsync<InvalidContainerOperationException>(() => sut.DeleteAsync("c1"));
+        Assert.IsEmpty(client.DeleteCalls);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_ContainerIdNotFound_ThrowsContainerNotFoundException()
+    {
+        // Arrange
+        var client = new FakeContainerRuntimeClient { Containers = [] };
+        var sut = new ContainerManagementService(client);
+
+        // Act & Assert
+        await Assert.ThrowsExactlyAsync<ContainerNotFoundException>(() => sut.DeleteAsync("missing"));
+    }
+
+    [TestMethod]
+    public async Task StartAsync_ClientThrowsContainerRuntimeException_ExceptionPropagatesUnchanged()
+    {
+        // Arrange
+        var runtimeException = new ContainerRuntimeException("container start c1", 1, "起動に失敗しました。");
+        var client = new FakeContainerRuntimeClient
+        {
+            Containers = [CreateContainer("c1", ContainerState.Stopped)],
+            ExceptionToThrow = runtimeException,
+        };
+        var sut = new ContainerManagementService(client);
+
+        // Act & Assert
+        var actual = await Assert.ThrowsExactlyAsync<ContainerRuntimeException>(() => sut.StartAsync("c1"));
+        Assert.AreSame(runtimeException, actual);
+    }
+}

--- a/tests/WslContainersDesktop.Domain.Tests/ContainerTests.cs
+++ b/tests/WslContainersDesktop.Domain.Tests/ContainerTests.cs
@@ -1,0 +1,133 @@
+using WslContainersDesktop.Domain;
+
+namespace WslContainersDesktop.Domain.Tests;
+
+[TestClass]
+public sealed class ContainerTests
+{
+    private static Container CreateContainer(ContainerState state) => new(
+        Id: "c1",
+        Name: "web",
+        Image: "nginx:latest",
+        State: state,
+        CreatedAt: new DateTimeOffset(2026, 7, 2, 9, 0, 0, TimeSpan.Zero));
+
+    [TestMethod]
+    public void Constructor_ValidValues_PropertiesAreSetAsGiven()
+    {
+        // Arrange
+        var createdAt = new DateTimeOffset(2026, 7, 2, 9, 0, 0, TimeSpan.Zero);
+
+        // Act
+        var sut = new Container(
+            Id: "c1",
+            Name: "web",
+            Image: "nginx:latest",
+            State: ContainerState.Running,
+            CreatedAt: createdAt);
+
+        // Assert
+        Assert.AreEqual("c1", sut.Id);
+        Assert.AreEqual("web", sut.Name);
+        Assert.AreEqual("nginx:latest", sut.Image);
+        Assert.AreEqual(ContainerState.Running, sut.State);
+        Assert.AreEqual(createdAt, sut.CreatedAt);
+    }
+
+    [TestMethod]
+    public void CanStart_StateIsStopped_IsTrue()
+    {
+        // Arrange
+        var sut = CreateContainer(ContainerState.Stopped);
+
+        // Act & Assert
+        Assert.IsTrue(sut.CanStart);
+    }
+
+    [TestMethod]
+    public void CanStart_StateIsRunning_IsFalse()
+    {
+        // Arrange
+        var sut = CreateContainer(ContainerState.Running);
+
+        // Act & Assert
+        Assert.IsFalse(sut.CanStart);
+    }
+
+    [TestMethod]
+    public void CanStop_StateIsRunning_IsTrue()
+    {
+        // Arrange
+        var sut = CreateContainer(ContainerState.Running);
+
+        // Act & Assert
+        Assert.IsTrue(sut.CanStop);
+    }
+
+    [TestMethod]
+    public void CanStop_StateIsStopped_IsFalse()
+    {
+        // Arrange
+        var sut = CreateContainer(ContainerState.Stopped);
+
+        // Act & Assert
+        Assert.IsFalse(sut.CanStop);
+    }
+
+    [TestMethod]
+    public void CanRestart_StateIsRunning_IsTrue()
+    {
+        // Arrange
+        var sut = CreateContainer(ContainerState.Running);
+
+        // Act & Assert
+        Assert.IsTrue(sut.CanRestart);
+    }
+
+    [TestMethod]
+    public void CanRestart_StateIsStopped_IsFalse()
+    {
+        // Arrange
+        var sut = CreateContainer(ContainerState.Stopped);
+
+        // Act & Assert
+        Assert.IsFalse(sut.CanRestart);
+    }
+
+    [TestMethod]
+    public void CanDelete_StateIsStopped_IsTrue()
+    {
+        // Arrange
+        var sut = CreateContainer(ContainerState.Stopped);
+
+        // Act & Assert
+        Assert.IsTrue(sut.CanDelete);
+    }
+
+    [TestMethod]
+    public void CanDelete_StateIsRunning_IsFalse()
+    {
+        // Arrange
+        var sut = CreateContainer(ContainerState.Running);
+
+        // Act & Assert
+        Assert.IsFalse(sut.CanDelete);
+    }
+
+    [TestMethod]
+    public void With_StateChangedToRunning_OtherPropertiesAreUnchanged()
+    {
+        // Arrange
+        var sut = CreateContainer(ContainerState.Stopped);
+
+        // Act
+        var updated = sut with { State = ContainerState.Running };
+
+        // Assert
+        Assert.AreEqual(ContainerState.Running, updated.State);
+        Assert.AreEqual(sut.Id, updated.Id);
+        Assert.AreEqual(sut.Name, updated.Name);
+        Assert.AreEqual(sut.Image, updated.Image);
+        Assert.AreEqual(sut.CreatedAt, updated.CreatedAt);
+    }
+}

--- a/tests/WslContainersDesktop.Infrastructure.Tests/Cli/WslcCliRunnerTests.cs
+++ b/tests/WslContainersDesktop.Infrastructure.Tests/Cli/WslcCliRunnerTests.cs
@@ -1,0 +1,60 @@
+using WslContainersDesktop.Infrastructure.Cli;
+
+namespace WslContainersDesktop.Infrastructure.Tests.Cli;
+
+[TestClass]
+public sealed class WslcCliRunnerTests
+{
+    [TestMethod]
+    public async Task RunAsync_CommandWritesToStandardOutput_ReturnsExitCodeZeroAndStandardOutput()
+    {
+        // Arrange
+        // 実在のwslc.exeに依存せず、Windows標準のcmd.exeで代替してプロセス起動の
+        // 仕組みそのものを検証する。
+        var sut = new WslcCliRunner(executablePath: "cmd.exe");
+
+        // Act
+        var result = await sut.RunAsync(["/c", "echo hello-stdout"]);
+
+        // Assert
+        Assert.AreEqual(0, result.ExitCode);
+        StringAssert.Contains(result.StandardOutput, "hello-stdout");
+    }
+
+    [TestMethod]
+    public async Task RunAsync_CommandWritesToStandardError_StandardErrorIsCapturedSeparatelyFromStandardOutput()
+    {
+        // Arrange
+        var sut = new WslcCliRunner(executablePath: "cmd.exe");
+
+        // Act
+        var result = await sut.RunAsync(["/c", "echo hello-stderr 1>&2"]);
+
+        // Assert
+        StringAssert.Contains(result.StandardError, "hello-stderr");
+        StringAssert.DoesNotMatch(result.StandardOutput, new System.Text.RegularExpressions.Regex("hello-stderr"));
+    }
+
+    [TestMethod]
+    public async Task RunAsync_CommandExitsWithNonZeroCode_ExitCodeIsReturned()
+    {
+        // Arrange
+        var sut = new WslcCliRunner(executablePath: "cmd.exe");
+
+        // Act
+        var result = await sut.RunAsync(["/c", "exit 3"]);
+
+        // Assert
+        Assert.AreEqual(3, result.ExitCode);
+    }
+
+    [TestMethod]
+    public void Constructor_NoExecutablePathSpecified_DefaultsToWslc()
+    {
+        // Arrange & Act
+        var sut = new WslcCliRunner();
+
+        // Assert
+        Assert.AreEqual("wslc", sut.ExecutablePath);
+    }
+}

--- a/tests/WslContainersDesktop.Infrastructure.Tests/Clients/WslcCliContainerRuntimeClientTests.cs
+++ b/tests/WslContainersDesktop.Infrastructure.Tests/Clients/WslcCliContainerRuntimeClientTests.cs
@@ -1,0 +1,190 @@
+using WslContainersDesktop.Application.Exceptions;
+using WslContainersDesktop.Domain;
+using WslContainersDesktop.Infrastructure.Clients;
+using WslContainersDesktop.Infrastructure.Tests.Fakes;
+
+namespace WslContainersDesktop.Infrastructure.Tests.Clients;
+
+[TestClass]
+public sealed class WslcCliContainerRuntimeClientTests
+{
+    [TestMethod]
+    public async Task ListContainersAsync_CliReturnsContainers_MapsJsonToContainers()
+    {
+        // Arrange
+        // 実機の `wslc list -a --format json` で確認したスキーマに基づく。
+        const string json = """
+            [
+              {
+                "CreatedAt": 1751446800,
+                "Id": "sha256:aaa",
+                "Image": "nginx:latest",
+                "Name": "web",
+                "Ports": [],
+                "State": 2,
+                "StateChangedAt": 1751446801
+              },
+              {
+                "CreatedAt": 1751443200,
+                "Id": "sha256:bbb",
+                "Image": "alpine:latest",
+                "Name": "wcd-test",
+                "Ports": [],
+                "State": 3,
+                "StateChangedAt": 1751443260
+              }
+            ]
+            """;
+        var runner = new FakeWslcCliRunner { Result = new(0, json, string.Empty) };
+        var sut = new WslcCliContainerRuntimeClient(runner);
+
+        // Act
+        var containers = await sut.ListContainersAsync();
+
+        // Assert
+        Assert.HasCount(2, containers);
+        Assert.AreEqual("sha256:aaa", containers[0].Id);
+        Assert.AreEqual("web", containers[0].Name);
+        Assert.AreEqual("nginx:latest", containers[0].Image);
+        Assert.AreEqual(ContainerState.Running, containers[0].State);
+        Assert.AreEqual(DateTimeOffset.FromUnixTimeSeconds(1751446800), containers[0].CreatedAt);
+
+        Assert.AreEqual("sha256:bbb", containers[1].Id);
+        Assert.AreEqual(ContainerState.Stopped, containers[1].State);
+    }
+
+    [TestMethod]
+    public async Task ListContainersAsync_CliReturnsEmptyArray_ReturnsEmptyList()
+    {
+        // Arrange
+        var runner = new FakeWslcCliRunner { Result = new(0, "[]", string.Empty) };
+        var sut = new WslcCliContainerRuntimeClient(runner);
+
+        // Act
+        var containers = await sut.ListContainersAsync();
+
+        // Assert
+        Assert.IsEmpty(containers);
+    }
+
+    [TestMethod]
+    public async Task ListContainersAsync_CliArguments_AreListAllFormatJson()
+    {
+        // Arrange
+        var runner = new FakeWslcCliRunner { Result = new(0, "[]", string.Empty) };
+        var sut = new WslcCliContainerRuntimeClient(runner);
+
+        // Act
+        await sut.ListContainersAsync();
+
+        // Assert
+        CollectionAssert.AreEqual(new[] { "list", "-a", "--format", "json" }, runner.Calls[0].ToList());
+    }
+
+    [TestMethod]
+    public async Task ListContainersAsync_CliExitsWithNonZeroCode_ThrowsContainerRuntimeExceptionWithStandardError()
+    {
+        // Arrange
+        var runner = new FakeWslcCliRunner { Result = new(1, string.Empty, "一覧の取得に失敗しました。") };
+        var sut = new WslcCliContainerRuntimeClient(runner);
+
+        // Act & Assert
+        var ex = await Assert.ThrowsExactlyAsync<ContainerRuntimeException>(() => sut.ListContainersAsync());
+        Assert.AreEqual(1, ex.ExitCode);
+        StringAssert.Contains(ex.Message, "一覧の取得に失敗しました。");
+    }
+
+    [TestMethod]
+    public async Task ListContainersAsync_CliReturnsMalformedJson_ThrowsContainerRuntimeExceptionWithInnerException()
+    {
+        // Arrange
+        var runner = new FakeWslcCliRunner { Result = new(0, "not-json", string.Empty) };
+        var sut = new WslcCliContainerRuntimeClient(runner);
+
+        // Act & Assert
+        var ex = await Assert.ThrowsExactlyAsync<ContainerRuntimeException>(() => sut.ListContainersAsync());
+        Assert.IsNotNull(ex.InnerException);
+    }
+
+    [TestMethod]
+    public async Task StartAsync_CliSucceeds_CompletesWithoutException()
+    {
+        // Arrange
+        var runner = new FakeWslcCliRunner { Result = new(0, string.Empty, string.Empty) };
+        var sut = new WslcCliContainerRuntimeClient(runner);
+
+        // Act
+        await sut.StartAsync("c1");
+
+        // Assert
+        CollectionAssert.AreEqual(new[] { "container", "start", "c1" }, runner.Calls[0].ToList());
+    }
+
+    [TestMethod]
+    public async Task StartAsync_CliExitsWithNonZeroCode_ThrowsContainerRuntimeException()
+    {
+        // Arrange
+        var runner = new FakeWslcCliRunner { Result = new(1, string.Empty, "起動に失敗しました。") };
+        var sut = new WslcCliContainerRuntimeClient(runner);
+
+        // Act & Assert
+        var ex = await Assert.ThrowsExactlyAsync<ContainerRuntimeException>(() => sut.StartAsync("c1"));
+        StringAssert.Contains(ex.Message, "起動に失敗しました。");
+    }
+
+    [TestMethod]
+    public async Task StopAsync_CliSucceeds_CallsContainerStopWithId()
+    {
+        // Arrange
+        var runner = new FakeWslcCliRunner { Result = new(0, string.Empty, string.Empty) };
+        var sut = new WslcCliContainerRuntimeClient(runner);
+
+        // Act
+        await sut.StopAsync("c1");
+
+        // Assert
+        CollectionAssert.AreEqual(new[] { "container", "stop", "c1" }, runner.Calls[0].ToList());
+    }
+
+    [TestMethod]
+    public async Task StopAsync_CliExitsWithNonZeroCode_ThrowsContainerRuntimeException()
+    {
+        // Arrange
+        var runner = new FakeWslcCliRunner { Result = new(1, string.Empty, "停止に失敗しました。") };
+        var sut = new WslcCliContainerRuntimeClient(runner);
+
+        // Act & Assert
+        await Assert.ThrowsExactlyAsync<ContainerRuntimeException>(() => sut.StopAsync("c1"));
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_CliSucceeds_CallsContainerRemoveWithIdWithoutForceFlag()
+    {
+        // Arrange
+        var runner = new FakeWslcCliRunner { Result = new(0, string.Empty, string.Empty) };
+        var sut = new WslcCliContainerRuntimeClient(runner);
+
+        // Act
+        await sut.DeleteAsync("c1");
+
+        // Assert
+        // -f を付けないことで、実行中コンテナの削除をwslc自体に拒否させる
+        // （ADR-0009）。
+        CollectionAssert.AreEqual(new[] { "container", "remove", "c1" }, runner.Calls[0].ToList());
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_CliExitsWithNonZeroCode_ThrowsContainerRuntimeExceptionWithStandardError()
+    {
+        // Arrange
+        var runner = new FakeWslcCliRunner
+        {
+            Result = new(1, string.Empty, "エラー コード: WSLC_E_CONTAINER_IS_RUNNING"),
+        };
+        var sut = new WslcCliContainerRuntimeClient(runner);
+
+        // Act & Assert
+        var ex = await Assert.ThrowsExactlyAsync<ContainerRuntimeException>(() => sut.DeleteAsync("c1"));
+        StringAssert.Contains(ex.Message, "WSLC_E_CONTAINER_IS_RUNNING");
+    }
+}

--- a/tests/WslContainersDesktop.Infrastructure.Tests/Fakes/FakeWslcCliRunner.cs
+++ b/tests/WslContainersDesktop.Infrastructure.Tests/Fakes/FakeWslcCliRunner.cs
@@ -1,0 +1,20 @@
+using WslContainersDesktop.Infrastructure.Cli;
+
+namespace WslContainersDesktop.Infrastructure.Tests.Fakes;
+
+/// <summary>
+/// <see cref="IWslcCliRunner"/> のテスト用フェイク実装。
+/// 呼び出された引数を記録し、あらかじめ設定した <see cref="CliResult"/> を返す。
+/// </summary>
+internal sealed class FakeWslcCliRunner : IWslcCliRunner
+{
+    public CliResult Result { get; set; } = new(0, string.Empty, string.Empty);
+
+    public List<IReadOnlyList<string>> Calls { get; } = [];
+
+    public Task<CliResult> RunAsync(IReadOnlyList<string> arguments, CancellationToken cancellationToken = default)
+    {
+        Calls.Add(arguments);
+        return Task.FromResult(Result);
+    }
+}

--- a/tests/WslContainersDesktop.Infrastructure.Tests/MSTestSettings.cs
+++ b/tests/WslContainersDesktop.Infrastructure.Tests/MSTestSettings.cs
@@ -1,0 +1,1 @@
+﻿[assembly: Parallelize(Scope = ExecutionScope.MethodLevel)]

--- a/tests/WslContainersDesktop.Infrastructure.Tests/WslContainersDesktop.Infrastructure.Tests.csproj
+++ b/tests/WslContainersDesktop.Infrastructure.Tests/WslContainersDesktop.Infrastructure.Tests.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest" Version="4.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\WslContainersDesktop.Infrastructure\WslContainersDesktop.Infrastructure.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## 背景

WSL Containers Desktopの最初のコア機能として、`wslc` CLIが管理するコンテナの一覧表示とStart/Stop/Restart/Delete操作をGUIから行えるようにする（Issue #4）。

Fixes: #4

## 実装内容

クリーンアーキテクチャの4層構成に沿って実装した。

- **Domain**: `Container`エンティティ、`ContainerState`、状態に応じた`Can*`ルール
- **Application**: `IContainerManagementService`/`IContainerRuntimeClient`ポート、`ContainerManagementService`実装、例外階層（`ContainerNotFoundException`等）
- **Infrastructure**: `wslc` CLIをラップする`IWslcCliRunner`/`WslcCliRunner`と、JSON出力をドメインモデルへマッピングする`WslcCliContainerRuntimeClient`
- **Presentation**: `ContainersViewModel`/`ContainerRowViewModel`（MVVM）、`ContainersPage.xaml`のUI、DIコンテナ配線（`App.xaml.cs`）

各層はTDD（Red/Green/Refactor）で実装し、詳細設計・テスト作成・振り返りの各フェーズでラバーダックレビューを実施した。

## 並行操作まわりの2つの不具合修正

実装完了後の実機E2E検証で、複数コンテナへの並行操作時に発生する2件の不具合を発見し、それぞれ追加のTDDサイクルで修正した。

1. **busy状態のスタック**: 操作完了直後ではなく`finally`節でbusy解除していたため、操作完了前にバックグラウンド再同期（`ReplaceContainers`）が走ると、再構築後の新しい行インスタンスにbusy状態を復元する手段がなく、ボタンが恒久的に無効化されたままになっていた。busy解除の呼び出し順序を修正。
2. **行インスタンスの陳腐化**: `await`をまたいだ後のコード（楽観的更新の反映、busy解除、削除後の行除去）が、操作開始時に捕まえた行インスタンスをそのまま使っていたため、途中で別の並行操作が行インスタンスを作り直すと、操作対象が既にライブのコレクションから外れたインスタンスになってしまっていた。`FindLiveRow(containerId)`による都度のライブ行再検索方式に変更し、削除失敗時に復旧用リフレッシュも失敗した場合の行復元ロジックも追加した。

いずれもコンテナID単位の状態追跡（`_busyContainerIds`/`_pendingDeleteContainerIds`）と、ライブ行の都度再検索という一貫したパターンで解決している。詳細設計は`docs/design/containers-view.md`に記載。

## 検証結果

- `dotnet test`（ソリューション全体）: 82/82成功（Domain 10, Application 18, Infrastructure 15, App.Tests 39）
- E2Eテスト（`winapp ui`自動操作、26アサーション）: 26/26成功
- 実機での複数コンテナ並行操作の手動検証、および最終ラバーダックレビューでブロッキング問題なしを確認済み

## ドキュメント

- ADR-0009: wslc CLIをInfrastructure層でラップする方針
- ADR-0010: Presentation層へのDIコンテナ導入方針
- `docs/design/containers-view.md`: ContainersViewModelの行インスタンス非永続化・busy状態管理・削除の楽観的更新の設計スナップショット