### PR TITLE
Add image management

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -19,6 +19,7 @@
 | [`design-policy.md`](design-policy.md) | WinUI / Fluent Design に基づくUI・ビジュアルデザイン方針の現在のスナップショット |
 | [`presentation-navigation.md`](presentation-navigation.md) | Presentation層のナビゲーション基盤・ローカライズ基盤・DI構成の現在のスナップショット |
 | [`containers-view.md`](containers-view.md) | コンテナ一覧ViewModel（`ContainersViewModel`）の行操作・ログ表示状態管理の現在のスナップショット |
+| [`images-view.md`](images-view.md) | イメージ一覧ViewModel（`ImagesViewModel`）のpull・削除・状態管理の現在のスナップショット |
 | (機能追加に応じて追加) | 個別機能の設計ドキュメントは `docs/design/<feature-name>.md` として追加していく |
 
 ## 更新のタイミング

--- a/docs/design/architecture-overview.md
+++ b/docs/design/architecture-overview.md
@@ -10,17 +10,17 @@
 
 | プロジェクト | 種別 | 内容 |
 |---|---|---|
-| `src/WslContainersDesktop.Domain` | classlib | コンテナエンティティ・状態・状態別操作可否 |
-| `src/WslContainersDesktop.Application` | classlib | コンテナ管理ユースケースとInbound/Outboundポート |
+| `src/WslContainersDesktop.Domain` | classlib | コンテナ/イメージエンティティ・状態・状態別操作可否 |
+| `src/WslContainersDesktop.Application` | classlib | コンテナ/イメージ管理ユースケースとInbound/Outboundポート |
 | `src/WslContainersDesktop.Infrastructure` | classlib | `wslc` CLIラッパーによるWSL Containers連携 |
-| `src/WslContainersDesktop.App` | WinUI3 MSIXパッケージアプリ（net10.0-windows） | Presentation層。ナビゲーション、ローカライズ、DI構成、コンテナ一覧/ログ表示を実装済み |
+| `src/WslContainersDesktop.App` | WinUI3 MSIXパッケージアプリ（net10.0-windows） | Presentation層。ナビゲーション、ローカライズ、DI構成、コンテナ一覧/ログ表示、イメージ一覧/pull/削除を実装済み |
 | `tests/WslContainersDesktop.Domain.Tests` | MSTest | Domain層の単体テスト |
 | `tests/WslContainersDesktop.Application.Tests` | MSTest | Application層の単体テスト |
 | `tests/WslContainersDesktop.Infrastructure.Tests` | MSTest | Infrastructure層のCLIクライアント/ランナー単体テスト |
-| `tests/WslContainersDesktop.App.Tests` | MSTest | Presentation層（ナビゲーション制御・コンテナ一覧ViewModel）の単体テスト |
+| `tests/WslContainersDesktop.App.Tests` | MSTest | Presentation層（ナビゲーション制御・コンテナ/イメージ一覧ViewModel）の単体テスト |
 
 現在の主要な振る舞いは、コンテナ一覧取得、起動・停止・再起動・削除、ログのスナップショット表示と
-ライブ追跡である。
+ライブ追跡、イメージ一覧取得、イメージpull、イメージ削除である。
 
 ## 層構成
 
@@ -47,6 +47,8 @@ flowchart TB
 - 外部フレームワーク（WinUI, WSL API等）への依存を一切持たない。
 - 現在は`Container`と`ContainerState`を定義し、停止中/実行中に応じた起動・停止・再起動・削除の
   操作可否を`Container`に保持する。
+- `ContainerImage`はローカルイメージのID、リポジトリ、タグ、サイズ、作成日時を保持し、untaggedを含む
+  表示名を`DisplayName`として提供する。
 
 ### Application
 
@@ -60,7 +62,11 @@ flowchart TB
   存在と状態を検証する。再起動は`wslc`のサブコマンドではなく停止→起動として扱うが、停止中コンテナを
   起動にすり替えない。
 - `IContainerRuntimeClient`はInfrastructure層向けのOutboundポートであり、CLI/SDKなど具体的な
-  ランタイム連携方式をApplication層から隠蔽する。
+  ランタイム連携方式をApplication層から隠蔽する。コンテナ操作に加えて、イメージ一覧取得、pull、
+  削除のランタイム呼び出しもこのポートに集約する。
+- `IImageManagementService`はPresentation層向けのInboundポートであり、イメージ一覧取得、pull、
+  削除を提供する。pull後の一覧更新や削除確認はPresentation層で扱い、Application層はランタイム操作の
+  オーケストレーションと入力検証に留める。
 
 ### Infrastructure
 
@@ -72,6 +78,9 @@ flowchart TB
 - Applicationで定義された抽象を実装する。
 - 現在は [ADR-0009](../adr/0009-wrap-wslc-cli-for-infrastructure-layer.md) に基づき、
   `WslcCliContainerRuntimeClient`が`wslc` CLIを呼び出して`IContainerRuntimeClient`を実装する。
+- イメージ一覧は`wslc image list --format json --no-trunc`のJSONを`ContainerImage`へ変換する。
+  pullは`wslc pull <image>`、削除は`wslc image remove <image>`を呼び出す。削除時は強制削除フラグを
+  付けず、参照中イメージの拒否は`wslc`のエラーとしてApplication/Presentation層へ伝播する。
 - `IWslcCliRunner.RunAsync`は短時間で終了するCLI呼び出しの標準出力/標準エラーをまとめて取得する。
   `IWslcCliRunner.StreamLinesAsync`は`wslc container logs --since <unix-epoch> --follow`のような長時間実行コマンドの
   stdout/stderrを行単位でストリーミングする。実プロセス起動は`IWslcProcessFactory`/`IWslcProcess`で
@@ -88,6 +97,7 @@ flowchart TB
   [`docs/design/presentation-navigation.md`](presentation-navigation.md) を参照。
 - コンテナ一覧ViewModelの状態管理とログ表示の詳細は
   [`docs/design/containers-view.md`](containers-view.md) を参照。
+- イメージ一覧ViewModelの状態管理の詳細は [`docs/design/images-view.md`](images-view.md) を参照。
 
 ## テスト戦略との対応
 

--- a/docs/design/images-view.md
+++ b/docs/design/images-view.md
@@ -1,0 +1,46 @@
+# Presentation層: イメージ一覧ViewModelの状態管理
+
+> このドキュメントは現時点のスナップショットです。経緯・検討過程は書きません。
+
+## 概要
+
+`ImagesViewModel`（`ViewModels/ImagesViewModel.cs`）は、ローカルイメージ一覧の取得、レジストリからの
+pull、不要イメージの削除を担うViewModel。Application層の`IImageManagementService`にのみ依存し、
+`wslc` CLIの具体的な呼び出し方法には依存しない。
+
+## 一覧UI
+
+- `ImagesPage`はローカルイメージ一覧を表示する。各行は`ImageRowViewModel`で、表示名、イメージID、
+  サイズ（バイト）、作成日時、削除操作を表示する。
+- 表示名はDomain層の`ContainerImage.DisplayName`を使う。untaggedイメージは`<none>:<none>`として表示し、
+  一覧・削除の対象に含める。
+- 作成日時は`DateTimeOffsetToLocalStringConverter`でローカル日時へ変換して表示する。
+- `Images`が空の場合は空状態テキストを表示する。
+
+## 更新とエラー表示
+
+- `RefreshAsync`は`IImageManagementService.GetImagesAsync`で最新状態を取得し、成功時に`Images`を
+  全件置き換える。
+- 更新失敗時は既存の一覧を保持し、`ErrorMessage`に例外メッセージを設定する。
+- 新しい操作を開始する際は古い成功メッセージをクリアし、エラーと成功メッセージが矛盾して同時表示されない
+  ようにする。
+
+## Pull操作
+
+- `PullReference`はユーザーが入力したイメージ参照を保持する。`ImagesPage`のTextBoxは
+  `Mode=TwoWay, UpdateSourceTrigger=PropertyChanged`でバインドする。
+- `PullReference`が空または空白だけの場合、`PullAsync`はApplication層を呼び出さず、入力必須エラーを
+  `ErrorMessage`として表示する。
+- `PullAsync`は開始時に`IsPulling`を`true`にし、入力欄とPullボタンを無効化し、`ProgressRing`を表示する。
+- pull成功後は`PullReference`を空にし、成功メッセージを表示してからベストエフォートで一覧を再取得する。
+  pull自体が成功した後の一覧再取得失敗は`ErrorMessage`として表示し、pullの成功状態は維持する。
+- pull失敗時は入力値と既存一覧を保持し、`ErrorMessage`に失敗理由を表示する。
+
+## 削除操作
+
+- `ImagesPage`の削除ボタンは、`ContentDialog`で確認を取ってから`ImagesViewModel.DeleteCommand`を実行する。
+- `DeleteAsync`は対象行の`IsBusy`を`true`にして二重操作を防ぎ、成功時はライブの`Images`から対象行を
+  取り除く。
+- 削除は`wslc image remove <image>`に委譲され、強制削除フラグは付けない。参照中イメージやランタイム不調は
+  `IImageManagementService`からの例外としてPresentation層へ伝播し、`ErrorMessage`に表示する。
+- 削除失敗時は対象行を一覧に残し、`IsBusy`を解除する。

