### PR TITLE
Add UI design policy and visual hierarchy

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -16,6 +16,7 @@
 | ドキュメント | 内容 |
 |---|---|
 | [`architecture-overview.md`](architecture-overview.md) | システム全体のレイヤー構成・依存関係の現在のスナップショット |
+| [`design-policy.md`](design-policy.md) | WinUI / Fluent Design に基づくUI・ビジュアルデザイン方針の現在のスナップショット |
 | [`presentation-navigation.md`](presentation-navigation.md) | Presentation層のナビゲーション基盤・ローカライズ基盤・DI構成の現在のスナップショット |
 | [`containers-view.md`](containers-view.md) | コンテナ一覧ViewModel（`ContainersViewModel`）の行操作・ログ表示状態管理の現在のスナップショット |
 | (機能追加に応じて追加) | 個別機能の設計ドキュメントは `docs/design/<feature-name>.md` として追加していく |

--- a/docs/design/design-policy.md
+++ b/docs/design/design-policy.md
@@ -1,0 +1,112 @@
+# UI / ビジュアルデザイン方針
+
+> このドキュメントは現時点のスナップショットです。経緯・検討過程は書きません。
+
+## 目的
+
+WSL Containers Desktop は、WSL Containers を管理する Windows ネイティブの開発者向けデスクトップアプリである。
+UIは、コンテナの状態・操作・ログを短時間で把握できるよう、Fluent Design に沿った明確な視覚階層を持つ。
+
+## 基本原則
+
+- Windows 11 / WinUI 3 の標準コントロールと Fluent Design の見た目を優先する。
+- Mica の背景を活かし、画面全体を単色の暗い面で覆わない。
+- 情報のまとまりはカード面、境界線、余白、アクセントで区切る。
+- 独自色は WSL / terminal らしいグリーン系アクセントに限定し、本文や大面積背景には使いすぎない。
+- High Contrast では独自色ではなく Windows のシステム色を使う。
+
+## 画面構成
+
+`MainWindow` は `TitleBar`、`NavigationView`、`Frame` で構成する。
+
+- トップレベルナビゲーションは `NavigationView` の左ペインを使う。
+- ウィンドウ背景は `MicaBackdrop` を使う。
+- 各ページは `Frame` 内で表示し、ページ本文には `24,16,24,16` の余白を取る。
+- ページ内の主要領域は `CardBackgroundFillColorDefaultBrush` と `CardStrokeColorDefaultBrush` を使ったカード面として表現する。
+
+## アプリ独自アクセント
+
+アプリ独自アクセントは `src/WslContainersDesktop.App/Themes/AppThemeResources.xaml` に集約する。
+
+| リソース | 用途 |
+|---|---|
+| `WslContainersAccentFillColorDefaultBrush` | 見出し横のアクセントバーなど、主要な強調面 |
+| `WslContainersAccentFillColorSubtleBrush` | 控えめなアクセント面。現在は将来の補助アクセント用に予約 |
+| `WslContainersAccentStrokeColorBrush` | 強調したい境界線・アイコン |
+| `WslContainersAccentTextFillColorBrush` | アクセント色のテキスト。現在は将来のテキスト強調用に予約 |
+| `WslContainersSurfaceBorderThickness` | カード面の境界線太さ。High Contrastでは通常より太くする |
+
+テーマ辞書は `Default`、`Light`、`HighContrast` を定義する。Darkテーマ用に `Dark` キーは使わない。
+XAMLの使用箇所では `{ThemeResource ...}` を使い、テーマ切り替えに追従させる。
+
+## レイアウトと余白
+
+- 余白・間隔・サイズは4pxグリッドに揃える。
+- ページ内の主要セクション間は16pxまたは24pxを基準にする。
+- カード内部の余白は16pxを基準にする。
+- 角丸は標準リソースを使う。カード面は `OverlayCornerRadius`、小さなアクセントバーや操作部品は `ControlCornerRadius` を使う。
+- `Grid` を構造化レイアウトに使い、単純な縦横並びだけ `StackPanel` を使う。
+
+## タイポグラフィ
+
+- ページタイトルは `TitleTextBlockStyle` を使う。
+- セクション見出しは `SubtitleTextBlockStyle` を使う。
+- 通常説明文は既定の本文スタイルを使い、不要な `FontSize` や `FontWeight` は指定しない。
+- 強調が必要な本文のみ `BodyStrongTextBlockStyle` を使う。
+
+## コンテナ一覧画面
+
+`ContainersPage` は以下の面で構成する。
+
+| 領域 | 方針 |
+|---|---|
+| ヘッダー | カード面にページタイトル、説明、更新ボタンを置き、左端にグリーン系アクセントバーを表示する |
+| エラー表示 | `InfoBar` をヘッダー直下にインライン表示する |
+| コンテナ一覧 | `DataGrid` をカード面で囲み、表の境界を背景から分離する |
+| 空状態 | 中央にカード面を置き、一覧が空であることを背景と区別して表示する |
+| ログパネル | 下部カード面として表示し、アクセント色の境界線で一覧領域と区別する |
+
+行操作は常時表示の `Logs` ボタンと `More` メニューに集約する。
+ログ一覧は `ListView` と `ItemsStackPanel.ItemsUpdatingScrollMode="KeepLastItemInView"` を使い、スクロール挙動をWinUI標準に委譲する。
+
+## 設定画面
+
+`SettingsPage` は、設定項目が少ない状態でも空白だけに見えないよう、ページ説明をカード面に載せる。
+今後設定項目を追加する場合も、関連する設定をカード単位でまとめる。
+
+## 色・素材
+
+- 背景は Mica を基本とし、ページ本文のまとまりには WinUI のカード/レイヤーブラシを使う。
+- XAML使用箇所で色コードを直接指定しない。
+- 通常テーマの独自アクセント色は `AppThemeResources.xaml` のみに置く。
+- High Contrast のテーマ辞書では `SystemColor*Brush` のみを使い、独自の緑色や不透明度で上書きしない。
+
+## アイコン
+
+- 標準的な操作・ナビゲーションには Segoe Fluent Icons / `FontIcon` / `SymbolIcon` を使う。
+- ナビゲーションアイコンは `NavigationViewItem` の標準状態色に従わせ、選択状態やHigh Contrastでのコントラストを維持する。
+- 画像アイコンはアプリロゴなどブランド資産に限定する。
+
+## フィードバックと状態表示
+
+- 操作失敗やログ取得失敗は `InfoBar` でインライン表示する。
+- 取り消しにくい操作は `ContentDialog` で確認する。
+- コンテナ行の起動中・停止中・再起動中・削除中などの途中状態はViewModelの表示状態に従い、一覧上で確認できるようにする。
+
+## アクセシビリティとローカライズ
+
+- ユーザーが操作するコントロールには `AutomationProperties.AutomationId` を設定する。
+- UI文字列は `.resw` と `x:Uid` を使い、XAMLやViewModelに直接埋め込まない。
+- アイコンだけの操作にはアクセシブル名を設定する。
+- High Contrast では独自色を使わず、システム色で十分なコントラストを確保する。
+
+## レビュー観点
+
+UI変更時は以下を確認する。
+
+- 画面全体が黒一色・白一色に見えず、面の境界がわかる。
+- 独自グリーンが強調用途に留まり、本文の読みやすさを妨げていない。
+- Light / Default / HighContrast の各テーマ辞書に同じリソースキーが存在する。
+- XAML使用箇所は `{ThemeResource}` でテーマリソースを参照している。
+- 余白・角丸・境界線が4pxグリッドと標準リソースに沿っている。
+- 既存の `AutomationId`、`x:Uid`、ViewModelへのバインディングを壊していない。