--- a/docs/design/presentation-navigation.md
+++ b/docs/design/presentation-navigation.md
@@ -15,7 +15,7 @@ UI文字列はすべて `.resw` リソースに外出しされ、コードやXAM
 
 | 型 | 場所 | 役割 |
 |---|---|---|
-| `NavigationPageKey` | `Navigation/NavigationPageKey.cs` | ページを表す `enum`（`Containers`, `Settings`）。string/Tagベースの遷移は使わない。 |
+| `NavigationPageKey` | `Navigation/NavigationPageKey.cs` | ページを表す `enum`（`Containers`, `Images`, `Settings`）。string/Tagベースの遷移は使わない。 |
 | `NavigationPageKeyExtensions.EnsureDefined` | `Navigation/NavigationPageKeyExtensions.cs` | `NavigationPageKey` が定義済みの値であることを検証する拡張メソッド。未定義値なら `ArgumentOutOfRangeException` を送出する。`NavigationPageRegistry`・`NavigationViewModel` の双方から共通利用する。 |
 | `NavigationPageRegistry` | `Navigation/NavigationPageRegistry.cs` | `NavigationPageKey → Page派生型` のマッピングを一元管理する、XAML非依存の素のC#クラス。 |
 | `NavigationViewModel` | `ViewModels/NavigationViewModel.cs` | 現在表示中のページキー（`CurrentPageKey`、setterはprivate）を保持するObservableObject。`NavigateToCommand`でのみ変更できる。 |
@@ -42,12 +42,13 @@ UI文字列はすべて `.resw` リソースに外出しされ、コードやXAM
 
 Composition Rootは`App.xaml.cs`に置く。`Microsoft.Extensions.DependencyInjection`で
 `IContainerRuntimeClient`→`WslcCliContainerRuntimeClient`、
-`IContainerManagementService`→`ContainerManagementService`、`IWslcCliRunner`→`WslcCliRunner`、
+`IContainerManagementService`→`ContainerManagementService`、
+`IImageManagementService`→`ImageManagementService`、`IWslcCliRunner`→`WslcCliRunner`、
 `IUiDispatcher`→`DispatcherQueueUiDispatcher`を登録する。
 
-`ContainersPage`は`Frame.Navigate(Type)`から生成されるためパラメーターレスコンストラクタを持つ。
-ページは`((App)Application.Current).Services`から`ContainersViewModel`を解決し、ViewModel自体は
-Application層の`IContainerManagementService`とUIディスパッチ抽象`IUiDispatcher`だけに依存する。
+トップレベルページは`Frame.Navigate(Type)`から生成されるためパラメーターレスコンストラクタを持つ。
+ページは`((App)Application.Current).Services`から対応するViewModelを解決し、ViewModel自体は
+Application層のInboundポートと必要なUI抽象だけに依存する。
 詳細は [ADR-0010](../adr/0010-adopt-di-container-for-presentation.md) を参照。
 
 ## ローカライズ

--- a/src/WslContainersDesktop.App/App.xaml.cs
+++ b/src/WslContainersDesktop.App/App.xaml.cs
@@ -49,11 +49,13 @@ public partial class App : Application
         services.AddSingleton<IWslcCliRunner, WslcCliRunner>();
         services.AddSingleton<IContainerRuntimeClient, WslcCliContainerRuntimeClient>();
         services.AddSingleton<IContainerManagementService, ContainerManagementService>();
+        services.AddSingleton<IImageManagementService, ImageManagementService>();
         services.AddSingleton<IUiDispatcher>(_ => new DispatcherQueueUiDispatcher(DispatcherQueue.GetForCurrentThread()));
 
         // トップレベルページのViewModelはNavigationViewModelと同様、アプリケーション
         // ライフタイムで1インスタンスとする。
         services.AddSingleton<ContainersViewModel>();
+        services.AddSingleton<ImagesViewModel>();
 
         return services.BuildServiceProvider();
     }

--- a/src/WslContainersDesktop.App/MainWindow.xaml
+++ b/src/WslContainersDesktop.App/MainWindow.xaml
@@ -45,6 +45,14 @@
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
                 <NavigationViewItem
+                    x:Name="NavItemImages"
+                    x:Uid="NavItemImages"
+                    AutomationProperties.AutomationId="NavItemImages">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="&#xE8B1;" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+                <NavigationViewItem
                     x:Name="NavItemSettings"
                     x:Uid="NavItemSettings"
                     AutomationProperties.AutomationId="NavItemSettings">

--- a/src/WslContainersDesktop.App/MainWindow.xaml.cs
+++ b/src/WslContainersDesktop.App/MainWindow.xaml.cs
@@ -32,6 +32,7 @@ public sealed partial class MainWindow : Window
         _navigationItemToPageKey = new()
         {
             [NavItemContainers] = NavigationPageKey.Containers,
+            [NavItemImages] = NavigationPageKey.Images,
             [NavItemSettings] = NavigationPageKey.Settings,
         };
 

--- a/src/WslContainersDesktop.App/Navigation/NavigationPageKey.cs
+++ b/src/WslContainersDesktop.App/Navigation/NavigationPageKey.cs
@@ -11,6 +11,9 @@ public enum NavigationPageKey
     /// <summary>コンテナー一覧ページ。</summary>
     Containers,
 
+    /// <summary>コンテナーイメージ一覧ページ。</summary>
+    Images,
+
     /// <summary>設定ページ。</summary>
     Settings,
 }

--- a/src/WslContainersDesktop.App/Navigation/NavigationPageRegistry.cs
+++ b/src/WslContainersDesktop.App/Navigation/NavigationPageRegistry.cs
@@ -23,6 +23,7 @@ public static class NavigationPageRegistry
         return pageKey.EnsureDefined(nameof(pageKey)) switch
         {
             NavigationPageKey.Containers => typeof(ContainersPage),
+            NavigationPageKey.Images => typeof(ImagesPage),
             NavigationPageKey.Settings => typeof(SettingsPage),
             _ => throw new ArgumentOutOfRangeException(nameof(pageKey), pageKey, "未定義のNavigationPageKeyです。"),
         };

--- a/src/WslContainersDesktop.App/Pages/ImagesPage.xaml
+++ b/src/WslContainersDesktop.App/Pages/ImagesPage.xaml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Page
+    x:Class="WslContainersDesktop_App.Pages.ImagesPage"
+    x:Name="RootPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:conv="using:WslContainersDesktop_App.Converters"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:WslContainersDesktop_App.Pages"
+    xmlns:vm="using:WslContainersDesktop_App.ViewModels"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Page.Resources>
+        <conv:AutomationIdConverter x:Key="AutomationIdConverter" />
+        <conv:DateTimeOffsetToLocalStringConverter x:Key="CreatedAtConverter" />
+    </Page.Resources>
+
+    <Grid Padding="24,16,24,16" RowSpacing="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <Border
+            Grid.Row="0"
+            Padding="16"
+            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+            BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+            BorderThickness="{ThemeResource WslContainersSurfaceBorderThickness}"
+            CornerRadius="{StaticResource OverlayCornerRadius}">
+            <Grid ColumnSpacing="16">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0">
+                    <TextBlock x:Name="TxtImagesPageTitle" x:Uid="ImagesPageTitle" Style="{StaticResource TitleTextBlockStyle}" />
+                    <TextBlock x:Name="TxtImagesPageDescription" x:Uid="ImagesPageDescription" />
+                </StackPanel>
+                <Button
+                    x:Name="BtnRefreshImages"
+                    x:Uid="BtnRefreshImages"
+                    Grid.Column="1"
+                    VerticalAlignment="Bottom"
+                    AutomationProperties.AutomationId="BtnRefreshImages"
+                    Command="{x:Bind ViewModel.RefreshCommand}" />
+            </Grid>
+        </Border>
+
+        <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="8">
+            <TextBox
+                x:Name="TxtPullReference"
+                x:Uid="TxtPullReference"
+                Width="320"
+                AutomationProperties.AutomationId="TxtPullReference"
+                IsEnabled="{x:Bind ViewModel.CanPull, Mode=OneWay}"
+                Text="{x:Bind ViewModel.PullReference, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+            <Button
+                x:Name="BtnPullImage"
+                x:Uid="BtnPullImage"
+                VerticalAlignment="Bottom"
+                AutomationProperties.AutomationId="BtnPullImage"
+                Command="{x:Bind ViewModel.PullCommand}"
+                IsEnabled="{x:Bind ViewModel.CanPull, Mode=OneWay}" />
+            <ProgressRing
+                x:Name="PrgPullImage"
+                Width="24"
+                Height="24"
+                AutomationProperties.AutomationId="PrgPullImage"
+                IsActive="{x:Bind ViewModel.IsPulling, Mode=OneWay}"
+                Visibility="{x:Bind ToVisibleWhenTrue(ViewModel.IsPulling), Mode=OneWay}" />
+        </StackPanel>
+
+        <StackPanel Grid.Row="2" Spacing="8">
+            <InfoBar
+                x:Name="InfoBarImageError"
+                Severity="Error"
+                IsClosable="False"
+                IsOpen="{x:Bind ViewModel.IsErrorMessageVisible, Mode=OneWay}"
+                Message="{x:Bind ViewModel.ErrorMessage, Mode=OneWay}" />
+            <InfoBar
+                x:Name="InfoBarImageStatus"
+                Severity="Success"
+                IsClosable="False"
+                IsOpen="{x:Bind ViewModel.IsStatusMessageVisible, Mode=OneWay}"
+                Message="{x:Bind ViewModel.StatusMessage, Mode=OneWay}" />
+        </StackPanel>
+
+        <Grid Grid.Row="3">
+            <ListView
+                x:Name="LstImages"
+                AutomationProperties.AutomationId="LstImages"
+                ItemsSource="{x:Bind ViewModel.Images, Mode=OneWay}"
+                SelectionMode="None"
+                Visibility="{x:Bind ToVisibleWhenFalse(ViewModel.IsEmpty), Mode=OneWay}">
+                <ListView.ItemTemplate>
+                    <DataTemplate x:DataType="vm:ImageRowViewModel">
+                        <Grid Padding="8" ColumnSpacing="12">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="2*" />
+                                <ColumnDefinition Width="2*" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0" Text="{x:Bind DisplayName}" />
+                            <TextBlock Grid.Column="1" Text="{x:Bind Id}" />
+                            <TextBlock Grid.Column="2" Text="{x:Bind SizeBytes}" />
+                            <TextBlock Grid.Column="3" Text="{x:Bind CreatedAt, Converter={StaticResource CreatedAtConverter}}" />
+                            <Button
+                                x:Uid="BtnDeleteImage"
+                                Grid.Column="4"
+                                AutomationProperties.AutomationId="{x:Bind Id, Mode=OneWay, Converter={StaticResource AutomationIdConverter}, ConverterParameter=BtnDeleteImage}"
+                                CommandParameter="{x:Bind}"
+                                Click="BtnDeleteImage_Click" />
+                        </Grid>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
+
+            <TextBlock
+                x:Name="TxtImagesEmptyState"
+                x:Uid="TxtImagesEmptyState"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                Visibility="{x:Bind ToVisibleWhenTrue(ViewModel.IsEmpty), Mode=OneWay}" />
+        </Grid>
+    </Grid>
+</Page>

--- a/src/WslContainersDesktop.App/Pages/ImagesPage.xaml.cs
+++ b/src/WslContainersDesktop.App/Pages/ImagesPage.xaml.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using WslContainersDesktop_App.ViewModels;
+using Windows.ApplicationModel.Resources;
+
+namespace WslContainersDesktop_App.Pages;
+
+/// <summary>
+/// コンテナーイメージ一覧ページ。
+/// </summary>
+public sealed partial class ImagesPage : Page
+{
+    private readonly ResourceLoader _resourceLoader = new();
+
+    /// <summary>
+    /// <see cref="ImagesPage"/> の新しいインスタンスを初期化する。
+    /// </summary>
+    public ImagesPage()
+    {
+        ViewModel = ((App)Application.Current).Services.GetRequiredService<ImagesViewModel>();
+
+        InitializeComponent();
+
+        Loaded += ImagesPage_Loaded;
+    }
+
+    /// <summary>
+    /// ページのViewModel。
+    /// </summary>
+    public ImagesViewModel ViewModel { get; }
+
+    private async void ImagesPage_Loaded(object sender, RoutedEventArgs e)
+    {
+        await ViewModel.RefreshCommand.ExecuteAsync(null);
+    }
+
+    private async void BtnDeleteImage_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button { CommandParameter: ImageRowViewModel row })
+        {
+            return;
+        }
+
+        var dialog = new ContentDialog
+        {
+            XamlRoot = XamlRoot,
+            Title = _resourceLoader.GetString("DeleteImageConfirmationDialog_Title"),
+            Content = string.Format(_resourceLoader.GetString("DeleteImageConfirmationDialog_Message"), row.DisplayName),
+            PrimaryButtonText = _resourceLoader.GetString("DeleteImageConfirmationDialog_PrimaryButtonText"),
+            CloseButtonText = _resourceLoader.GetString("DeleteImageConfirmationDialog_CloseButtonText"),
+            DefaultButton = ContentDialogButton.Close,
+        };
+
+        var result = await dialog.ShowAsync();
+        if (result == ContentDialogResult.Primary)
+        {
+            await ViewModel.DeleteCommand.ExecuteAsync(row);
+        }
+    }
+
+    /// <summary>
+    /// x:Bind用のbool→Visibility変換関数。値がtrueのとき表示する。
+    /// </summary>
+    /// <param name="value">変換元の値。</param>
+    /// <returns>対応する <see cref="Visibility"/>。</returns>
+    public Visibility ToVisibleWhenTrue(bool value) => value ? Visibility.Visible : Visibility.Collapsed;
+
+    /// <summary>
+    /// x:Bind用のbool→Visibility変換関数。値がfalseのとき表示する。
+    /// </summary>
+    /// <param name="value">変換元の値。</param>
+    /// <returns>対応する <see cref="Visibility"/>。</returns>
+    public Visibility ToVisibleWhenFalse(bool value) => value ? Visibility.Collapsed : Visibility.Visible;
+
+    /// <summary>
+    /// x:Bind用のnull/空判定関数。
+    /// </summary>
+    /// <param name="value">判定対象の値。</param>
+    /// <returns>値がnullでも空でもない場合は <see langword="true"/>。</returns>
+    public bool IsNotNullOrEmpty(string? value) => !string.IsNullOrEmpty(value);
+}

--- a/src/WslContainersDesktop.App/Strings/en-US/Resources.resw
+++ b/src/WslContainersDesktop.App/Strings/en-US/Resources.resw
@@ -126,6 +126,9 @@
   <data name="NavItemContainers.Content" xml:space="preserve">
     <value>Containers</value>
   </data>
+  <data name="NavItemImages.Content" xml:space="preserve">
+    <value>Images</value>
+  </data>
   <data name="NavItemSettings.Content" xml:space="preserve">
     <value>Settings</value>
   </data>
@@ -204,6 +207,27 @@
   <data name="TxtLogEmptyState.Text" xml:space="preserve">
     <value>No logs to display.</value>
   </data>
+  <data name="ImagesPageTitle.Text" xml:space="preserve">
+    <value>Images</value>
+  </data>
+  <data name="ImagesPageDescription.Text" xml:space="preserve">
+    <value>Pull and remove container images.</value>
+  </data>
+  <data name="BtnRefreshImages.Content" xml:space="preserve">
+    <value>Refresh</value>
+  </data>
+  <data name="TxtPullReference.Header" xml:space="preserve">
+    <value>Image reference</value>
+  </data>
+  <data name="BtnPullImage.Content" xml:space="preserve">
+    <value>Pull</value>
+  </data>
+  <data name="BtnDeleteImage.Content" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="TxtImagesEmptyState.Text" xml:space="preserve">
+    <value>No images.</value>
+  </data>
   <data name="ContainerState_Running" xml:space="preserve">
     <value>Running</value>
   </data>
@@ -232,6 +256,18 @@
     <value>Delete</value>
   </data>
   <data name="DeleteConfirmationDialog_CloseButtonText" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="DeleteImageConfirmationDialog_Title" xml:space="preserve">
+    <value>Delete image</value>
+  </data>
+  <data name="DeleteImageConfirmationDialog_Message" xml:space="preserve">
+    <value>Are you sure you want to delete '{0}'? This action cannot be undone.</value>
+  </data>
+  <data name="DeleteImageConfirmationDialog_PrimaryButtonText" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="DeleteImageConfirmationDialog_CloseButtonText" xml:space="preserve">
     <value>Cancel</value>
   </data>
   <data name="SettingsPageTitle.Text" xml:space="preserve">