--- a/src/WslContainersDesktop.App/App.xaml
+++ b/src/WslContainersDesktop.App/App.xaml
@@ -8,7 +8,7 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
-                <!-- Other merged dictionaries here -->
+                <ResourceDictionary Source="Themes/AppThemeResources.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <!-- Other app resources here -->
         </ResourceDictionary>

--- a/src/WslContainersDesktop.App/Pages/ContainersPage.xaml
+++ b/src/WslContainersDesktop.App/Pages/ContainersPage.xaml
@@ -28,23 +28,36 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <Grid Grid.Row="0" ColumnSpacing="8">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" />
-            </Grid.ColumnDefinitions>
-            <StackPanel Grid.Column="0">
-                <TextBlock x:Name="TxtPageTitle" x:Uid="ContainersPageTitle" Style="{StaticResource TitleTextBlockStyle}" />
-                <TextBlock x:Name="TxtPageDescription" x:Uid="ContainersPageDescription" />
-            </StackPanel>
-            <Button
-                x:Name="BtnRefresh"
-                Grid.Column="1"
-                x:Uid="BtnRefresh"
-                VerticalAlignment="Bottom"
-                AutomationProperties.AutomationId="BtnRefresh"
-                Command="{x:Bind ViewModel.RefreshCommand}" />
-        </Grid>
+        <Border
+            Grid.Row="0"
+            Padding="16"
+            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+            BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+            BorderThickness="{ThemeResource WslContainersSurfaceBorderThickness}"
+            CornerRadius="{StaticResource OverlayCornerRadius}">
+            <Grid ColumnSpacing="16">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="4" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <Border
+                    Grid.Column="0"
+                    Background="{ThemeResource WslContainersAccentFillColorDefaultBrush}"
+                    CornerRadius="{StaticResource ControlCornerRadius}" />
+                <StackPanel Grid.Column="1">
+                    <TextBlock x:Name="TxtPageTitle" x:Uid="ContainersPageTitle" Style="{StaticResource TitleTextBlockStyle}" />
+                    <TextBlock x:Name="TxtPageDescription" x:Uid="ContainersPageDescription" />
+                </StackPanel>
+                <Button
+                    x:Name="BtnRefresh"
+                    Grid.Column="2"
+                    x:Uid="BtnRefresh"
+                    VerticalAlignment="Bottom"
+                    AutomationProperties.AutomationId="BtnRefresh"
+                    Command="{x:Bind ViewModel.RefreshCommand}" />
+            </Grid>
+        </Border>
 
         <InfoBar
             x:Name="InfoBarError"