--- a/src/WslContainersDesktop.App/ViewModels/ImageRowViewModel.cs
+++ b/src/WslContainersDesktop.App/ViewModels/ImageRowViewModel.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using WslContainersDesktop.Domain;
+
+namespace WslContainersDesktop_App.ViewModels;
+
+/// <summary>
+/// XAMLバインディング用に <see cref="ContainerImage"/> をラップする行ViewModel。
+/// </summary>
+public sealed partial class ImageRowViewModel : ObservableObject
+{
+    /// <summary>
+    /// <see cref="ImageRowViewModel"/> の新しいインスタンスを初期化する。
+    /// </summary>
+    /// <param name="image">初期状態の元となるコンテナーイメージ。</param>
+    public ImageRowViewModel(ContainerImage image)
+    {
+        Id = image.Id;
+        Repository = image.Repository;
+        Tag = image.Tag;
+        DisplayName = image.DisplayName;
+        SizeBytes = image.SizeBytes;
+        CreatedAt = image.CreatedAt;
+    }
+
+    /// <summary>
+    /// イメージID。
+    /// </summary>
+    public string Id { get; }
+
+    /// <summary>
+    /// リポジトリ名。
+    /// </summary>
+    public string Repository { get; }
+
+    /// <summary>
+    /// タグ名。
+    /// </summary>
+    public string Tag { get; }
+
+    /// <summary>
+    /// 表示用イメージ名。
+    /// </summary>
+    public string DisplayName { get; }
+
+    /// <summary>
+    /// イメージサイズ（バイト）。
+    /// </summary>
+    public long SizeBytes { get; }
+
+    /// <summary>
+    /// 作成日時。
+    /// </summary>
+    public DateTimeOffset CreatedAt { get; }
+
+    /// <summary>
+    /// この行に対する操作が進行中かどうか。
+    /// </summary>
+    [ObservableProperty]
+    public partial bool IsBusy { get; set; } = false;
+}

--- a/src/WslContainersDesktop.App/ViewModels/ImagesViewModel.cs
+++ b/src/WslContainersDesktop.App/ViewModels/ImagesViewModel.cs
@@ -1,0 +1,185 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using WslContainersDesktop.Application.Ports;
+using WslContainersDesktop.Domain;
+
+namespace WslContainersDesktop_App.ViewModels;
+
+/// <summary>
+/// コンテナーイメージ一覧の表示・操作を管理するViewModel。
+/// </summary>
+public sealed partial class ImagesViewModel(IImageManagementService imageManagementService) : ObservableObject
+{
+    private const string PullingStatusMessage = "Pulling image...";
+    private const string PullCompletedStatusMessage = "Pull completed.";
+    private const string EmptyPullReferenceMessage = "Image reference is required.";
+
+    /// <summary>
+    /// 現在表示中のコンテナーイメージ一覧。
+    /// </summary>
+    public ObservableCollection<ImageRowViewModel> Images { get; } = [];
+
+    /// <summary>
+    /// Pull操作で取得するイメージ参照。
+    /// </summary>
+    [ObservableProperty]
+    public partial string PullReference { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 直近の操作で発生したエラーメッセージ。エラーがない場合は <see langword="null"/>。
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsErrorMessageVisible))]
+    public partial string? ErrorMessage { get; private set; }
+
+    /// <summary>
+    /// 直近の成功操作を表すステータスメッセージ。
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsStatusMessageVisible))]
+    public partial string? StatusMessage { get; private set; }
+
+    /// <summary>
+    /// エラーメッセージを表示するかどうか。
+    /// </summary>
+    public bool IsErrorMessageVisible => !string.IsNullOrEmpty(ErrorMessage);
+
+    /// <summary>
+    /// 成功または進行中ステータスメッセージを表示するかどうか。
+    /// </summary>
+    public bool IsStatusMessageVisible => !string.IsNullOrEmpty(StatusMessage);
+
+    /// <summary>
+    /// Pull操作が進行中かどうか。
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanPull))]
+    public partial bool IsPulling { get; private set; }
+
+    /// <summary>
+    /// Pull操作を開始できるかどうか。
+    /// </summary>
+    public bool CanPull => !IsPulling;
+
+    /// <summary>
+    /// <see cref="Images"/> が空かどうか。
+    /// </summary>
+    [ObservableProperty]
+    public partial bool IsEmpty { get; private set; } = true;
+
+    /// <summary>
+    /// コンテナーイメージ一覧を手動で再取得する。
+    /// </summary>
+    [RelayCommand]
+    public async Task RefreshAsync()
+    {
+        StatusMessage = null;
+        try
+        {
+            var images = await imageManagementService.GetImagesAsync();
+            ReplaceImages(images);
+            ErrorMessage = null;
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = ex.Message;
+        }
+    }
+
+    /// <summary>
+    /// 入力されたイメージ参照を取得し、成功後に一覧を再取得する。
+    /// </summary>
+    [RelayCommand]
+    public async Task PullAsync()
+    {
+        var imageReference = PullReference.Trim();
+        StatusMessage = null;
+        ErrorMessage = null;
+        if (imageReference.Length == 0)
+        {
+            ErrorMessage = EmptyPullReferenceMessage;
+            return;
+        }
+
+        StatusMessage = PullingStatusMessage;
+        IsPulling = true;
+        try
+        {
+            await imageManagementService.PullAsync(imageReference);
+            PullReference = string.Empty;
+            StatusMessage = PullCompletedStatusMessage;
+            ErrorMessage = null;
+            await RefreshImagesAfterPullAsync();
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = ex.Message;
+            StatusMessage = null;
+        }
+        finally
+        {
+            IsPulling = false;
+        }
+    }
+
+    /// <summary>
+    /// 指定したコンテナーイメージを削除する。
+    /// </summary>
+    /// <param name="row">対象の行。</param>
+    [RelayCommand]
+    public async Task DeleteAsync(ImageRowViewModel row)
+    {
+        StatusMessage = null;
+        row.IsBusy = true;
+        try
+        {
+            await imageManagementService.DeleteAsync(row.Id);
+            var liveRow = Images.FirstOrDefault(image => image.Id == row.Id);
+            if (liveRow is not null)
+            {
+                liveRow.IsBusy = false;
+                Images.Remove(liveRow);
+            }
+            else
+            {
+                row.IsBusy = false;
+            }
+
+            IsEmpty = Images.Count == 0;
+            ErrorMessage = null;
+        }
+        catch (Exception ex)
+        {
+            row.IsBusy = false;
+            ErrorMessage = ex.Message;
+        }
+    }
+
+    private async Task RefreshImagesAfterPullAsync()
+    {
+        try
+        {
+            var images = await imageManagementService.GetImagesAsync();
+            ReplaceImages(images);
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = ex.Message;
+        }
+    }
+
+    private void ReplaceImages(IReadOnlyList<ContainerImage> images)
+    {
+        Images.Clear();
+        foreach (var image in images)
+        {
+            Images.Add(new ImageRowViewModel(image));
+        }
+
+        IsEmpty = Images.Count == 0;
+    }
+}

--- a/src/WslContainersDesktop.Application/Ports/IContainerRuntimeClient.cs
+++ b/src/WslContainersDesktop.Application/Ports/IContainerRuntimeClient.cs
@@ -15,6 +15,26 @@ public interface IContainerRuntimeClient
     Task<IReadOnlyList<Container>> ListContainersAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// 現在存在するすべてのコンテナーイメージを取得する。
+    /// </summary>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    Task<IReadOnlyList<ContainerImage>> ListImagesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 指定したイメージ参照を取得する。
+    /// </summary>
+    /// <param name="imageReference">取得するイメージ参照。</param>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    Task PullImageAsync(string imageReference, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 指定したコンテナーイメージを削除する。
+    /// </summary>
+    /// <param name="imageId">対象イメージのID。</param>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    Task DeleteImageAsync(string imageId, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// 指定したコンテナを起動する。
     /// </summary>
     /// <param name="containerId">対象コンテナのID。</param>