@@ -54,91 +67,105 @@
             IsOpen="{x:Bind IsNotNullOrEmpty(ViewModel.ErrorMessage), Mode=OneWay}"
             Message="{x:Bind ViewModel.ErrorMessage, Mode=OneWay}" />
 
-        <controls:DataGrid
-            x:Name="LstContainers"
+        <Border
             Grid.Row="2"
             Grid.RowSpan="2"
-            AutomationProperties.AutomationId="LstContainers"
-            AutoGenerateColumns="False"
-            CanUserReorderColumns="False"
-            CanUserResizeColumns="True"
-            CanUserSortColumns="False"
-            GridLinesVisibility="None"
-            HeadersVisibility="Column"
-            IsReadOnly="True"
-            ItemsSource="{x:Bind ViewModel.Containers, Mode=OneWay}"
+            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+            BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+            BorderThickness="{ThemeResource WslContainersSurfaceBorderThickness}"
+            CornerRadius="{StaticResource OverlayCornerRadius}"
             Visibility="{x:Bind ToVisibleWhenFalse(ViewModel.IsEmpty), Mode=OneWay}">
-            <controls:DataGrid.Columns>
-                <controls:DataGridTextColumn Binding="{Binding Name}" Header="Name" MinWidth="160" Width="260" />
-                <controls:DataGridTextColumn Binding="{Binding Image}" Header="Image" MinWidth="80" Width="100" />
-                <controls:DataGridTextColumn Binding="{Binding DisplayState, Converter={StaticResource StateToDisplayTextConverter}}" Header="State" MinWidth="80" Width="90" />
-                <controls:DataGridTextColumn Binding="{Binding CreatedAt, Converter={StaticResource CreatedAtConverter}}" Header="Created" MinWidth="120" Width="140" />
-                <controls:DataGridTemplateColumn Header="" MinWidth="140" Width="150">
-                    <controls:DataGridTemplateColumn.CellTemplate>
-                        <DataTemplate x:DataType="vm:ContainerRowViewModel">
-                            <StackPanel Orientation="Horizontal" Spacing="8">
-                                <Button
-                                    x:Uid="BtnLogs"
-                                    AutomationProperties.AutomationId="{x:Bind Id, Mode=OneWay, Converter={StaticResource AutomationIdConverter}, ConverterParameter=BtnLogs}"
-                                    CommandParameter="{x:Bind Id}"
-                                    Click="BtnLogs_Click" />
-                                <Button
-                                    x:Uid="BtnMoreActions"
-                                    AutomationProperties.AutomationId="{x:Bind Id, Mode=OneWay, Converter={StaticResource AutomationIdConverter}, ConverterParameter=BtnMoreActions}">
-                                    <Button.Flyout>
-                                        <MenuFlyout>
-                                            <MenuFlyoutItem
-                                                x:Uid="MenuStart"
-                                                AutomationProperties.AutomationId="{x:Bind Id, Mode=OneWay, Converter={StaticResource AutomationIdConverter}, ConverterParameter=MenuStart}"
-                                                CommandParameter="{x:Bind}"
-                                                Click="MenuStart_Click"
-                                                Visibility="{x:Bind CanStart, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
-                                            <MenuFlyoutItem
-                                                x:Uid="MenuStop"
-                                                AutomationProperties.AutomationId="{x:Bind Id, Mode=OneWay, Converter={StaticResource AutomationIdConverter}, ConverterParameter=MenuStop}"
-                                                CommandParameter="{x:Bind}"
-                                                Click="MenuStop_Click"
-                                                Visibility="{x:Bind CanStop, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
-                                            <MenuFlyoutItem
-                                                x:Uid="MenuRestart"
-                                                AutomationProperties.AutomationId="{x:Bind Id, Mode=OneWay, Converter={StaticResource AutomationIdConverter}, ConverterParameter=MenuRestart}"
-                                                CommandParameter="{x:Bind}"
-                                                Click="MenuRestart_Click"
-                                                Visibility="{x:Bind CanRestart, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
-                                            <MenuFlyoutItem
-                                                x:Uid="MenuDelete"
-                                                AutomationProperties.AutomationId="{x:Bind Id, Mode=OneWay, Converter={StaticResource AutomationIdConverter}, ConverterParameter=MenuDelete}"
-                                                CommandParameter="{x:Bind}"
-                                                Click="BtnDelete_Click"
-                                                Visibility="{x:Bind CanDelete, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
-                                        </MenuFlyout>
-                                    </Button.Flyout>
-                                </Button>
-                            </StackPanel>
-                        </DataTemplate>
-                    </controls:DataGridTemplateColumn.CellTemplate>
-                </controls:DataGridTemplateColumn>
-            </controls:DataGrid.Columns>
-        </controls:DataGrid>
+            <controls:DataGrid
+                x:Name="LstContainers"
+                AutomationProperties.AutomationId="LstContainers"
+                AutoGenerateColumns="False"
+                Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                CanUserReorderColumns="False"
+                CanUserResizeColumns="True"
+                CanUserSortColumns="False"
+                GridLinesVisibility="None"
+                HeadersVisibility="Column"
+                IsReadOnly="True"
+                ItemsSource="{x:Bind ViewModel.Containers, Mode=OneWay}">
+                <controls:DataGrid.Columns>
+                    <controls:DataGridTextColumn Binding="{Binding Name}" Header="Name" MinWidth="160" Width="260" />
+                    <controls:DataGridTextColumn Binding="{Binding Image}" Header="Image" MinWidth="80" Width="100" />
+                    <controls:DataGridTextColumn Binding="{Binding DisplayState, Converter={StaticResource StateToDisplayTextConverter}}" Header="State" MinWidth="80" Width="90" />
+                    <controls:DataGridTextColumn Binding="{Binding CreatedAt, Converter={StaticResource CreatedAtConverter}}" Header="Created" MinWidth="120" Width="140" />
+                    <controls:DataGridTemplateColumn Header="" MinWidth="140" Width="150">
+                        <controls:DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate x:DataType="vm:ContainerRowViewModel">
+                                <StackPanel Orientation="Horizontal" Spacing="8">
+                                    <Button
+                                        x:Uid="BtnLogs"
+                                        AutomationProperties.AutomationId="{x:Bind Id, Mode=OneWay, Converter={StaticResource AutomationIdConverter}, ConverterParameter=BtnLogs}"
+                                        CommandParameter="{x:Bind Id}"
+                                        Click="BtnLogs_Click" />
+                                    <Button
+                                        x:Uid="BtnMoreActions"
+                                        AutomationProperties.AutomationId="{x:Bind Id, Mode=OneWay, Converter={StaticResource AutomationIdConverter}, ConverterParameter=BtnMoreActions}">
+                                        <Button.Flyout>
+                                            <MenuFlyout>
+                                                <MenuFlyoutItem
+                                                    x:Uid="MenuStart"
+                                                    AutomationProperties.AutomationId="{x:Bind Id, Mode=OneWay, Converter={StaticResource AutomationIdConverter}, ConverterParameter=MenuStart}"
+                                                    CommandParameter="{x:Bind}"
+                                                    Click="MenuStart_Click"
+                                                    Visibility="{x:Bind CanStart, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
+                                                <MenuFlyoutItem
+                                                    x:Uid="MenuStop"
+                                                    AutomationProperties.AutomationId="{x:Bind Id, Mode=OneWay, Converter={StaticResource AutomationIdConverter}, ConverterParameter=MenuStop}"
+                                                    CommandParameter="{x:Bind}"
+                                                    Click="MenuStop_Click"
+                                                    Visibility="{x:Bind CanStop, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
+                                                <MenuFlyoutItem
+                                                    x:Uid="MenuRestart"
+                                                    AutomationProperties.AutomationId="{x:Bind Id, Mode=OneWay, Converter={StaticResource AutomationIdConverter}, ConverterParameter=MenuRestart}"
+                                                    CommandParameter="{x:Bind}"
+                                                    Click="MenuRestart_Click"
+                                                    Visibility="{x:Bind CanRestart, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
+                                                <MenuFlyoutItem
+                                                    x:Uid="MenuDelete"
+                                                    AutomationProperties.AutomationId="{x:Bind Id, Mode=OneWay, Converter={StaticResource AutomationIdConverter}, ConverterParameter=MenuDelete}"
+                                                    CommandParameter="{x:Bind}"
+                                                    Click="BtnDelete_Click"
+                                                    Visibility="{x:Bind CanDelete, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
+                                            </MenuFlyout>
+                                        </Button.Flyout>
+                                    </Button>
+                                </StackPanel>
+                            </DataTemplate>
+                        </controls:DataGridTemplateColumn.CellTemplate>
+                    </controls:DataGridTemplateColumn>
+                </controls:DataGrid.Columns>
+            </controls:DataGrid>
+        </Border>
 
-        <StackPanel
+        <Border
             Grid.Row="2"
             Grid.RowSpan="2"
             HorizontalAlignment="Center"
             VerticalAlignment="Center"
-            Spacing="8"
+            Padding="24"
+            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+            BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+            BorderThickness="{ThemeResource WslContainersSurfaceBorderThickness}"
+            CornerRadius="{StaticResource OverlayCornerRadius}"
             Visibility="{x:Bind ToVisibleWhenTrue(ViewModel.IsEmpty), Mode=OneWay}">
-            <TextBlock x:Name="TxtEmptyStateTitle" x:Uid="TxtEmptyStateTitle" HorizontalAlignment="Center" Style="{StaticResource SubtitleTextBlockStyle}" />
-            <TextBlock x:Name="TxtEmptyStateDescription" x:Uid="TxtEmptyStateDescription" HorizontalAlignment="Center" />
-        </StackPanel>
+            <StackPanel Spacing="8">
+                <TextBlock x:Name="TxtEmptyStateTitle" x:Uid="TxtEmptyStateTitle" HorizontalAlignment="Center" Style="{StaticResource SubtitleTextBlockStyle}" />
+                <TextBlock x:Name="TxtEmptyStateDescription" x:Uid="TxtEmptyStateDescription" HorizontalAlignment="Center" />
+            </StackPanel>
+        </Border>
 
         <Border
             x:Name="BrdLogPanel"
             Grid.Row="4"
             Padding="16"