--- a/src/WslContainersDesktop.Application/Ports/IImageManagementService.cs
+++ b/src/WslContainersDesktop.Application/Ports/IImageManagementService.cs
@@ -1,0 +1,29 @@
+using WslContainersDesktop.Domain;
+
+namespace WslContainersDesktop.Application.Ports;
+
+/// <summary>
+/// コンテナーイメージ管理ユースケースを提供するインバウンドポート。
+/// </summary>
+public interface IImageManagementService
+{
+    /// <summary>
+    /// 現在存在するすべてのコンテナーイメージを取得する。
+    /// </summary>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    Task<IReadOnlyList<ContainerImage>> GetImagesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 指定したイメージ参照を取得する。
+    /// </summary>
+    /// <param name="imageReference">取得するイメージ参照。</param>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    Task PullAsync(string imageReference, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 指定したコンテナーイメージを削除する。
+    /// </summary>
+    /// <param name="imageId">対象イメージのID。</param>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    Task DeleteAsync(string imageId, CancellationToken cancellationToken = default);
+}

--- a/src/WslContainersDesktop.Application/Services/ImageManagementService.cs
+++ b/src/WslContainersDesktop.Application/Services/ImageManagementService.cs
@@ -1,0 +1,41 @@
+using WslContainersDesktop.Application.Ports;
+using WslContainersDesktop.Domain;
+
+namespace WslContainersDesktop.Application.Services;
+
+/// <summary>
+/// <see cref="IImageManagementService"/> の実装。
+/// </summary>
+public sealed class ImageManagementService(IContainerRuntimeClient runtimeClient) : IImageManagementService
+{
+    /// <inheritdoc />
+    public Task<IReadOnlyList<ContainerImage>> GetImagesAsync(CancellationToken cancellationToken = default)
+    {
+        return runtimeClient.ListImagesAsync(cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task PullAsync(string imageReference, CancellationToken cancellationToken = default)
+    {
+        var trimmed = ValidateNotWhiteSpace(imageReference, nameof(imageReference));
+        return runtimeClient.PullImageAsync(trimmed, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task DeleteAsync(string imageId, CancellationToken cancellationToken = default)
+    {
+        var trimmed = ValidateNotWhiteSpace(imageId, nameof(imageId));
+        return runtimeClient.DeleteImageAsync(trimmed, cancellationToken);
+    }
+
+    private static string ValidateNotWhiteSpace(string value, string parameterName)
+    {
+        var trimmed = value.Trim();
+        if (trimmed.Length == 0)
+        {
+            throw new ArgumentException("値を空白だけにすることはできません。", parameterName);
+        }
+
+        return trimmed;
+    }
+}

--- a/src/WslContainersDesktop.Domain/ContainerImage.cs
+++ b/src/WslContainersDesktop.Domain/ContainerImage.cs
@@ -1,0 +1,19 @@
+namespace WslContainersDesktop.Domain;
+
+/// <summary>
+/// WSL Containers上のコンテナーイメージを表すエンティティ。
+/// </summary>
+/// <param name="Id">イメージID。</param>
+/// <param name="Repository">リポジトリ名。</param>
+/// <param name="Tag">タグ名。</param>
+/// <param name="SizeBytes">イメージサイズ（バイト）。</param>
+/// <param name="CreatedAt">作成日時。</param>
+public sealed record ContainerImage(string Id, string Repository, string Tag, long SizeBytes, DateTimeOffset CreatedAt)
+{
+    /// <summary>
+    /// 一覧表示用のイメージ名。
+    /// </summary>
+    public string DisplayName => $"{NormalizeNamePart(Repository)}:{NormalizeNamePart(Tag)}";
+
+    private static string NormalizeNamePart(string value) => string.IsNullOrEmpty(value) ? "<none>" : value;
+}

--- a/src/WslContainersDesktop.Infrastructure/Clients/ImageListItemDto.cs
+++ b/src/WslContainersDesktop.Infrastructure/Clients/ImageListItemDto.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+
+namespace WslContainersDesktop.Infrastructure.Clients;
+
+/// <summary>
+/// <c>wslc image list --format json --no-trunc</c> の1要素に対応するJSON DTO。
+/// </summary>
+internal sealed class ImageListItemDto
+{
+    [JsonPropertyName("Created")]
+    public long Created { get; set; }
+
+    [JsonPropertyName("Id")]
+    public string Id { get; set; } = string.Empty;
+
+    [JsonPropertyName("Repository")]
+    public string Repository { get; set; } = string.Empty;
+
+    [JsonPropertyName("Size")]
+    public long Size { get; set; }
+
+    [JsonPropertyName("Tag")]
+    public string Tag { get; set; } = string.Empty;
+}

--- a/src/WslContainersDesktop.Infrastructure/Clients/WslcCliContainerRuntimeClient.cs
+++ b/src/WslContainersDesktop.Infrastructure/Clients/WslcCliContainerRuntimeClient.cs
@@ -51,6 +51,49 @@ public sealed class WslcCliContainerRuntimeClient(IWslcCliRunner cliRunner) : IC
             .ToList();
     }
 
+    public async Task<IReadOnlyList<ContainerImage>> ListImagesAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await RunAsync(["image", "list", "--format", "json", "--no-trunc"], cancellationToken);
+
+        List<ImageListItemDto>? items;
+        try
+        {
+            items = JsonSerializer.Deserialize<List<ImageListItemDto>>(result.StandardOutput);
+        }
+        catch (JsonException ex)
+        {
+            throw new ContainerRuntimeException(
+                command: "image list --format json --no-trunc",
+                exitCode: result.ExitCode,
+                message: "コンテナーイメージ一覧の解析に失敗しました。",
+                innerException: ex);
+        }
+
+        if (items is null)
+        {
+            return [];
+        }
+
+        return items
+            .Select(item => new ContainerImage(
+                Id: item.Id,
+                Repository: item.Repository,
+                Tag: item.Tag,
+                SizeBytes: item.Size,
+                CreatedAt: DateTimeOffset.FromUnixTimeSeconds(item.Created)))
+            .ToList();
+    }
+
+    public Task PullImageAsync(string imageReference, CancellationToken cancellationToken = default)
+    {
+        return RunAsync(["pull", imageReference], cancellationToken);
+    }
+
+    public Task DeleteImageAsync(string imageId, CancellationToken cancellationToken = default)
+    {
+        return RunAsync(["image", "remove", imageId], cancellationToken);
+    }
+
     public Task StartAsync(string containerId, CancellationToken cancellationToken = default)
     {
         return RunAsync(["container", "start", containerId], cancellationToken);

--- a/tests/WslContainersDesktop.App.Tests/Fakes/FakeImageManagementService.cs
+++ b/tests/WslContainersDesktop.App.Tests/Fakes/FakeImageManagementService.cs
@@ -1,0 +1,88 @@
+using WslContainersDesktop.Application.Ports;
+using WslContainersDesktop.Domain;
+
+namespace WslContainersDesktop_App_Tests.Fakes;
+
+internal sealed class FakeImageManagementService : IImageManagementService
+{
+    private bool _usePullResultImages;
+    private bool _useDeleteResultImages;
+
+    public Queue<Func<Task<IReadOnlyList<ContainerImage>>>> GetImagesResults { get; } = new();
+
+    public IReadOnlyList<ContainerImage> DefaultImages { get; set; } = [];
+
+    public IReadOnlyList<ContainerImage> PullResultImages { get; set; } = [];
+
+    public IReadOnlyList<ContainerImage> DeleteResultImages { get; set; } = [];
+
+    public Exception? GetImagesException { get; set; }
+
+    public Exception? PullException { get; set; }
+
+    public Exception? DeleteException { get; set; }
+
+    public TaskCompletionSource<bool>? PullGate { get; set; }
+
+    public List<string> PullCalls { get; } = [];
+
+    public List<string> DeleteCalls { get; } = [];
+
+    public Task<IReadOnlyList<ContainerImage>> GetImagesAsync(CancellationToken cancellationToken = default)
+    {
+        if (GetImagesResults.Count > 0)
+        {
+            return GetImagesResults.Dequeue()();
+        }
+
+        if (GetImagesException is not null)
+        {
+            throw GetImagesException;
+        }
+
+        if (_usePullResultImages)
+        {
+            _usePullResultImages = false;
+            return Task.FromResult(PullResultImages);
+        }
+
+        if (_useDeleteResultImages)
+        {
+            _useDeleteResultImages = false;
+            return Task.FromResult(DeleteResultImages);
+        }
+
+        return Task.FromResult(DefaultImages);
+    }
+
+    public async Task PullAsync(string reference, CancellationToken cancellationToken = default)
+    {
+        PullCalls.Add(reference);
+        _usePullResultImages = true;
+        _useDeleteResultImages = false;
+        if (PullGate is not null)
+        {
+            await PullGate.Task;
+        }
+
+        if (PullException is not null)
+        {
+            throw PullException;
+        }
+
+        await Task.CompletedTask;
+    }
+
+    public Task DeleteAsync(string imageId, CancellationToken cancellationToken = default)
+    {
+        DeleteCalls.Add(imageId);
+        _useDeleteResultImages = true;
+        _usePullResultImages = false;
+        if (DeleteException is not null)
+        {
+            throw DeleteException;
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/tests/WslContainersDesktop.App.Tests/Navigation/NavigationPageRegistryTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/Navigation/NavigationPageRegistryTests.cs
@@ -8,6 +8,7 @@ public sealed class NavigationPageRegistryTests
 {
     [TestMethod]
     [DataRow(NavigationPageKey.Containers, typeof(ContainersPage))]
+    [DataRow(NavigationPageKey.Images, typeof(ImagesPage))]
     [DataRow(NavigationPageKey.Settings, typeof(SettingsPage))]
     public void GetPageType_DefinedPageKey_ReturnsExpectedPageType(NavigationPageKey pageKey, Type expectedPageType)
     {

--- a/tests/WslContainersDesktop.App.Tests/Pages/ImagesPageSourceTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/Pages/ImagesPageSourceTests.cs
@@ -1,0 +1,70 @@
+namespace WslContainersDesktop_App_Tests.Pages;
+
+[TestClass]
+public sealed class ImagesPageSourceTests
+{
+    [TestMethod]
+    public void ImagesPage_XamlDisplaysRequiredImageFields()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Pages\ImagesPage.xaml");
+
+        // Act
+        // No-op: the test validates source bindings required by the feature specification.
+
+        // Assert
+        StringAssert.Contains(sourceText, "Text=\"{x:Bind DisplayName}\"");
+        StringAssert.Contains(sourceText, "Text=\"{x:Bind Id}\"");
+        StringAssert.Contains(sourceText, "CreatedAt");
+    }
+
+    [TestMethod]
+    public void ImagesPage_DeleteClickShowsConfirmationBeforeExecutingDeleteCommand()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Pages\ImagesPage.xaml.cs");
+
+        // Act
+        var handlerIndex = sourceText.IndexOf("BtnDeleteImage_Click", StringComparison.Ordinal);
+        var dialogIndex = sourceText.IndexOf("ContentDialog", StringComparison.Ordinal);
+        var primaryResultIndex = sourceText.IndexOf("ContentDialogResult.Primary", StringComparison.Ordinal);
+        var deleteCommandIndex = sourceText.IndexOf("DeleteCommand.ExecuteAsync", StringComparison.Ordinal);
+
+        // Assert
+        Assert.IsGreaterThanOrEqualTo(0, handlerIndex, "Expected ImagesPage to define BtnDeleteImage_Click.");
+        Assert.IsGreaterThanOrEqualTo(0, dialogIndex, "Expected image deletion to create a confirmation dialog.");
+        Assert.IsGreaterThanOrEqualTo(0, primaryResultIndex, "Expected image deletion to require primary confirmation.");
+        Assert.IsGreaterThanOrEqualTo(0, deleteCommandIndex, "Expected confirmed image deletion to execute DeleteCommand.");
+        Assert.IsTrue(
+            handlerIndex < dialogIndex && dialogIndex < deleteCommandIndex,
+            "Expected the delete confirmation dialog to be created before executing the delete command.");
+    }
+
+    private static string ReadRepositorySourceFile(string relativePath)
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var normalizedRelativePath = relativePath.Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar);
+        var fullPath = Path.Combine(repositoryRoot, normalizedRelativePath);
+
+        Assert.IsTrue(File.Exists(fullPath), $"Expected source file '{relativePath}' to exist at '{fullPath}'.");
+        return File.ReadAllText(fullPath);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var currentDirectory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (currentDirectory is not null)
+        {
+            var appProjectFilePath = Path.Combine(currentDirectory.FullName, "src", "WslContainersDesktop.App", "WslContainersDesktop.App.csproj");
+            if (File.Exists(appProjectFilePath))
+            {
+                return currentDirectory.FullName;
+            }
+
+            currentDirectory = currentDirectory.Parent;
+        }
+
+        Assert.Fail($"Could not locate repository root from '{AppContext.BaseDirectory}'.");
+        return string.Empty;
+    }
+}

--- a/tests/WslContainersDesktop.App.Tests/ViewModels/ImagesViewModelTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/ViewModels/ImagesViewModelTests.cs
@@ -1,0 +1,252 @@
+using WslContainersDesktop.Application.Exceptions;
+using WslContainersDesktop.Domain;
+using WslContainersDesktop_App.ViewModels;
+using WslContainersDesktop_App_Tests.Fakes;
+
+namespace WslContainersDesktop_App_Tests.ViewModels;
+
+[TestClass]
+public sealed class ImagesViewModelTests
+{
+    private static ContainerImage CreateImage(string id) => new(
+        Id: id,
+        Repository: "ubuntu",
+        Tag: "latest",
+        SizeBytes: 120L,
+        CreatedAt: new DateTimeOffset(2026, 7, 2, 9, 0, 0, TimeSpan.Zero));
+
+    [TestMethod]
+    public async Task RefreshAsync_ServiceReturnsImages_PopulatesRowsAndClearsErrorAndIsEmptyIsFalse()
+    {
+        // Arrange
+        var service = new FakeImageManagementService
+        {
+            DefaultImages = [CreateImage("img-1"), CreateImage("img-2")],
+        };
+        var sut = new ImagesViewModel(service);
+
+        // Act
+        await sut.RefreshAsync();
+
+        // Assert
+        Assert.HasCount(2, sut.Images);
+        Assert.AreEqual("img-1", sut.Images[0].Id);
+        Assert.AreEqual("ubuntu:latest", sut.Images[0].DisplayName);
+        Assert.IsFalse(sut.IsEmpty);
+        Assert.IsNull(sut.ErrorMessage);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_ServiceReturnsEmptyList_IsEmptyIsTrue()
+    {
+        // Arrange
+        var service = new FakeImageManagementService { DefaultImages = [] };
+        var sut = new ImagesViewModel(service);
+
+        // Act
+        await sut.RefreshAsync();
+
+        // Assert
+        Assert.IsEmpty(sut.Images);
+        Assert.IsTrue(sut.IsEmpty);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_ServiceThrows_ErrorMessageIsSetAndExistingImagesArePreserved()
+    {
+        // Arrange
+        var service = new FakeImageManagementService();
+        service.GetImagesResults.Enqueue(() => Task.FromResult<IReadOnlyList<ContainerImage>>([CreateImage("img-1")]));
+        service.GetImagesResults.Enqueue(() => Task.FromException<IReadOnlyList<ContainerImage>>(new ContainerRuntimeException("list", 1, "一覧の取得に失敗しました。")));
+        var sut = new ImagesViewModel(service);
+        await sut.RefreshAsync();
+
+        // Act
+        await sut.RefreshAsync();
+
+        // Assert
+        Assert.AreEqual("一覧の取得に失敗しました。", sut.ErrorMessage);
+        Assert.HasCount(1, sut.Images);
+        Assert.AreEqual("img-1", sut.Images[0].Id);
+    }
+
+    [TestMethod]
+    public async Task PullAsync_ServiceSucceeds_ClearsInputSetsStatusAndRefreshesImages()
+    {
+        // Arrange
+        var service = new FakeImageManagementService
+        {
+            DefaultImages = [],
+            PullResultImages = [CreateImage("img-1")],
+        };
+        var sut = new ImagesViewModel(service)
+        {
+            PullReference = "  ubuntu:latest  ",
+        };
+
+        // Act
+        await sut.PullAsync();
+
+        // Assert
+        Assert.AreEqual(string.Empty, sut.PullReference);
+        Assert.AreEqual("Pull completed.", sut.StatusMessage);
+        Assert.HasCount(1, sut.Images);
+        Assert.AreEqual("img-1", sut.Images[0].Id);
+        Assert.IsFalse(sut.IsErrorMessageVisible);
+        Assert.IsTrue(sut.IsStatusMessageVisible);
+    }
+
+    [TestMethod]
+    public async Task PullAsync_PullReferenceIsEmpty_ShowsValidationErrorAndDoesNotCallService()
+    {
+        // Arrange
+        var service = new FakeImageManagementService();
+        var sut = new ImagesViewModel(service)
+        {
+            PullReference = string.Empty,
+        };
+
+        // Act
+        await sut.PullAsync();
+
+        // Assert
+        Assert.AreEqual("Image reference is required.", sut.ErrorMessage);
+        Assert.IsTrue(sut.IsErrorMessageVisible);
+        Assert.IsNull(sut.StatusMessage);
+        Assert.IsFalse(sut.IsStatusMessageVisible);
+        Assert.IsFalse(sut.IsPulling);
+        Assert.IsEmpty(service.PullCalls);
+    }
+
+    [TestMethod]
+    public async Task PullAsync_PullReferenceIsWhiteSpace_ShowsValidationErrorAndDoesNotCallService()
+    {
+        // Arrange
+        var service = new FakeImageManagementService();
+        var sut = new ImagesViewModel(service)
+        {
+            PullReference = "   ",
+        };
+
+        // Act
+        await sut.PullAsync();
+
+        // Assert
+        Assert.AreEqual("Image reference is required.", sut.ErrorMessage);
+        Assert.IsTrue(sut.IsErrorMessageVisible);
+        Assert.IsFalse(sut.IsStatusMessageVisible);
+        Assert.IsEmpty(service.PullCalls);
+    }
+
+    [TestMethod]
+    public async Task PullAsync_OperationIsRunning_IsPullingIsTrueThenFalse()
+    {
+        // Arrange
+        var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var service = new FakeImageManagementService
+        {
+            PullGate = gate,
+            PullResultImages = [CreateImage("img-1")],
+        };
+        var sut = new ImagesViewModel(service)
+        {
+            PullReference = "ubuntu:latest",
+        };
+
+        // Act
+        var pullTask = sut.PullAsync();
+
+        // Assert
+        Assert.IsTrue(sut.IsPulling);
+        gate.SetResult(true);
+        await pullTask;
+        Assert.IsFalse(sut.IsPulling);
+    }
+
+    [TestMethod]
+    public async Task PullAsync_ServiceThrows_ErrorMessageIsSetAndInputIsPreserved()
+    {
+        // Arrange
+        var service = new FakeImageManagementService { PullException = new ContainerRuntimeException("pull", 1, "pull failed") };
+        var sut = new ImagesViewModel(service)
+        {
+            PullReference = "ubuntu:latest",
+        };
+
+        // Act
+        await sut.PullAsync();
+
+        // Assert
+        Assert.AreEqual("pull failed", sut.ErrorMessage);
+        Assert.AreEqual("ubuntu:latest", sut.PullReference);
+        Assert.IsTrue(sut.IsErrorMessageVisible);
+        Assert.IsFalse(sut.IsStatusMessageVisible);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_AfterPullSucceeded_ClearsStaleStatusMessage()
+    {
+        // Arrange
+        var service = new FakeImageManagementService
+        {
+            DefaultImages = [CreateImage("img-1")],
+            PullResultImages = [CreateImage("img-1")],
+        };
+        var sut = new ImagesViewModel(service)
+        {
+            PullReference = "ubuntu:latest",
+        };
+        await sut.RefreshAsync();
+        await sut.PullAsync();
+        var row = sut.Images[0];
+
+        // Act
+        await sut.DeleteAsync(row);
+
+        // Assert
+        Assert.IsNull(sut.StatusMessage);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_ServiceSucceeds_RemovesImageRowAndUpdatesIsEmpty()
+    {
+        // Arrange
+        var service = new FakeImageManagementService
+        {
+            DefaultImages = [CreateImage("img-1")],
+            DeleteResultImages = [],
+        };
+        var sut = new ImagesViewModel(service);
+        await sut.RefreshAsync();
+        var row = sut.Images[0];
+
+        // Act
+        await sut.DeleteAsync(row);
+
+        // Assert
+        Assert.IsEmpty(sut.Images);
+        Assert.IsTrue(sut.IsEmpty);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_ServiceThrows_ErrorMessageIsSetAndRowRemains()
+    {
+        // Arrange
+        var service = new FakeImageManagementService
+        {
+            DefaultImages = [CreateImage("img-1")],
+            DeleteException = new ContainerRuntimeException("delete", 1, "delete failed"),
+        };
+        var sut = new ImagesViewModel(service);
+        await sut.RefreshAsync();
+        var row = sut.Images[0];
+
+        // Act
+        await sut.DeleteAsync(row);
+
+        // Assert
+        Assert.AreEqual("delete failed", sut.ErrorMessage);
+        Assert.HasCount(1, sut.Images);
+        Assert.AreSame(row, sut.Images[0]);
+    }
+}

--- a/tests/WslContainersDesktop.Application.Tests/Fakes/FakeContainerRuntimeClient.cs
+++ b/tests/WslContainersDesktop.Application.Tests/Fakes/FakeContainerRuntimeClient.cs
@@ -12,7 +12,13 @@ internal sealed class FakeContainerRuntimeClient : IContainerRuntimeClient
 {
     public IReadOnlyList<Container> Containers { get; set; } = [];
 
+    public IReadOnlyList<ContainerImage> Images { get; set; } = [];
+
     public Exception? ExceptionToThrow { get; set; }
+
+    public Exception? PullException { get; set; }
+
+    public Exception? DeleteImageException { get; set; }
 
     public IReadOnlyList<string> ContainerLogs { get; set; } = [];
 
@@ -30,6 +36,10 @@ internal sealed class FakeContainerRuntimeClient : IContainerRuntimeClient
 
     public List<string> DeleteCalls { get; } = [];
 
+    public List<string> PullCalls { get; } = [];
+
+    public List<string> DeleteImageCalls { get; } = [];
+
     public List<string> GetContainerLogsCalls { get; } = [];
 
     public List<string> FollowContainerLogsCalls { get; } = [];
@@ -37,6 +47,33 @@ internal sealed class FakeContainerRuntimeClient : IContainerRuntimeClient
     public Task<IReadOnlyList<Container>> ListContainersAsync(CancellationToken cancellationToken = default)
     {
         return Task.FromResult(Containers);
+    }
+
+    public Task<IReadOnlyList<ContainerImage>> ListImagesAsync(CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(Images);
+    }
+
+    public Task PullImageAsync(string reference, CancellationToken cancellationToken = default)
+    {
+        PullCalls.Add(reference);
+        if (PullException is not null)
+        {
+            throw PullException;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteImageAsync(string imageId, CancellationToken cancellationToken = default)
+    {
+        DeleteImageCalls.Add(imageId);
+        if (DeleteImageException is not null)
+        {
+            throw DeleteImageException;
+        }
+
+        return Task.CompletedTask;
     }
 
     public Task StartAsync(string containerId, CancellationToken cancellationToken = default)

--- a/tests/WslContainersDesktop.Application.Tests/Services/ImageManagementServiceTests.cs
+++ b/tests/WslContainersDesktop.Application.Tests/Services/ImageManagementServiceTests.cs
@@ -1,0 +1,99 @@
+using WslContainersDesktop.Application.Exceptions;
+using WslContainersDesktop.Application.Ports;
+using WslContainersDesktop.Application.Services;
+using WslContainersDesktop.Application.Tests.Fakes;
+using WslContainersDesktop.Domain;
+
+namespace WslContainersDesktop.Application.Tests.Services;
+
+[TestClass]
+public sealed class ImageManagementServiceTests
+{
+    private static ContainerImage CreateImage(string id) => new(
+        Id: id,
+        Repository: "ubuntu",
+        Tag: "latest",
+        SizeBytes: 120L,
+        CreatedAt: new DateTimeOffset(2026, 7, 2, 9, 0, 0, TimeSpan.Zero));
+
+    [TestMethod]
+    public async Task GetImagesAsync_ClientReturnsImages_ReturnsSameImages()
+    {
+        // Arrange
+        var expected = new[] { CreateImage("img-1"), CreateImage("img-2") };
+        var client = new FakeContainerRuntimeClient { Images = expected };
+        var sut = new ImageManagementService(client);
+
+        // Act
+        var actual = await sut.GetImagesAsync();
+
+        // Assert
+        CollectionAssert.AreEqual(expected.ToList(), actual.ToList());
+    }
+
+    [TestMethod]
+    public async Task PullAsync_ImageReferenceHasWhitespace_TrimsAndCallsClientPull()
+    {
+        // Arrange
+        var client = new FakeContainerRuntimeClient();
+        var sut = new ImageManagementService(client);
+
+        // Act
+        await sut.PullAsync("  ubuntu:latest  ");
+
+        // Assert
+        CollectionAssert.AreEqual(new[] { "ubuntu:latest" }, client.PullCalls);
+    }
+
+    [TestMethod]
+    public async Task PullAsync_ImageReferenceIsWhitespace_ThrowsArgumentExceptionAndDoesNotCallClient()
+    {
+        // Arrange
+        var client = new FakeContainerRuntimeClient();
+        var sut = new ImageManagementService(client);
+
+        // Act & Assert
+        await Assert.ThrowsExactlyAsync<ArgumentException>(() => sut.PullAsync("   "));
+        Assert.IsEmpty(client.PullCalls);
+    }
+
+    [TestMethod]
+    public async Task PullAsync_ClientThrowsContainerRuntimeException_ExceptionPropagatesUnchanged()
+    {
+        // Arrange
+        var runtimeException = new ContainerRuntimeException("pull", 1, "pull failed");
+        var client = new FakeContainerRuntimeClient { PullException = runtimeException };
+        var sut = new ImageManagementService(client);
+
+        // Act & Assert
+        var actual = await Assert.ThrowsExactlyAsync<ContainerRuntimeException>(() => sut.PullAsync("ubuntu:latest"));
+        Assert.AreSame(runtimeException, actual);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_ImageIdProvided_CallsClientDeleteImage()
+    {
+        // Arrange
+        var client = new FakeContainerRuntimeClient();
+        var sut = new ImageManagementService(client);
+
+        // Act
+        await sut.DeleteAsync("sha256:abc");
+
+        // Assert
+        CollectionAssert.AreEqual(new[] { "sha256:abc" }, client.DeleteImageCalls);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_ClientThrowsContainerRuntimeException_ExceptionPropagatesUnchanged()
+    {
+        // Arrange
+        var runtimeException = new ContainerRuntimeException("delete", 1, "delete failed");
+        var client = new FakeContainerRuntimeClient { DeleteImageException = runtimeException };
+        var sut = new ImageManagementService(client);
+
+        // Act & Assert
+        var actual = await Assert.ThrowsExactlyAsync<ContainerRuntimeException>(() => sut.DeleteAsync("sha256:abc"));
+        Assert.AreSame(runtimeException, actual);
+    }
+}

--- a/tests/WslContainersDesktop.Domain.Tests/ContainerImageTests.cs
+++ b/tests/WslContainersDesktop.Domain.Tests/ContainerImageTests.cs
@@ -1,0 +1,53 @@
+using WslContainersDesktop.Domain;
+
+namespace WslContainersDesktop.Domain.Tests;
+
+[TestClass]
+public sealed class ContainerImageTests
+{
+    [TestMethod]
+    public void DisplayName_TaggedImage_ReturnsRepositoryColonTag()
+    {
+        // Arrange
+        var createdAt = new DateTimeOffset(2026, 7, 2, 9, 0, 0, TimeSpan.Zero);
+        var sut = new ContainerImage(
+            Id: "sha256:abc",
+            Repository: "ubuntu",
+            Tag: "latest",
+            SizeBytes: 120L,
+            CreatedAt: createdAt);
+
+        // Act
+        var displayName = sut.DisplayName;
+
+        // Assert
+        Assert.AreEqual("ubuntu:latest", displayName);
+    }
+
+    [TestMethod]
+    public void DisplayName_UntaggedImage_ReturnsNoneColonNone()
+    {
+        // Arrange
+        var createdAt = new DateTimeOffset(2026, 7, 2, 9, 0, 0, TimeSpan.Zero);
+        var sut = new ContainerImage(
+            Id: "sha256:def",
+            Repository: "<none>",
+            Tag: "<none>",
+            SizeBytes: 120L,
+            CreatedAt: createdAt);
+        var emptyValues = new ContainerImage(
+            Id: "sha256:ghi",
+            Repository: string.Empty,
+            Tag: string.Empty,
+            SizeBytes: 120L,
+            CreatedAt: createdAt);
+
+        // Act
+        var displayName = sut.DisplayName;
+        var emptyValuesDisplayName = emptyValues.DisplayName;
+
+        // Assert
+        Assert.AreEqual("<none>:<none>", displayName);
+        Assert.AreEqual("<none>:<none>", emptyValuesDisplayName);
+    }
+}

--- a/tests/WslContainersDesktop.Infrastructure.Tests/Clients/WslcCliContainerRuntimeClientTests.cs
+++ b/tests/WslContainersDesktop.Infrastructure.Tests/Clients/WslcCliContainerRuntimeClientTests.cs
@@ -109,6 +109,90 @@ public sealed class WslcCliContainerRuntimeClientTests
     }
 
     [TestMethod]
+    public async Task ListImagesAsync_CliReturnsImages_MapsJsonToContainerImages()
+    {
+        // Arrange
+        const string json = """
+            [{
+              "Created": 1782533899,
+              "Id": "sha256:fb3bcc37a9d41b510f9bdb8ec8e66884578aa44b9703f77cef905db46c6557e5",
+              "Repository": "ubuntu",
+              "Size": 120033654,
+              "Tag": "latest"
+            }]
+            """;
+        var runner = new FakeWslcCliRunner { Result = new(0, json, string.Empty) };
+        var sut = new WslcCliContainerRuntimeClient(runner);
+
+        // Act
+        var images = await sut.ListImagesAsync();
+
+        // Assert
+        Assert.HasCount(1, images);
+        Assert.AreEqual("sha256:fb3bcc37a9d41b510f9bdb8ec8e66884578aa44b9703f77cef905db46c6557e5", images[0].Id);
+        Assert.AreEqual("ubuntu", images[0].Repository);
+        Assert.AreEqual("latest", images[0].Tag);
+        Assert.AreEqual(120033654L, images[0].SizeBytes);
+        Assert.AreEqual(DateTimeOffset.FromUnixTimeSeconds(1782533899), images[0].CreatedAt);
+    }
+
+    [TestMethod]
+    public async Task ListImagesAsync_CliArguments_AreImageListJsonNoTrunc()
+    {
+        // Arrange
+        var runner = new FakeWslcCliRunner { Result = new(0, "[]", string.Empty) };
+        var sut = new WslcCliContainerRuntimeClient(runner);
+
+        // Act
+        await sut.ListImagesAsync();
+
+        // Assert
+        CollectionAssert.AreEqual(new[] { "image", "list", "--format", "json", "--no-trunc" }, runner.Calls[0].ToList());
+    }
+
+    [TestMethod]
+    public async Task ListImagesAsync_CliReturnsMalformedJson_ThrowsContainerRuntimeExceptionWithInnerException()
+    {
+        // Arrange
+        var runner = new FakeWslcCliRunner { Result = new(0, "not-json", string.Empty) };
+        var sut = new WslcCliContainerRuntimeClient(runner);
+
+        // Act & Assert
+        var ex = await Assert.ThrowsExactlyAsync<ContainerRuntimeException>(() => sut.ListImagesAsync());
+        Assert.IsNotNull(ex.InnerException);
+    }
+
+    [TestMethod]
+    public async Task PullImageAsync_CliArguments_AreTopLevelPullWithImageReference()
+    {
+        // Arrange
+        var runner = new FakeWslcCliRunner { Result = new(0, string.Empty, string.Empty) };
+        var sut = new WslcCliContainerRuntimeClient(runner);
+
+        // Act
+        await sut.PullImageAsync("ubuntu:latest");
+
+        // Assert
+        CollectionAssert.AreEqual(new[] { "pull", "ubuntu:latest" }, runner.Calls[0].ToList());
+    }
+
+    [TestMethod]
+    public async Task DeleteImageAsync_CliArguments_AreImageRemoveWithoutForce()
+    {
+        // Arrange
+        var runner = new FakeWslcCliRunner { Result = new(0, string.Empty, string.Empty) };
+        var sut = new WslcCliContainerRuntimeClient(runner);
+
+        // Act
+        await sut.DeleteImageAsync("sha256:abc");
+
+        // Assert
+        var arguments = runner.Calls[0].ToList();
+        CollectionAssert.AreEqual(new[] { "image", "remove", "sha256:abc" }, arguments);
+        Assert.IsFalse(arguments.Contains("--force"));
+    }
+
+    [TestMethod]
     public async Task GetContainerLogsAsync_CliReturnsLinesWithTrailingNewline_ReturnsLinesWithoutTrailingPhantomEmpty()
     {
         // Arrange


### PR DESCRIPTION
Adds the Images tab for Issue #6 so users can inspect local WSL Container images, pull new images from a registry, and delete unused images from the desktop UI instead of dropping to `wslc` manually.

## Summary
- Adds `ContainerImage`, image management application ports/services, and `wslc` image list/pull/remove support using the verified CLI contract.
- Adds an Images page with refresh, pull, empty state, image ID/size/created display, delete confirmation, pull progress state, and explicit empty-input validation.
- Wires the Images page into navigation/DI/localized resources and updates current design docs.
- Adds Domain/Application/Infrastructure/Presentation tests for image management behavior and source-level UI criteria.

## Notes
- Image deletion intentionally calls `wslc image remove <image>` without `--force`, so referenced-image failures come from the runtime and are surfaced to the user.
- Pull input is validated in the ViewModel before calling Application services to avoid an empty runtime error banner.

## Validation
- `dotnet test WslContainersDesktop.slnx --no-restore --verbosity quiet`
- WinUI UIA scripted check for Images navigation, pull input, delete confirmation, and AutomationId coverage

Fixes: #6