-            BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-            BorderThickness="1"
-            CornerRadius="8"
+            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+            BorderBrush="{ThemeResource WslContainersAccentStrokeColorBrush}"
+            BorderThickness="{ThemeResource WslContainersSurfaceBorderThickness}"
+            CornerRadius="{StaticResource OverlayCornerRadius}"
             Visibility="{x:Bind ToVisibleWhenTrue(ViewModel.IsLogPanelVisible), Mode=OneWay}">
             <Grid RowSpacing="12">
                 <Grid.RowDefinitions>

--- a/src/WslContainersDesktop.App/Pages/SettingsPage.xaml
+++ b/src/WslContainersDesktop.App/Pages/SettingsPage.xaml
@@ -13,7 +13,26 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <TextBlock x:Name="TxtPageTitle" x:Uid="SettingsPageTitle" Style="{StaticResource TitleTextBlockStyle}" />
-        <TextBlock x:Name="TxtPageDescription" x:Uid="SettingsPageDescription" Grid.Row="1" />
+        <Border
+            Padding="16"
+            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+            BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+            BorderThickness="{ThemeResource WslContainersSurfaceBorderThickness}"
+            CornerRadius="{StaticResource OverlayCornerRadius}">
+            <Grid ColumnSpacing="16">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="4" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <Border
+                    Grid.Column="0"
+                    Background="{ThemeResource WslContainersAccentFillColorDefaultBrush}"
+                    CornerRadius="{StaticResource ControlCornerRadius}" />
+                <StackPanel Grid.Column="1">
+                    <TextBlock x:Name="TxtPageTitle" x:Uid="SettingsPageTitle" Style="{StaticResource TitleTextBlockStyle}" />
+                    <TextBlock x:Name="TxtPageDescription" x:Uid="SettingsPageDescription" />
+                </StackPanel>
+            </Grid>
+        </Border>
     </Grid>
 </Page>

--- a/src/WslContainersDesktop.App/Themes/AppThemeResources.xaml
+++ b/src/WslContainersDesktop.App/Themes/AppThemeResources.xaml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key="Default">
+            <SolidColorBrush x:Key="WslContainersAccentFillColorDefaultBrush" Color="#107C10" />
+            <SolidColorBrush x:Key="WslContainersAccentFillColorSubtleBrush" Color="#0F6B0F" />
+            <SolidColorBrush x:Key="WslContainersAccentStrokeColorBrush" Color="#13A10E" />
+            <SolidColorBrush x:Key="WslContainersAccentTextFillColorBrush" Color="#13A10E" />
+            <Thickness x:Key="WslContainersSurfaceBorderThickness">1</Thickness>
+        </ResourceDictionary>
+        <ResourceDictionary x:Key="Light">
+            <SolidColorBrush x:Key="WslContainersAccentFillColorDefaultBrush" Color="#107C10" />
+            <SolidColorBrush x:Key="WslContainersAccentFillColorSubtleBrush" Color="#13A10E" />
+            <SolidColorBrush x:Key="WslContainersAccentStrokeColorBrush" Color="#0F6B0F" />
+            <SolidColorBrush x:Key="WslContainersAccentTextFillColorBrush" Color="#0F6B0F" />
+            <Thickness x:Key="WslContainersSurfaceBorderThickness">1</Thickness>
+        </ResourceDictionary>
+        <ResourceDictionary x:Key="HighContrast">
+            <StaticResource x:Key="WslContainersAccentFillColorDefaultBrush" ResourceKey="SystemColorHighlightColorBrush" />
+            <StaticResource x:Key="WslContainersAccentFillColorSubtleBrush" ResourceKey="SystemColorWindowColorBrush" />
+            <StaticResource x:Key="WslContainersAccentStrokeColorBrush" ResourceKey="SystemColorWindowTextColorBrush" />
+            <StaticResource x:Key="WslContainersAccentTextFillColorBrush" ResourceKey="SystemColorHighlightTextColorBrush" />
+            <Thickness x:Key="WslContainersSurfaceBorderThickness">2</Thickness>
+        </ResourceDictionary>
+    </ResourceDictionary.ThemeDictionaries>
+</ResourceDictionary>

--- a/tests/WslContainersDesktop.App.Tests/Themes/AppThemeResourcesTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/Themes/AppThemeResourcesTests.cs
@@ -1,0 +1,116 @@
+using System.Text.RegularExpressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace WslContainersDesktop_App_Tests.Themes;
+
+[TestClass]
+public sealed class AppThemeResourcesTests
+{
+    [TestMethod]
+    public void AppThemeResources_ThemeDictionaries_DefineSupportedThemeKeys()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Themes\AppThemeResources.xaml");
+
+        // Act
+        // No-op: the test is validating the XAML dictionary keys declared in the source file.
+
+        // Assert
+        StringAssert.Contains(sourceText, "x:Key=\"Default\"");
+        StringAssert.Contains(sourceText, "x:Key=\"Light\"");
+        StringAssert.Contains(sourceText, "x:Key=\"HighContrast\"");
+        Assert.IsFalse(sourceText.Contains("x:Key=\"Dark\"", StringComparison.Ordinal), "Expected the theme resource XAML to avoid a Dark theme dictionary entry.");
+    }
+
+    [TestMethod]
+    public void AppThemeResources_ThemeDictionaries_DefineExpectedResourceKeys()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Themes\AppThemeResources.xaml");
+        var expectedResourceKeys = new[]
+        {
+            "WslContainersAccentFillColorDefaultBrush",
+            "WslContainersAccentFillColorSubtleBrush",
+            "WslContainersAccentStrokeColorBrush",
+            "WslContainersAccentTextFillColorBrush",
+            "WslContainersSurfaceBorderThickness",
+        };
+
+        // Act
+        // No-op: the test is validating the XAML resource keys declared in the source file.
+
+        // Assert
+        foreach (var expectedResourceKey in expectedResourceKeys)
+        {
+            StringAssert.Contains(sourceText, expectedResourceKey, $"Expected theme resource key '{expectedResourceKey}' to be declared in the theme resource XAML.");
+        }
+    }
+
+    [TestMethod]
+    public void AppThemeResources_HighContrastDictionary_UsesSystemColorBrushes()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Themes\AppThemeResources.xaml");
+        var match = Regex.Match(sourceText, @"<ResourceDictionary\s+x:Key=""HighContrast"".*?</ResourceDictionary>", RegexOptions.Singleline);
+
+        // Act
+        // No-op: the test is validating the structure of the HighContrast dictionary section.
+
+        // Assert
+        Assert.IsTrue(match.Success, "Expected the theme resource XAML to define a HighContrast ResourceDictionary.");
+
+        var highContrastSection = match.Value;
+        StringAssert.Contains(highContrastSection, "SystemColorHighlightColorBrush");
+        StringAssert.Contains(highContrastSection, "SystemColorHighlightTextColorBrush");
+        StringAssert.Contains(highContrastSection, "SystemColorWindowColorBrush");
+        StringAssert.Contains(highContrastSection, "SystemColorWindowTextColorBrush");
+        Assert.IsFalse(highContrastSection.Contains("#107C10", StringComparison.Ordinal), "Expected the HighContrast dictionary to avoid the app green hex literal '#107C10'.");
+        Assert.IsFalse(highContrastSection.Contains("#0F6B0F", StringComparison.Ordinal), "Expected the HighContrast dictionary to avoid the app green hex literal '#0F6B0F'.");
+        Assert.IsFalse(highContrastSection.Contains("#13A10E", StringComparison.Ordinal), "Expected the HighContrast dictionary to avoid the app green hex literal '#13A10E'.");
+        Assert.IsFalse(highContrastSection.Contains("Color=\"#", StringComparison.Ordinal), "Expected the HighContrast dictionary to avoid inline Color values with hex literals.");
+    }
+
+    [TestMethod]
+    public void AppXaml_MergesAppThemeResources()
+    {
+        // Arrange
+        var appXamlText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\App.xaml");
+
+        // Act
+        // No-op: the test is validating the App.xaml merge dictionary declaration.
+
+        // Assert
+        Assert.IsTrue(
+            appXamlText.Contains("Themes/AppThemeResources.xaml", StringComparison.Ordinal) ||
+            appXamlText.Contains("Themes\\AppThemeResources.xaml", StringComparison.Ordinal),
+            "Expected App.xaml to merge the AppThemeResources.xaml file from the Themes folder.");
+    }
+
+    private static string ReadRepositorySourceFile(string relativePath)
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var normalizedRelativePath = relativePath.Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar);
+        var fullPath = Path.Combine(repositoryRoot, normalizedRelativePath);
+
+        Assert.IsTrue(File.Exists(fullPath), $"Expected source file '{relativePath}' to exist at '{fullPath}'.");
+        return File.ReadAllText(fullPath);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var currentDirectory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (currentDirectory is not null)
+        {
+            var appProjectFilePath = Path.Combine(currentDirectory.FullName, "src", "WslContainersDesktop.App", "WslContainersDesktop.App.csproj");
+            if (File.Exists(appProjectFilePath))
+            {
+                return currentDirectory.FullName;
+            }
+
+            currentDirectory = currentDirectory.Parent;
+        }
+
+        Assert.Fail($"Could not locate repository root from '{AppContext.BaseDirectory}'.");
+        return string.Empty;
+    }
+}


### PR DESCRIPTION
This change addresses the lack of an explicit visual design policy and improves the current dark UI, which looked flat and made boundaries between areas hard to read.

## Summary

- Adds a WinUI/Fluent UI design policy snapshot under `docs/design/design-policy.md` and registers it in the design docs index.
- Adds app-level WSL/terminal-like green accent theme resources with `Default`, `Light`, and `HighContrast` dictionaries.
- Applies clearer visual hierarchy to the existing pages by using card surfaces, borders, accent strips, and a stronger log panel boundary without changing ViewModel or navigation behavior.
- Adds MSTest coverage for the theme resource contract so unsupported theme dictionary keys and missing app resources are caught.

## Validation

- `dotnet test WslContainersDesktop.slnx`
- Launched the WinUI app with `BuildAndRun.ps1` using ARM64 RID
- Ran UIA smoke checks for navigation and key controls
- Captured and reviewed screenshots for Containers and Settings pages