### PR TITLE
Add volume management

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -20,6 +20,7 @@
 | [`presentation-navigation.md`](presentation-navigation.md) | Presentation層のナビゲーション基盤・ローカライズ基盤・DI構成の現在のスナップショット |
 | [`containers-view.md`](containers-view.md) | コンテナ一覧ViewModel（`ContainersViewModel`）の行操作・ログ表示状態管理の現在のスナップショット |
 | [`images-view.md`](images-view.md) | イメージ一覧ViewModel（`ImagesViewModel`）のpull・削除・状態管理の現在のスナップショット |
+| [`volumes-view.md`](volumes-view.md) | ボリューム一覧ViewModel（`VolumesViewModel`）の作成・削除・使用状況表示の現在のスナップショット |
 | (機能追加に応じて追加) | 個別機能の設計ドキュメントは `docs/design/<feature-name>.md` として追加していく |
 
 ## 更新のタイミング

--- a/docs/design/architecture-overview.md
+++ b/docs/design/architecture-overview.md
@@ -10,18 +10,18 @@
 
 | プロジェクト | 種別 | 内容 |
 |---|---|---|
-| `src/WslContainersDesktop.Domain` | classlib | コンテナ/イメージエンティティ・状態・詳細情報値オブジェクト・状態別操作可否 |
-| `src/WslContainersDesktop.Application` | classlib | コンテナ/イメージ管理ユースケース、execセッション抽象、Inbound/Outboundポート |
+| `src/WslContainersDesktop.Domain` | classlib | コンテナ/イメージ/ボリュームエンティティ・状態・詳細情報値オブジェクト・状態別操作可否 |
+| `src/WslContainersDesktop.Application` | classlib | コンテナ/イメージ/ボリューム管理ユースケース、execセッション抽象、Inbound/Outboundポート |
 | `src/WslContainersDesktop.Infrastructure` | classlib | `wslc` CLIラッパーによるWSL Containers連携 |
-| `src/WslContainersDesktop.App` | WinUI3 MSIXパッケージアプリ（net10.0-windows） | Presentation層。ナビゲーション、ローカライズ、DI構成、コンテナ一覧/詳細/ログ/シェル表示、イメージ一覧/pull/削除を実装済み |
+| `src/WslContainersDesktop.App` | WinUI3 MSIXパッケージアプリ（net10.0-windows） | Presentation層。ナビゲーション、ローカライズ、DI構成、コンテナ一覧/詳細/ログ/シェル表示、イメージ一覧/pull/削除、ボリューム一覧/作成/削除を実装済み |
 | `tests/WslContainersDesktop.Domain.Tests` | MSTest | Domain層の単体テスト |
 | `tests/WslContainersDesktop.Application.Tests` | MSTest | Application層の単体テスト |
 | `tests/WslContainersDesktop.Infrastructure.Tests` | MSTest | Infrastructure層のCLIクライアント/ランナー単体テスト |
-| `tests/WslContainersDesktop.App.Tests` | MSTest | Presentation層（ナビゲーション制御・コンテナ/イメージ一覧ViewModel）の単体テスト |
+| `tests/WslContainersDesktop.App.Tests` | MSTest | Presentation層（ナビゲーション制御・コンテナ/イメージ/ボリューム一覧ViewModel）の単体テスト |
 
 現在の主要な振る舞いは、コンテナ一覧取得、起動・停止・再起動・削除、詳細情報表示、ログの
 スナップショット表示とライブ追跡、稼働中コンテナへの対話的execシェル、イメージ一覧取得、
-イメージpull、イメージ削除である。
+イメージpull、イメージ削除、ボリューム一覧取得、ボリューム作成、ボリューム削除である。
 
 ## 層構成
 
@@ -52,6 +52,8 @@ flowchart TB
   ポートマッピング、環境変数、マウント、ネットワーク、直近の実行状態を保持する。
 - `ContainerImage`はローカルイメージのID、リポジトリ、タグ、サイズ、作成日時を保持し、untaggedを含む
   表示名を`DisplayName`として提供する。
+- `ContainerVolume`はローカルボリュームの名前、ドライバー、作成日時、参照中コンテナ名を保持し、
+  参照有無に応じた削除可否を提供する。
 
 ### Application
 
@@ -72,6 +74,9 @@ flowchart TB
 - `IImageManagementService`はPresentation層向けのInboundポートであり、イメージ一覧取得、pull、
   削除を提供する。pull後の一覧更新や削除確認はPresentation層で扱い、Application層はランタイム操作の
   オーケストレーションと入力検証に留める。
+- `IVolumeManagementService`はPresentation層向けのInboundポートであり、ボリューム一覧取得、作成、
+  削除を提供する。`VolumeManagementService`は一覧取得時にコンテナ詳細のマウント情報から参照中
+  コンテナ名を推定し、削除前にも再評価して参照中ボリュームの削除を拒否する。
 
 ### Infrastructure
 
@@ -86,6 +91,10 @@ flowchart TB
 - イメージ一覧は`wslc image list --format json --no-trunc`のJSONを`ContainerImage`へ変換する。
   pullは`wslc pull <image>`、削除は`wslc image remove <image>`を呼び出す。削除時は強制削除フラグを
   付けず、参照中イメージの拒否は`wslc`のエラーとしてApplication/Presentation層へ伝播する。
+- ボリューム一覧は`wslc volume list --format json`のJSONを基点に、各ボリュームの
+  `wslc volume inspect <name>`から作成日時を補完して`ContainerVolume`へ変換する。作成は
+  `wslc volume create <name>`、削除は`wslc volume remove <name>`を呼び出す。削除時は強制削除フラグを
+  付けず、ランタイム側の拒否はApplication/Presentation層へ伝播する。
 - コンテナ詳細は`wslc container inspect <container-id>`のJSON配列を`ContainerDetail`へ変換する。
 - execシェルは`wslc container exec -i <container-id> /bin/sh`を対話プロセスとして起動する。
   標準入力はLFでコマンドを終端してフラッシュし、標準出力/標準エラーは行ではなくチャンク単位で
@@ -108,6 +117,7 @@ flowchart TB
 - コンテナ一覧ViewModelの状態管理とログ表示の詳細は
   [`docs/design/containers-view.md`](containers-view.md) を参照。
 - イメージ一覧ViewModelの状態管理の詳細は [`docs/design/images-view.md`](images-view.md) を参照。
+- ボリューム一覧ViewModelの状態管理の詳細は [`docs/design/volumes-view.md`](volumes-view.md) を参照。
 
 ## テスト戦略との対応
 

--- a/docs/design/presentation-navigation.md
+++ b/docs/design/presentation-navigation.md
@@ -15,7 +15,7 @@ UI文字列はすべて `.resw` リソースに外出しされ、コードやXAM
 
 | 型 | 場所 | 役割 |
 |---|---|---|
-| `NavigationPageKey` | `Navigation/NavigationPageKey.cs` | ページを表す `enum`（`Containers`, `Images`, `Settings`）。string/Tagベースの遷移は使わない。 |
+| `NavigationPageKey` | `Navigation/NavigationPageKey.cs` | ページを表す `enum`（`Containers`, `Images`, `Volumes`, `Settings`）。string/Tagベースの遷移は使わない。 |
 | `NavigationPageKeyExtensions.EnsureDefined` | `Navigation/NavigationPageKeyExtensions.cs` | `NavigationPageKey` が定義済みの値であることを検証する拡張メソッド。未定義値なら `ArgumentOutOfRangeException` を送出する。`NavigationPageRegistry`・`NavigationViewModel` の双方から共通利用する。 |
 | `NavigationPageRegistry` | `Navigation/NavigationPageRegistry.cs` | `NavigationPageKey → Page派生型` のマッピングを一元管理する、XAML非依存の素のC#クラス。 |
 | `NavigationViewModel` | `ViewModels/NavigationViewModel.cs` | 現在表示中のページキー（`CurrentPageKey`、setterはprivate）を保持するObservableObject。`NavigateToCommand`でのみ変更できる。 |
@@ -43,7 +43,8 @@ UI文字列はすべて `.resw` リソースに外出しされ、コードやXAM
 Composition Rootは`App.xaml.cs`に置く。`Microsoft.Extensions.DependencyInjection`で
 `IContainerRuntimeClient`→`WslcCliContainerRuntimeClient`、
 `IContainerManagementService`→`ContainerManagementService`、
-`IImageManagementService`→`ImageManagementService`、`IWslcCliRunner`→`WslcCliRunner`、
+`IImageManagementService`→`ImageManagementService`、
+`IVolumeManagementService`→`VolumeManagementService`、`IWslcCliRunner`→`WslcCliRunner`、
 `IUiDispatcher`→`DispatcherQueueUiDispatcher`を登録する。
 
 トップレベルページは`Frame.Navigate(Type)`から生成されるためパラメーターレスコンストラクタを持つ。

--- a/docs/design/volumes-view.md
+++ b/docs/design/volumes-view.md
@@ -1,0 +1,52 @@
+# Presentation層: ボリューム一覧ViewModelの状態管理
+
+> このドキュメントは現時点のスナップショットです。経緯・検討過程は書きません。
+
+## 概要
+
+`VolumesViewModel`（`ViewModels/VolumesViewModel.cs`）は、ローカルボリューム一覧の取得、新規作成、
+不要ボリュームの削除を担うViewModel。Application層の`IVolumeManagementService`にのみ依存し、
+`wslc` CLIの具体的な呼び出し方法には依存しない。
+
+## 一覧UI
+
+- `VolumesPage`はローカルボリューム一覧を表示する。各行は`VolumeRowViewModel`で、ボリューム名、
+  ドライバー、作成日時、使用状況、削除操作を表示する。
+- 使用状況は、参照中コンテナ名がある場合はコンテナ名をカンマ区切りで表示し、参照がない場合は
+  `Unused`として表示する。
+- 参照中ボリュームの削除ボタンは無効化する。
+- `Volumes`が空の場合は空状態テキストを表示する。
+
+## 更新とエラー表示
+
+- `RefreshAsync`は`IVolumeManagementService.GetVolumesAsync`で最新状態を取得し、成功時に`Volumes`を
+  全件置き換える。
+- 更新失敗時は既存の一覧を保持し、`ErrorMessage`に例外メッセージを設定する。
+- 新しい操作を開始する際は古い成功メッセージをクリアし、エラーと成功メッセージが矛盾して同時表示されない
+  ようにする。
+
+## 作成操作
+
+- `NewVolumeName`はユーザーが入力したボリューム名を保持する。`VolumesPage`のTextBoxは
+  `Mode=TwoWay, UpdateSourceTrigger=PropertyChanged`でバインドする。
+- `NewVolumeName`が空または空白だけの場合、`CreateAsync`はApplication層を呼び出さず、入力必須エラーを
+  `ErrorMessage`として表示する。
+- `CreateAsync`は開始時に`IsCreating`を`true`にし、入力欄とCreateボタンを無効化し、
+  `ProgressRing`を表示する。
+- 作成成功後は`NewVolumeName`を空にし、成功メッセージを表示してから一覧を再取得する。
+- 作成失敗時は入力値と既存一覧を保持し、`ErrorMessage`に失敗理由を表示する。
+
+## 削除操作
+
+- `VolumesPage`の削除ボタンは、`ContentDialog`で確認を取ってから`VolumesViewModel.DeleteCommand`を実行する。
+- `DeleteAsync`は対象行の`IsBusy`を`true`にして二重操作を防ぎ、成功時はライブの`Volumes`から対象行を
+  取り除く。
+- `VolumeRowViewModel`が参照中として保持しているボリュームに対してはApplication層を呼び出さず、
+  参照中コンテナ名を含むエラーを表示する。
+- 削除直前のApplication層再評価で参照中と判定された場合は`VolumeInUseException`を捕捉し、
+  例外が保持する参照中コンテナ名をエラーとして表示する。
+- 削除は`wslc volume remove <name>`に委譲され、強制削除フラグは付けない。ランタイム不調や
+  Application層で推定できない参照中ボリュームの拒否は例外としてPresentation層へ伝播し、
+  `ErrorMessage`に表示する。
+- 削除失敗時は対象行を一覧に残し、`IsBusy`を解除する。
+

--- a/src/WslContainersDesktop.App/App.xaml.cs
+++ b/src/WslContainersDesktop.App/App.xaml.cs
@@ -50,12 +50,14 @@ public partial class App : Application
         services.AddSingleton<IContainerRuntimeClient, WslcCliContainerRuntimeClient>();
         services.AddSingleton<IContainerManagementService, ContainerManagementService>();
         services.AddSingleton<IImageManagementService, ImageManagementService>();
+        services.AddSingleton<IVolumeManagementService, VolumeManagementService>();
         services.AddSingleton<IUiDispatcher>(_ => new DispatcherQueueUiDispatcher(DispatcherQueue.GetForCurrentThread()));
 
         // トップレベルページのViewModelはNavigationViewModelと同様、アプリケーション
         // ライフタイムで1インスタンスとする。
         services.AddSingleton<ContainersViewModel>();
         services.AddSingleton<ImagesViewModel>();
+        services.AddSingleton<VolumesViewModel>();
 
         return services.BuildServiceProvider();
     }

--- a/src/WslContainersDesktop.App/MainWindow.xaml
+++ b/src/WslContainersDesktop.App/MainWindow.xaml
@@ -53,6 +53,14 @@
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
                 <NavigationViewItem
+                    x:Name="NavItemVolumes"
+                    x:Uid="NavItemVolumes"
+                    AutomationProperties.AutomationId="NavItemVolumes">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="&#xE8B7;" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+                <NavigationViewItem
                     x:Name="NavItemSettings"
                     x:Uid="NavItemSettings"
                     AutomationProperties.AutomationId="NavItemSettings">

--- a/src/WslContainersDesktop.App/MainWindow.xaml.cs
+++ b/src/WslContainersDesktop.App/MainWindow.xaml.cs
@@ -33,6 +33,7 @@ public sealed partial class MainWindow : Window
         {
             [NavItemContainers] = NavigationPageKey.Containers,
             [NavItemImages] = NavigationPageKey.Images,
+            [NavItemVolumes] = NavigationPageKey.Volumes,
             [NavItemSettings] = NavigationPageKey.Settings,
         };
 

--- a/src/WslContainersDesktop.App/Navigation/NavigationPageKey.cs
+++ b/src/WslContainersDesktop.App/Navigation/NavigationPageKey.cs
@@ -14,6 +14,9 @@ public enum NavigationPageKey
     /// <summary>コンテナーイメージ一覧ページ。</summary>
     Images,
 
+    /// <summary>コンテナーボリューム一覧ページ。</summary>
+    Volumes,
+
     /// <summary>設定ページ。</summary>
     Settings,
 }

--- a/src/WslContainersDesktop.App/Navigation/NavigationPageRegistry.cs
+++ b/src/WslContainersDesktop.App/Navigation/NavigationPageRegistry.cs
@@ -24,6 +24,7 @@ public static class NavigationPageRegistry
         {
             NavigationPageKey.Containers => typeof(ContainersPage),
             NavigationPageKey.Images => typeof(ImagesPage),
+            NavigationPageKey.Volumes => typeof(VolumesPage),
             NavigationPageKey.Settings => typeof(SettingsPage),
             _ => throw new ArgumentOutOfRangeException(nameof(pageKey), pageKey, "未定義のNavigationPageKeyです。"),
         };

--- a/src/WslContainersDesktop.App/Pages/VolumesPage.xaml
+++ b/src/WslContainersDesktop.App/Pages/VolumesPage.xaml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Page
+    x:Class="WslContainersDesktop_App.Pages.VolumesPage"
+    x:Name="RootPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:conv="using:WslContainersDesktop_App.Converters"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:WslContainersDesktop_App.Pages"
+    xmlns:vm="using:WslContainersDesktop_App.ViewModels"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Page.Resources>
+        <conv:AutomationIdConverter x:Key="AutomationIdConverter" />
+    </Page.Resources>
+
+    <Grid Padding="24,16,24,16" RowSpacing="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <Border
+            Grid.Row="0"
+            Padding="16"
+            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+            BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+            BorderThickness="{ThemeResource WslContainersSurfaceBorderThickness}"
+            CornerRadius="{StaticResource OverlayCornerRadius}">
+            <Grid ColumnSpacing="16">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0">
+                    <TextBlock x:Name="TxtVolumesPageTitle" x:Uid="VolumesPageTitle" Style="{StaticResource TitleTextBlockStyle}" />
+                    <TextBlock x:Name="TxtVolumesPageDescription" x:Uid="VolumesPageDescription" />
+                </StackPanel>
+                <Button
+                    x:Name="BtnRefreshVolumes"
+                    x:Uid="BtnRefreshVolumes"
+                    Grid.Column="1"
+                    VerticalAlignment="Bottom"
+                    AutomationProperties.AutomationId="BtnRefreshVolumes"
+                    Command="{x:Bind ViewModel.RefreshCommand}" />
+            </Grid>
+        </Border>
+
+        <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="8">
+            <TextBox
+                x:Name="TxtNewVolumeName"
+                x:Uid="TxtNewVolumeName"
+                Width="320"
+                AutomationProperties.AutomationId="TxtNewVolumeName"
+                IsEnabled="{x:Bind ViewModel.CanCreate, Mode=OneWay}"
+                Text="{x:Bind ViewModel.NewVolumeName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+            <Button
+                x:Name="BtnCreateVolume"
+                x:Uid="BtnCreateVolume"
+                VerticalAlignment="Bottom"
+                AutomationProperties.AutomationId="BtnCreateVolume"
+                Command="{x:Bind ViewModel.CreateCommand}"
+                IsEnabled="{x:Bind ViewModel.CanCreate, Mode=OneWay}" />
+            <ProgressRing
+                x:Name="PrgCreateVolume"
+                Width="24"
+                Height="24"
+                AutomationProperties.AutomationId="PrgCreateVolume"
+                IsActive="{x:Bind ViewModel.IsCreating, Mode=OneWay}"
+                Visibility="{x:Bind ToVisibleWhenTrue(ViewModel.IsCreating), Mode=OneWay}" />
+        </StackPanel>
+
+        <StackPanel Grid.Row="2" Spacing="8">
+            <InfoBar
+                x:Name="InfoBarVolumeError"
+                Severity="Error"
+                IsClosable="False"
+                IsOpen="{x:Bind ViewModel.IsErrorMessageVisible, Mode=OneWay}"
+                Message="{x:Bind ViewModel.ErrorMessage, Mode=OneWay}" />
+            <InfoBar
+                x:Name="InfoBarVolumeStatus"
+                Severity="Success"
+                IsClosable="False"
+                IsOpen="{x:Bind ViewModel.IsStatusMessageVisible, Mode=OneWay}"
+                Message="{x:Bind ViewModel.StatusMessage, Mode=OneWay}" />
+        </StackPanel>
+
+        <Grid Grid.Row="3">
+            <Border
+                Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                BorderThickness="{ThemeResource WslContainersSurfaceBorderThickness}"
+                CornerRadius="{StaticResource OverlayCornerRadius}"
+                Visibility="{x:Bind ToVisibleWhenFalse(ViewModel.IsEmpty), Mode=OneWay}">
+                <Grid RowSpacing="4">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+
+                    <Grid Grid.Row="0" Padding="12,8" ColumnSpacing="12">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="220" />
+                            <ColumnDefinition Width="120" />
+                            <ColumnDefinition Width="180" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock x:Name="TxtVolumeColumnName" x:Uid="TxtVolumeColumnName" Grid.Column="0" FontWeight="SemiBold" />
+                        <TextBlock x:Name="TxtVolumeColumnDriver" x:Uid="TxtVolumeColumnDriver" Grid.Column="1" FontWeight="SemiBold" />
+                        <TextBlock x:Name="TxtVolumeColumnCreatedAt" x:Uid="TxtVolumeColumnCreatedAt" Grid.Column="2" FontWeight="SemiBold" />
+                        <TextBlock x:Name="TxtVolumeColumnUsage" x:Uid="TxtVolumeColumnUsage" Grid.Column="3" FontWeight="SemiBold" />
+                    </Grid>
+
+                    <ListView
+                        x:Name="LstVolumes"
+                        Grid.Row="1"
+                        AutomationProperties.AutomationId="LstVolumes"
+                        ItemsSource="{x:Bind ViewModel.Volumes, Mode=OneWay}"
+                        SelectionMode="None">
+                        <ListView.ItemTemplate>
+                            <DataTemplate x:DataType="vm:VolumeRowViewModel">
+                                <Grid Padding="8" ColumnSpacing="12">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="220" />
+                                        <ColumnDefinition Width="120" />
+                                        <ColumnDefinition Width="180" />
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" VerticalAlignment="Center" Text="{x:Bind Name}" />
+                                    <TextBlock Grid.Column="1" VerticalAlignment="Center" Text="{x:Bind Driver}" />
+                                    <TextBlock Grid.Column="2" VerticalAlignment="Center" Text="{x:Bind CreatedAt}" />
+                                    <TextBlock Grid.Column="3" VerticalAlignment="Center" Text="{x:Bind UsageText}" />
+                                    <Button
+                                        x:Name="BtnDeleteVolume"
+                                        x:Uid="BtnDeleteVolume"
+                                        Grid.Column="4"
+                                        VerticalAlignment="Center"
+                                        AutomationProperties.AutomationId="{x:Bind Name, Mode=OneWay, Converter={StaticResource AutomationIdConverter}, ConverterParameter=BtnDeleteVolume}"
+                                        CommandParameter="{x:Bind}"
+                                        Click="BtnDeleteVolume_Click"
+                                        IsEnabled="{x:Bind CanDelete, Mode=OneWay}" />
+                                </Grid>
+                            </DataTemplate>
+                        </ListView.ItemTemplate>
+                    </ListView>
+                </Grid>
+            </Border>
+
+            <TextBlock
+                x:Name="TxtVolumesEmptyState"
+                x:Uid="TxtVolumesEmptyState"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                Visibility="{x:Bind ToVisibleWhenTrue(ViewModel.IsEmpty), Mode=OneWay}" />
+        </Grid>
+    </Grid>
+</Page>

--- a/src/WslContainersDesktop.App/Pages/VolumesPage.xaml.cs
+++ b/src/WslContainersDesktop.App/Pages/VolumesPage.xaml.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using WslContainersDesktop_App.ViewModels;
+using Windows.ApplicationModel.Resources;
+
+namespace WslContainersDesktop_App.Pages;
+
+/// <summary>
+/// コンテナーボリューム一覧ページ。
+/// </summary>
+public sealed partial class VolumesPage : Page
+{
+    private readonly ResourceLoader _resourceLoader = new();
+
+    /// <summary>
+    /// <see cref="VolumesPage"/> の新しいインスタンスを初期化する。
+    /// </summary>
+    public VolumesPage()
+    {
+        ViewModel = ((App)Application.Current).Services.GetRequiredService<VolumesViewModel>();
+
+        InitializeComponent();
+
+        Loaded += VolumesPage_Loaded;
+    }
+
+    /// <summary>
+    /// ページのViewModel。
+    /// </summary>
+    public VolumesViewModel ViewModel { get; }
+
+    private async void VolumesPage_Loaded(object sender, RoutedEventArgs e)
+    {
+        await ViewModel.RefreshCommand.ExecuteAsync(null);
+    }
+
+    private async void BtnDeleteVolume_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button { CommandParameter: VolumeRowViewModel row })
+        {
+            return;
+        }
+
+        var dialog = new ContentDialog
+        {
+            XamlRoot = XamlRoot,
+            Title = _resourceLoader.GetString("DeleteVolumeConfirmationDialog_Title"),
+            Content = string.Format(_resourceLoader.GetString("DeleteVolumeConfirmationDialog_Message"), row.Name),
+            PrimaryButtonText = _resourceLoader.GetString("DeleteVolumeConfirmationDialog_PrimaryButtonText"),
+            CloseButtonText = _resourceLoader.GetString("DeleteVolumeConfirmationDialog_CloseButtonText"),
+            DefaultButton = ContentDialogButton.Close,
+        };
+
+        var result = await dialog.ShowAsync();
+        if (result == ContentDialogResult.Primary)
+        {
+            await ViewModel.DeleteCommand.ExecuteAsync(row);
+        }
+    }
+
+    /// <summary>
+    /// x:Bind用のbool→Visibility変換関数。値がtrueのとき表示する。
+    /// </summary>
+    /// <param name="value">変換元の値。</param>
+    /// <returns>対応する <see cref="Visibility"/>。</returns>
+    public Visibility ToVisibleWhenTrue(bool value) => value ? Visibility.Visible : Visibility.Collapsed;
+
+    /// <summary>
+    /// x:Bind用のbool→Visibility変換関数。値がfalseのとき表示する。
+    /// </summary>
+    /// <param name="value">変換元の値。</param>
+    /// <returns>対応する <see cref="Visibility"/>。</returns>
+    public Visibility ToVisibleWhenFalse(bool value) => value ? Visibility.Collapsed : Visibility.Visible;
+}

--- a/src/WslContainersDesktop.App/Strings/en-US/Resources.resw
+++ b/src/WslContainersDesktop.App/Strings/en-US/Resources.resw
@@ -129,6 +129,9 @@
   <data name="NavItemImages.Content" xml:space="preserve">
     <value>Images</value>
   </data>
+  <data name="NavItemVolumes.Content" xml:space="preserve">
+    <value>Volumes</value>
+  </data>
   <data name="NavItemSettings.Content" xml:space="preserve">
     <value>Settings</value>
   </data>
@@ -261,6 +264,39 @@
   <data name="TxtImagesEmptyState.Text" xml:space="preserve">
     <value>No images.</value>
   </data>
+  <data name="VolumesPageTitle.Text" xml:space="preserve">
+    <value>Volumes</value>
+  </data>
+  <data name="VolumesPageDescription.Text" xml:space="preserve">
+    <value>Create and remove container volumes.</value>
+  </data>
+  <data name="BtnRefreshVolumes.Content" xml:space="preserve">
+    <value>Refresh</value>
+  </data>
+  <data name="TxtNewVolumeName.Header" xml:space="preserve">
+    <value>Volume name</value>
+  </data>
+  <data name="BtnCreateVolume.Content" xml:space="preserve">
+    <value>Create</value>
+  </data>
+  <data name="TxtVolumeColumnName.Text" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="TxtVolumeColumnDriver.Text" xml:space="preserve">
+    <value>Driver</value>
+  </data>
+  <data name="TxtVolumeColumnCreatedAt.Text" xml:space="preserve">
+    <value>Created</value>
+  </data>
+  <data name="TxtVolumeColumnUsage.Text" xml:space="preserve">
+    <value>Usage</value>
+  </data>
+  <data name="BtnDeleteVolume.Content" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="TxtVolumesEmptyState.Text" xml:space="preserve">
+    <value>No volumes.</value>
+  </data>
   <data name="ContainerState_Running" xml:space="preserve">
     <value>Running</value>
   </data>
@@ -301,6 +337,18 @@
     <value>Delete</value>
   </data>
   <data name="DeleteImageConfirmationDialog_CloseButtonText" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="DeleteVolumeConfirmationDialog_Title" xml:space="preserve">
+    <value>Delete volume</value>
+  </data>
+  <data name="DeleteVolumeConfirmationDialog_Message" xml:space="preserve">
+    <value>Are you sure you want to delete volume '{0}'? This action cannot be undone.</value>
+  </data>
+  <data name="DeleteVolumeConfirmationDialog_PrimaryButtonText" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="DeleteVolumeConfirmationDialog_CloseButtonText" xml:space="preserve">
     <value>Cancel</value>
   </data>
   <data name="SettingsPageTitle.Text" xml:space="preserve">

--- a/src/WslContainersDesktop.App/ViewModels/VolumeRowViewModel.cs
+++ b/src/WslContainersDesktop.App/ViewModels/VolumeRowViewModel.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using WslContainersDesktop.Domain;
+
+namespace WslContainersDesktop_App.ViewModels;
+
+/// <summary>
+/// XAMLバインディング用に <see cref="ContainerVolume"/> をラップする行ViewModel。
+/// </summary>
+public sealed partial class VolumeRowViewModel : ObservableObject
+{
+    /// <summary>
+    /// <see cref="VolumeRowViewModel"/> の新しいインスタンスを初期化する。
+    /// </summary>
+    /// <param name="volume">初期状態の元となるコンテナーボリューム。</param>
+    public VolumeRowViewModel(ContainerVolume volume)
+    {
+        Name = volume.Name;
+        Driver = volume.Driver;
+        CreatedAt = volume.CreatedAt;
+        ReferencingContainerNames = volume.ReferencingContainerNames;
+    }
+
+    /// <summary>
+    /// ボリューム名。
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// ボリュームドライバー名。
+    /// </summary>
+    public string Driver { get; }
+
+    /// <summary>
+    /// 作成日時。
+    /// </summary>
+    public DateTimeOffset CreatedAt { get; }
+
+    /// <summary>
+    /// このボリュームを参照しているコンテナ名の一覧。
+    /// </summary>
+    public IReadOnlyList<string> ReferencingContainerNames { get; }
+
+    /// <summary>
+    /// ボリュームがいずれかのコンテナから参照されているかどうか。
+    /// </summary>
+    public bool IsInUse => ReferencingContainerNames.Count > 0;
+
+    /// <summary>
+    /// ボリュームを削除できるかどうか。
+    /// </summary>
+    public bool CanDelete => !IsInUse && !IsBusy;
+
+    /// <summary>
+    /// 参照しているコンテナ名の表示用テキスト。
+    /// </summary>
+    public string UsageText => IsInUse ? string.Join(", ", ReferencingContainerNames) : "Unused";
+
+    /// <summary>
+    /// この行に対する操作が進行中かどうか。
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanDelete))]
+    public partial bool IsBusy { get; set; }
+}

--- a/src/WslContainersDesktop.App/ViewModels/VolumesViewModel.cs
+++ b/src/WslContainersDesktop.App/ViewModels/VolumesViewModel.cs
@@ -1,0 +1,201 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using WslContainersDesktop.Application.Exceptions;
+using WslContainersDesktop.Application.Ports;
+using WslContainersDesktop.Domain;
+
+namespace WslContainersDesktop_App.ViewModels;
+
+/// <summary>
+/// コンテナーボリューム一覧の表示・操作を管理するViewModel。
+/// </summary>
+public sealed partial class VolumesViewModel(IVolumeManagementService volumeManagementService) : ObservableObject
+{
+    private const string CreatingStatusMessage = "Creating volume...";
+    private const string CreateCompletedStatusMessage = "Volume created.";
+    private const string EmptyVolumeNameMessage = "Volume name is required.";
+
+    /// <summary>
+    /// 現在表示中のコンテナーボリューム一覧。
+    /// </summary>
+    public ObservableCollection<VolumeRowViewModel> Volumes { get; } = [];
+
+    /// <summary>
+    /// 作成する新しいボリューム名。
+    /// </summary>
+    [ObservableProperty]
+    public partial string NewVolumeName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 直近の操作で発生したエラーメッセージ。エラーがない場合は <see langword="null"/>。
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsErrorMessageVisible))]
+    public partial string? ErrorMessage { get; private set; }
+
+    /// <summary>
+    /// 直近の成功操作を表すステータスメッセージ。
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsStatusMessageVisible))]
+    public partial string? StatusMessage { get; private set; }
+
+    /// <summary>
+    /// エラーメッセージを表示するかどうか。
+    /// </summary>
+    public bool IsErrorMessageVisible => !string.IsNullOrEmpty(ErrorMessage);
+
+    /// <summary>
+    /// 成功または進行中ステータスメッセージを表示するかどうか。
+    /// </summary>
+    public bool IsStatusMessageVisible => !string.IsNullOrEmpty(StatusMessage);
+
+    /// <summary>
+    /// ボリューム作成操作が進行中かどうか。
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanCreate))]
+    public partial bool IsCreating { get; private set; }
+
+    /// <summary>
+    /// ボリューム作成操作を開始できるかどうか。
+    /// </summary>
+    public bool CanCreate => !IsCreating;
+
+    /// <summary>
+    /// <see cref="Volumes"/> が空かどうか。
+    /// </summary>
+    [ObservableProperty]
+    public partial bool IsEmpty { get; private set; } = true;
+
+    /// <summary>
+    /// コンテナーボリューム一覧を手動で再取得する。
+    /// </summary>
+    [RelayCommand]
+    public async Task RefreshAsync()
+    {
+        StatusMessage = null;
+        try
+        {
+            var volumes = await volumeManagementService.GetVolumesAsync();
+            ReplaceVolumes(volumes);
+            ErrorMessage = null;
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = ex.Message;
+            StatusMessage = null;
+        }
+    }
+
+    /// <summary>
+    /// 入力されたボリューム名で新しいボリュームを作成し、成功後に一覧を再取得する。
+    /// </summary>
+    [RelayCommand]
+    public async Task CreateAsync()
+    {
+        var volumeName = NewVolumeName.Trim();
+        StatusMessage = null;
+        ErrorMessage = null;
+        if (volumeName.Length == 0)
+        {
+            ErrorMessage = EmptyVolumeNameMessage;
+            return;
+        }
+
+        StatusMessage = CreatingStatusMessage;
+        IsCreating = true;
+        try
+        {
+            var created = await volumeManagementService.CreateAsync(volumeName);
+            NewVolumeName = string.Empty;
+            StatusMessage = CreateCompletedStatusMessage;
+            ErrorMessage = null;
+            await RefreshVolumesAfterCreateAsync(created);
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = ex.Message;
+            StatusMessage = null;
+        }
+        finally
+        {
+            IsCreating = false;
+        }
+    }
+
+    /// <summary>
+    /// 指定したコンテナーボリュームを削除する。
+    /// </summary>
+    /// <param name="row">対象の行。</param>
+    [RelayCommand]
+    public async Task DeleteAsync(VolumeRowViewModel row)
+    {
+        StatusMessage = null;
+        if (row.IsInUse)
+        {
+            ErrorMessage = FormatInUseMessage(row.Name, row.ReferencingContainerNames);
+            return;
+        }
+
+        row.IsBusy = true;
+        try
+        {
+            await volumeManagementService.DeleteAsync(row.Name);
+            var liveRow = Volumes.FirstOrDefault(volume => volume.Name == row.Name);
+            if (liveRow is not null)
+            {
+                liveRow.IsBusy = false;
+                Volumes.Remove(liveRow);
+            }
+            else
+            {
+                row.IsBusy = false;
+            }
+
+            IsEmpty = Volumes.Count == 0;
+            ErrorMessage = null;
+        }
+        catch (VolumeInUseException ex)
+        {
+            row.IsBusy = false;
+            ErrorMessage = FormatInUseMessage(ex.VolumeName, ex.ReferencingContainerNames);
+        }
+        catch (Exception ex)
+        {
+            row.IsBusy = false;
+            ErrorMessage = ex.Message;
+        }
+    }
+
+    private async Task RefreshVolumesAfterCreateAsync(ContainerVolume created)
+    {
+        try
+        {
+            var volumes = await volumeManagementService.GetVolumesAsync();
+            ReplaceVolumes(volumes.Count == 0 ? [created] : volumes);
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = ex.Message;
+            StatusMessage = null;
+        }
+    }
+
+    private void ReplaceVolumes(IReadOnlyList<ContainerVolume> volumes)
+    {
+        Volumes.Clear();
+        foreach (var volume in volumes)
+        {
+            Volumes.Add(new VolumeRowViewModel(volume));
+        }
+
+        IsEmpty = Volumes.Count == 0;
+    }
+
+    private static string FormatInUseMessage(string volumeName, IReadOnlyList<string> referencingContainerNames)
+    {
+        return $"Volume '{volumeName}' is in use by: {string.Join(", ", referencingContainerNames)}";
+    }
+}

--- a/src/WslContainersDesktop.Application/Exceptions/VolumeInUseException.cs
+++ b/src/WslContainersDesktop.Application/Exceptions/VolumeInUseException.cs
@@ -1,0 +1,29 @@
+namespace WslContainersDesktop.Application.Exceptions;
+
+/// <summary>
+/// 参照中のコンテナーが存在するボリュームに対して削除が要求されたことを表す例外。
+/// </summary>
+public sealed class VolumeInUseException : ContainerManagementException
+{
+    /// <summary>
+    /// <see cref="VolumeInUseException"/> の新しいインスタンスを初期化する。
+    /// </summary>
+    /// <param name="volumeName">削除対象のボリューム名。</param>
+    /// <param name="referencingContainerNames">対象ボリュームを参照しているコンテナ名。</param>
+    public VolumeInUseException(string volumeName, IReadOnlyList<string> referencingContainerNames)
+        : base($"Volume '{volumeName}' is in use by: {string.Join(", ", referencingContainerNames)}")
+    {
+        VolumeName = volumeName;
+        ReferencingContainerNames = referencingContainerNames;
+    }
+
+    /// <summary>
+    /// 削除対象のボリューム名。
+    /// </summary>
+    public string VolumeName { get; }
+
+    /// <summary>
+    /// 対象ボリュームを参照しているコンテナ名。
+    /// </summary>
+    public IReadOnlyList<string> ReferencingContainerNames { get; }
+}

--- a/src/WslContainersDesktop.Application/Ports/IContainerRuntimeClient.cs
+++ b/src/WslContainersDesktop.Application/Ports/IContainerRuntimeClient.cs
@@ -35,6 +35,26 @@ public interface IContainerRuntimeClient
     Task DeleteImageAsync(string imageId, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// 現在存在するすべてのコンテナーボリュームを取得する。
+    /// </summary>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    Task<IReadOnlyList<ContainerVolume>> ListVolumesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 指定した名前のコンテナーボリュームを作成する。
+    /// </summary>
+    /// <param name="name">作成するボリューム名。</param>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    Task CreateVolumeAsync(string name, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 指定したコンテナーボリュームを削除する。
+    /// </summary>
+    /// <param name="name">削除するボリューム名。</param>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    Task DeleteVolumeAsync(string name, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// 指定したコンテナを起動する。
     /// </summary>
     /// <param name="containerId">対象コンテナのID。</param>

--- a/src/WslContainersDesktop.Application/Ports/IVolumeManagementService.cs
+++ b/src/WslContainersDesktop.Application/Ports/IVolumeManagementService.cs
@@ -1,0 +1,30 @@
+using WslContainersDesktop.Domain;
+
+namespace WslContainersDesktop.Application.Ports;
+
+/// <summary>
+/// コンテナーボリューム管理ユースケースを提供するインバウンドポート。
+/// </summary>
+public interface IVolumeManagementService
+{
+    /// <summary>
+    /// 現在存在するすべてのコンテナーボリュームを取得する。
+    /// </summary>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    Task<IReadOnlyList<ContainerVolume>> GetVolumesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 指定した名前のコンテナーボリュームを作成する。
+    /// </summary>
+    /// <param name="name">作成するボリューム名。</param>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    /// <returns>作成したボリューム。</returns>
+    Task<ContainerVolume> CreateAsync(string name, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 指定したコンテナーボリュームを削除する。
+    /// </summary>
+    /// <param name="name">削除するボリューム名。</param>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    Task DeleteAsync(string name, CancellationToken cancellationToken = default);
+}

--- a/src/WslContainersDesktop.Application/Services/VolumeManagementService.cs
+++ b/src/WslContainersDesktop.Application/Services/VolumeManagementService.cs
@@ -1,0 +1,146 @@
+using WslContainersDesktop.Application.Exceptions;
+using WslContainersDesktop.Application.Ports;
+using WslContainersDesktop.Domain;
+
+namespace WslContainersDesktop.Application.Services;
+
+/// <summary>
+/// <see cref="IVolumeManagementService"/> の実装。
+/// </summary>
+public sealed class VolumeManagementService(IContainerRuntimeClient runtimeClient) : IVolumeManagementService
+{
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<ContainerVolume>> GetVolumesAsync(CancellationToken cancellationToken = default)
+    {
+        var volumes = await runtimeClient.ListVolumesAsync(cancellationToken);
+        if (volumes.Count == 0)
+        {
+            return volumes;
+        }
+
+        var referencesByVolume = await GetReferencesByVolumeAsync(volumes.Select(volume => volume.Name), cancellationToken);
+        return volumes
+            .Select(volume => volume with
+            {
+                ReferencingContainerNames = referencesByVolume.TryGetValue(volume.Name, out var references)
+                    ? references
+                    : [],
+            })
+            .ToList();
+    }
+
+    /// <inheritdoc />
+    public async Task<ContainerVolume> CreateAsync(string name, CancellationToken cancellationToken = default)
+    {
+        var trimmed = ValidateNotWhiteSpace(name, nameof(name));
+        await runtimeClient.CreateVolumeAsync(trimmed, cancellationToken);
+
+        var volumes = await GetVolumesAsync(cancellationToken);
+        return volumes.FirstOrDefault(volume => volume.Name == trimmed)
+            ?? new ContainerVolume(trimmed, string.Empty, DateTimeOffset.MinValue, []);
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteAsync(string name, CancellationToken cancellationToken = default)
+    {
+        var trimmed = ValidateNotWhiteSpace(name, nameof(name));
+        var references = await GetReferencesForVolumeAsync(trimmed, cancellationToken);
+        if (references.Count > 0)
+        {
+            throw new VolumeInUseException(trimmed, references);
+        }
+
+        await runtimeClient.DeleteVolumeAsync(trimmed, cancellationToken);
+    }
+
+    private async Task<IReadOnlyList<string>> GetReferencesForVolumeAsync(string volumeName, CancellationToken cancellationToken)
+    {
+        var referencesByVolume = await GetReferencesByVolumeAsync([volumeName], cancellationToken);
+        return referencesByVolume.TryGetValue(volumeName, out var references) ? references : [];
+    }
+
+    private async Task<Dictionary<string, IReadOnlyList<string>>> GetReferencesByVolumeAsync(
+        IEnumerable<string> volumeNames,
+        CancellationToken cancellationToken)
+    {
+        var volumeNameList = volumeNames
+            .Where(name => name.Length > 0)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+        var referenceSets = CreateReferenceSets(volumeNameList);
+
+        if (volumeNameList.Count == 0)
+        {
+            return ToReferenceMap(referenceSets);
+        }
+
+        var containers = await runtimeClient.ListContainersAsync(cancellationToken);
+        foreach (var container in containers)
+        {
+            ContainerDetail detail;
+            try
+            {
+                detail = await runtimeClient.GetContainerDetailAsync(container.Id, cancellationToken);
+            }
+            catch (ContainerManagementException)
+            {
+                continue;
+            }
+
+            foreach (var volumeName in volumeNameList)
+            {
+                if (detail.Mounts.Any(mount => SourceReferencesVolume(mount.Source, volumeName)))
+                {
+                    referenceSets[volumeName].Add(detail.Name);
+                }
+            }
+        }
+
+        return ToReferenceMap(referenceSets);
+    }
+
+    private static Dictionary<string, SortedSet<string>> CreateReferenceSets(IReadOnlyList<string> volumeNames)
+    {
+        return volumeNames.ToDictionary(
+            volumeName => volumeName,
+            _ => new SortedSet<string>(StringComparer.Ordinal),
+            StringComparer.Ordinal);
+    }
+
+    private static Dictionary<string, IReadOnlyList<string>> ToReferenceMap(Dictionary<string, SortedSet<string>> referenceSets)
+    {
+        return referenceSets.ToDictionary(
+            item => item.Key,
+            item => (IReadOnlyList<string>)item.Value.ToList(),
+            StringComparer.Ordinal);
+    }
+
+    private static bool SourceReferencesVolume(string source, string volumeName)
+    {
+        if (string.IsNullOrEmpty(source) || string.IsNullOrEmpty(volumeName))
+        {
+            return false;
+        }
+
+        var normalized = source.Replace('\\', '/');
+        if (normalized.EndsWith($"/volumes/{volumeName}/_data", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        return normalized
+            .Split('/', StringSplitOptions.RemoveEmptyEntries)
+            .Any(segment => segment == volumeName);
+    }
+
+    private static string ValidateNotWhiteSpace(string value, string parameterName)
+    {
+        var trimmed = value.Trim();
+        if (trimmed.Length == 0)
+        {
+            throw new ArgumentException("値を空白だけにすることはできません。", parameterName);
+        }
+
+        return trimmed;
+    }
+}

--- a/src/WslContainersDesktop.Domain/ContainerVolume.cs
+++ b/src/WslContainersDesktop.Domain/ContainerVolume.cs
@@ -1,0 +1,25 @@
+namespace WslContainersDesktop.Domain;
+
+/// <summary>
+/// WSL Containers上のコンテナーボリュームを表すエンティティ。
+/// </summary>
+/// <param name="Name">ボリューム名。</param>
+/// <param name="Driver">ボリュームドライバー名。</param>
+/// <param name="CreatedAt">作成日時。</param>
+/// <param name="ReferencingContainerNames">このボリュームを参照しているコンテナ名の一覧。</param>
+public sealed record ContainerVolume(
+    string Name,
+    string Driver,
+    DateTimeOffset CreatedAt,
+    IReadOnlyList<string> ReferencingContainerNames)
+{
+    /// <summary>
+    /// ボリュームがいずれかのコンテナから参照されているかどうか。
+    /// </summary>
+    public bool IsInUse => ReferencingContainerNames.Count > 0;
+
+    /// <summary>
+    /// ボリュームを削除できるかどうか。
+    /// </summary>
+    public bool CanDelete => !IsInUse;
+}

--- a/src/WslContainersDesktop.Infrastructure/Clients/VolumeInspectDto.cs
+++ b/src/WslContainersDesktop.Infrastructure/Clients/VolumeInspectDto.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Serialization;
+
+namespace WslContainersDesktop.Infrastructure.Clients;
+
+/// <summary>
+/// <c>wslc volume inspect</c> の1要素に対応するJSON DTO。
+/// </summary>
+internal sealed class VolumeInspectDto
+{
+    [JsonPropertyName("Name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("Driver")]
+    public string Driver { get; set; } = string.Empty;
+
+    [JsonPropertyName("CreatedAt")]
+    public string CreatedAt { get; set; } = string.Empty;
+}

--- a/src/WslContainersDesktop.Infrastructure/Clients/VolumeListItemDto.cs
+++ b/src/WslContainersDesktop.Infrastructure/Clients/VolumeListItemDto.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace WslContainersDesktop.Infrastructure.Clients;
+
+/// <summary>
+/// <c>wslc volume list --format json</c> の1要素に対応するJSON DTO。
+/// </summary>
+internal sealed class VolumeListItemDto
+{
+    [JsonPropertyName("Name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("Driver")]
+    public string Driver { get; set; } = string.Empty;
+}

--- a/src/WslContainersDesktop.Infrastructure/Clients/WslcCliContainerRuntimeClient.cs
+++ b/src/WslContainersDesktop.Infrastructure/Clients/WslcCliContainerRuntimeClient.cs
@@ -22,20 +22,10 @@ public sealed class WslcCliContainerRuntimeClient(IWslcCliRunner cliRunner) : IC
     {
         var result = await RunAsync(["list", "-a", "--format", "json"], cancellationToken);
 
-        List<ContainerListItemDto>? items;
-        try
-        {
-            items = JsonSerializer.Deserialize<List<ContainerListItemDto>>(result.StandardOutput);
-        }
-        catch (JsonException ex)
-        {
-            throw new ContainerRuntimeException(
-                command: "list -a --format json",
-                exitCode: result.ExitCode,
-                message: "コンテナ一覧の解析に失敗しました。",
-                innerException: ex);
-        }
-
+        var items = DeserializeJsonList<ContainerListItemDto>(
+            result,
+            command: "list -a --format json",
+            failureMessage: "コンテナ一覧の解析に失敗しました。");
         if (items is null)
         {
             return [];
@@ -55,20 +45,10 @@ public sealed class WslcCliContainerRuntimeClient(IWslcCliRunner cliRunner) : IC
     {
         var result = await RunAsync(["image", "list", "--format", "json", "--no-trunc"], cancellationToken);
 
-        List<ImageListItemDto>? items;
-        try
-        {
-            items = JsonSerializer.Deserialize<List<ImageListItemDto>>(result.StandardOutput);
-        }
-        catch (JsonException ex)
-        {
-            throw new ContainerRuntimeException(
-                command: "image list --format json --no-trunc",
-                exitCode: result.ExitCode,
-                message: "コンテナーイメージ一覧の解析に失敗しました。",
-                innerException: ex);
-        }
-
+        var items = DeserializeJsonList<ImageListItemDto>(
+            result,
+            command: "image list --format json --no-trunc",
+            failureMessage: "コンテナーイメージ一覧の解析に失敗しました。");
         if (items is null)
         {
             return [];
@@ -92,6 +72,38 @@ public sealed class WslcCliContainerRuntimeClient(IWslcCliRunner cliRunner) : IC
     public Task DeleteImageAsync(string imageId, CancellationToken cancellationToken = default)
     {
         return RunAsync(["image", "remove", imageId], cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<ContainerVolume>> ListVolumesAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await RunAsync(["volume", "list", "--format", "json"], cancellationToken);
+
+        var items = DeserializeJsonList<VolumeListItemDto>(
+            result,
+            command: "volume list --format json",
+            failureMessage: "コンテナーボリューム一覧の解析に失敗しました。");
+        if (items is null)
+        {
+            return [];
+        }
+
+        var volumes = new List<ContainerVolume>();
+        foreach (var item in items)
+        {
+            volumes.Add(await InspectVolumeAsync(item, cancellationToken));
+        }
+
+        return volumes;
+    }
+
+    public Task CreateVolumeAsync(string name, CancellationToken cancellationToken = default)
+    {
+        return RunAsync(["volume", "create", name], cancellationToken);
+    }
+
+    public Task DeleteVolumeAsync(string name, CancellationToken cancellationToken = default)
+    {
+        return RunAsync(["volume", "remove", name], cancellationToken);
     }
 
     public Task StartAsync(string containerId, CancellationToken cancellationToken = default)
@@ -123,20 +135,10 @@ public sealed class WslcCliContainerRuntimeClient(IWslcCliRunner cliRunner) : IC
     {
         var result = await RunAsync(["container", "inspect", containerId], cancellationToken);
 
-        List<ContainerInspectDto>? items;
-        try
-        {
-            items = JsonSerializer.Deserialize<List<ContainerInspectDto>>(result.StandardOutput);
-        }
-        catch (JsonException ex)
-        {
-            throw new ContainerRuntimeException(
-                command: $"container inspect {containerId}",
-                exitCode: result.ExitCode,
-                message: "コンテナ詳細情報の解析に失敗しました。",
-                innerException: ex);
-        }
-
+        var items = DeserializeJsonList<ContainerInspectDto>(
+            result,
+            command: $"container inspect {containerId}",
+            failureMessage: "コンテナ詳細情報の解析に失敗しました。");
         var item = items?.FirstOrDefault();
         if (item is null)
         {
@@ -192,6 +194,43 @@ public sealed class WslcCliContainerRuntimeClient(IWslcCliRunner cliRunner) : IC
         }
 
         return result;
+    }
+
+    private static List<TDto>? DeserializeJsonList<TDto>(CliResult result, string command, string failureMessage)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<List<TDto>>(result.StandardOutput);
+        }
+        catch (JsonException ex)
+        {
+            throw new ContainerRuntimeException(
+                command: command,
+                exitCode: result.ExitCode,
+                message: failureMessage,
+                innerException: ex);
+        }
+    }
+
+    private async Task<ContainerVolume> InspectVolumeAsync(VolumeListItemDto listItem, CancellationToken cancellationToken)
+    {
+        var result = await RunAsync(["volume", "inspect", listItem.Name], cancellationToken);
+
+        var items = DeserializeJsonList<VolumeInspectDto>(
+            result,
+            command: $"volume inspect {listItem.Name}",
+            failureMessage: "コンテナーボリューム詳細情報の解析に失敗しました。");
+        var item = items?.FirstOrDefault();
+        if (item is null)
+        {
+            return new ContainerVolume(listItem.Name, listItem.Driver, DateTimeOffset.MinValue, []);
+        }
+
+        return new ContainerVolume(
+            Name: string.IsNullOrEmpty(item.Name) ? listItem.Name : item.Name,
+            Driver: string.IsNullOrEmpty(item.Driver) ? listItem.Driver : item.Driver,
+            CreatedAt: ParseDateTimeOffsetOrDefault(item.CreatedAt),
+            ReferencingContainerNames: []);
     }
 
     private static IReadOnlyList<string> SplitLogLines(string text)

--- a/tests/WslContainersDesktop.App.Tests/Fakes/FakeVolumeManagementService.cs
+++ b/tests/WslContainersDesktop.App.Tests/Fakes/FakeVolumeManagementService.cs
@@ -1,0 +1,60 @@
+using WslContainersDesktop.Application.Ports;
+using WslContainersDesktop.Domain;
+
+namespace WslContainersDesktop_App_Tests.Fakes;
+
+internal sealed class FakeVolumeManagementService : IVolumeManagementService
+{
+    public IReadOnlyList<ContainerVolume> DefaultVolumes { get; set; } = [];
+
+    public ContainerVolume? CreateResult { get; set; }
+
+    public Exception? GetVolumesException { get; set; }
+
+    public Exception? CreateException { get; set; }
+
+    public Exception? DeleteException { get; set; }
+
+    public TaskCompletionSource<bool>? CreateGate { get; set; }
+
+    public List<string> CreateCalls { get; } = [];
+
+    public List<string> DeleteCalls { get; } = [];
+
+    public Task<IReadOnlyList<ContainerVolume>> GetVolumesAsync(CancellationToken cancellationToken = default)
+    {
+        if (GetVolumesException is not null)
+        {
+            throw GetVolumesException;
+        }
+
+        return Task.FromResult(DefaultVolumes);
+    }
+
+    public async Task<ContainerVolume> CreateAsync(string name, CancellationToken cancellationToken = default)
+    {
+        CreateCalls.Add(name);
+        if (CreateGate is not null)
+        {
+            await CreateGate.Task;
+        }
+
+        if (CreateException is not null)
+        {
+            throw CreateException;
+        }
+
+        return CreateResult ?? new ContainerVolume(name, "guest", DateTimeOffset.UtcNow, []);
+    }
+
+    public Task DeleteAsync(string name, CancellationToken cancellationToken = default)
+    {
+        DeleteCalls.Add(name);
+        if (DeleteException is not null)
+        {
+            throw DeleteException;
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/tests/WslContainersDesktop.App.Tests/Navigation/NavigationPageRegistryTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/Navigation/NavigationPageRegistryTests.cs
@@ -9,6 +9,7 @@ public sealed class NavigationPageRegistryTests
     [TestMethod]
     [DataRow(NavigationPageKey.Containers, typeof(ContainersPage))]
     [DataRow(NavigationPageKey.Images, typeof(ImagesPage))]
+    [DataRow(NavigationPageKey.Volumes, typeof(VolumesPage))]
     [DataRow(NavigationPageKey.Settings, typeof(SettingsPage))]
     public void GetPageType_DefinedPageKey_ReturnsExpectedPageType(NavigationPageKey pageKey, Type expectedPageType)
     {

--- a/tests/WslContainersDesktop.App.Tests/Pages/VolumesPageSourceTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/Pages/VolumesPageSourceTests.cs
@@ -1,0 +1,80 @@
+namespace WslContainersDesktop_App_Tests.Pages;
+
+[TestClass]
+public sealed class VolumesPageSourceTests
+{
+    [TestMethod]
+    public void VolumesPage_XamlDisplaysRequiredVolumeFields()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Pages\VolumesPage.xaml");
+
+        // Assert
+        StringAssert.Contains(sourceText, "Text=\"{x:Bind Name}\"");
+        StringAssert.Contains(sourceText, "Text=\"{x:Bind Driver}\"");
+        StringAssert.Contains(sourceText, "Text=\"{x:Bind CreatedAt}\"");
+        StringAssert.Contains(sourceText, "Text=\"{x:Bind UsageText}\"");
+    }
+
+    [TestMethod]
+    public void VolumesPage_DeleteClickShowsConfirmationBeforeExecutingDeleteCommand()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Pages\VolumesPage.xaml.cs");
+
+        // Act
+        var handlerIndex = sourceText.IndexOf("BtnDeleteVolume_Click", StringComparison.Ordinal);
+        var dialogIndex = sourceText.IndexOf("ContentDialog", StringComparison.Ordinal);
+        var primaryResultIndex = sourceText.IndexOf("ContentDialogResult.Primary", StringComparison.Ordinal);
+        var deleteCommandIndex = sourceText.IndexOf("DeleteCommand.ExecuteAsync", StringComparison.Ordinal);
+
+        // Assert
+        Assert.IsGreaterThanOrEqualTo(0, handlerIndex, "Expected VolumesPage to define BtnDeleteVolume_Click.");
+        Assert.IsGreaterThanOrEqualTo(0, dialogIndex, "Expected volume deletion to create a confirmation dialog.");
+        Assert.IsGreaterThanOrEqualTo(0, primaryResultIndex, "Expected volume deletion to require primary confirmation.");
+        Assert.IsGreaterThanOrEqualTo(0, deleteCommandIndex, "Expected confirmed volume deletion to execute DeleteCommand.");
+        Assert.IsTrue(
+            handlerIndex < dialogIndex && dialogIndex < deleteCommandIndex,
+            "Expected the delete confirmation dialog to be created before executing the delete command.");
+    }
+
+    [TestMethod]
+    public void MainWindow_SourceContainsVolumesNavigationItemAndMapping()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\MainWindow.xaml");
+        var codeBehindText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\MainWindow.xaml.cs");
+
+        // Assert
+        StringAssert.Contains(sourceText, "AutomationProperties.AutomationId=\"NavItemVolumes\"");
+        StringAssert.Contains(codeBehindText, "[NavItemVolumes] = NavigationPageKey.Volumes");
+    }
+
+    private static string ReadRepositorySourceFile(string relativePath)
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var normalizedRelativePath = relativePath.Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar);
+        var fullPath = Path.Combine(repositoryRoot, normalizedRelativePath);
+
+        Assert.IsTrue(File.Exists(fullPath), $"Expected source file '{relativePath}' to exist at '{fullPath}'.");
+        return File.ReadAllText(fullPath);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var currentDirectory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (currentDirectory is not null)
+        {
+            var appProjectFilePath = Path.Combine(currentDirectory.FullName, "src", "WslContainersDesktop.App", "WslContainersDesktop.App.csproj");
+            if (File.Exists(appProjectFilePath))
+            {
+                return currentDirectory.FullName;
+            }
+
+            currentDirectory = currentDirectory.Parent;
+        }
+
+        Assert.Fail($"Could not locate repository root from '{AppContext.BaseDirectory}'.");
+        return string.Empty;
+    }
+}

--- a/tests/WslContainersDesktop.App.Tests/ViewModels/NavigationViewModelTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/ViewModels/NavigationViewModelTests.cs
@@ -19,6 +19,7 @@ public sealed class NavigationViewModelTests
     [TestMethod]
     [DataRow(NavigationPageKey.Containers)]
     [DataRow(NavigationPageKey.Settings)]
+    [DataRow(NavigationPageKey.Volumes)]
     public void Constructor_InitialPageKeySpecified_CurrentPageKeyMatchesArgument(NavigationPageKey initialPageKey)
     {
         // Arrange & Act

--- a/tests/WslContainersDesktop.App.Tests/ViewModels/VolumeRowViewModelTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/ViewModels/VolumeRowViewModelTests.cs
@@ -1,0 +1,37 @@
+using WslContainersDesktop.Domain;
+using WslContainersDesktop_App.ViewModels;
+
+namespace WslContainersDesktop_App_Tests.ViewModels;
+
+[TestClass]
+public sealed class VolumeRowViewModelTests
+{
+    [TestMethod]
+    public void UsageText_NoReferences_ReturnsUnused()
+    {
+        // Arrange
+        var volume = new ContainerVolume("vol-demo", "guest", new DateTimeOffset(2026, 7, 2, 9, 0, 0, TimeSpan.Zero), []);
+
+        // Act
+        var sut = new VolumeRowViewModel(volume);
+
+        // Assert
+        Assert.AreEqual("Unused", sut.UsageText);
+        Assert.IsTrue(sut.CanDelete);
+    }
+
+    [TestMethod]
+    public void UsageText_WithReferences_ReturnsCommaSeparatedNames()
+    {
+        // Arrange
+        var volume = new ContainerVolume("vol-demo", "guest", new DateTimeOffset(2026, 7, 2, 9, 0, 0, TimeSpan.Zero), ["web", "db"]);
+
+        // Act
+        var sut = new VolumeRowViewModel(volume);
+
+        // Assert
+        Assert.AreEqual("web, db", sut.UsageText);
+        Assert.IsFalse(sut.CanDelete);
+        Assert.IsTrue(sut.IsInUse);
+    }
+}

--- a/tests/WslContainersDesktop.App.Tests/ViewModels/VolumesViewModelTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/ViewModels/VolumesViewModelTests.cs
@@ -1,0 +1,264 @@
+using WslContainersDesktop.Application.Exceptions;
+using WslContainersDesktop.Domain;
+using WslContainersDesktop_App.ViewModels;
+using WslContainersDesktop_App_Tests.Fakes;
+
+namespace WslContainersDesktop_App_Tests.ViewModels;
+
+[TestClass]
+public sealed class VolumesViewModelTests
+{
+    private static ContainerVolume CreateVolume(string name, params string[] referencingContainerNames) => new(
+        Name: name,
+        Driver: "guest",
+        CreatedAt: new DateTimeOffset(2026, 7, 2, 9, 0, 0, TimeSpan.Zero),
+        ReferencingContainerNames: referencingContainerNames);
+
+    [TestMethod]
+    public async Task RefreshAsync_ServiceReturnsVolumes_PopulatesRowsAndClearsErrorAndIsEmptyIsFalse()
+    {
+        // Arrange
+        var service = new FakeVolumeManagementService
+        {
+            DefaultVolumes = [CreateVolume("vol-1"), CreateVolume("vol-2")],
+        };
+        var sut = new VolumesViewModel(service);
+
+        // Act
+        await sut.RefreshAsync();
+
+        // Assert
+        Assert.HasCount(2, sut.Volumes);
+        Assert.AreEqual("vol-1", sut.Volumes[0].Name);
+        Assert.IsFalse(sut.IsEmpty);
+        Assert.IsNull(sut.ErrorMessage);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_ServiceReturnsEmptyList_IsEmptyIsTrue()
+    {
+        // Arrange
+        var service = new FakeVolumeManagementService { DefaultVolumes = [] };
+        var sut = new VolumesViewModel(service);
+
+        // Act
+        await sut.RefreshAsync();
+
+        // Assert
+        Assert.IsEmpty(sut.Volumes);
+        Assert.IsTrue(sut.IsEmpty);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_ServiceThrows_ErrorMessageIsSetAndExistingRowsArePreserved()
+    {
+        // Arrange
+        var service = new FakeVolumeManagementService();
+        service.DefaultVolumes = [CreateVolume("vol-1")];
+        var sut = new VolumesViewModel(service);
+        await sut.RefreshAsync();
+        service.GetVolumesException = new ContainerRuntimeException("list", 1, "list failed");
+
+        // Act
+        await sut.RefreshAsync();
+
+        // Assert
+        Assert.AreEqual("list failed", sut.ErrorMessage);
+        Assert.HasCount(1, sut.Volumes);
+        Assert.AreEqual("vol-1", sut.Volumes[0].Name);
+    }
+
+    [TestMethod]
+    public async Task CreateAsync_ServiceSucceeds_ClearsInputSetsStatusAndRefreshesVolumes()
+    {
+        // Arrange
+        var service = new FakeVolumeManagementService
+        {
+            DefaultVolumes = [],
+            CreateResult = CreateVolume("vol-1"),
+        };
+        var sut = new VolumesViewModel(service)
+        {
+            NewVolumeName = "  vol-1  ",
+        };
+
+        // Act
+        await sut.CreateAsync();
+
+        // Assert
+        Assert.AreEqual(string.Empty, sut.NewVolumeName);
+        Assert.AreEqual("Volume created.", sut.StatusMessage);
+        Assert.HasCount(1, sut.Volumes);
+        Assert.AreEqual("vol-1", sut.Volumes[0].Name);
+        Assert.IsFalse(sut.IsCreating);
+    }
+
+    [TestMethod]
+    public async Task CreateAsync_NewVolumeNameIsEmpty_ShowsValidationErrorAndDoesNotCallService()
+    {
+        // Arrange
+        var service = new FakeVolumeManagementService();
+        var sut = new VolumesViewModel(service)
+        {
+            NewVolumeName = string.Empty,
+        };
+
+        // Act
+        await sut.CreateAsync();
+
+        // Assert
+        Assert.AreEqual("Volume name is required.", sut.ErrorMessage);
+        Assert.IsFalse(sut.IsCreating);
+        Assert.IsEmpty(service.CreateCalls);
+    }
+
+    [TestMethod]
+    public async Task CreateAsync_ServiceThrows_ErrorMessageIsSetAndInputIsPreserved()
+    {
+        // Arrange
+        var service = new FakeVolumeManagementService { CreateException = new ContainerRuntimeException("create", 1, "create failed") };
+        var sut = new VolumesViewModel(service)
+        {
+            NewVolumeName = "vol-1",
+        };
+
+        // Act
+        await sut.CreateAsync();
+
+        // Assert
+        Assert.AreEqual("create failed", sut.ErrorMessage);
+        Assert.AreEqual("vol-1", sut.NewVolumeName);
+        Assert.IsFalse(sut.IsCreating);
+    }
+
+    [TestMethod]
+    public async Task CreateAsync_RefreshAfterCreateFails_ClearsSuccessStatusAndShowsRefreshError()
+    {
+        // Arrange
+        var service = new FakeVolumeManagementService
+        {
+            CreateResult = CreateVolume("vol-1"),
+            GetVolumesException = new ContainerRuntimeException("list", 1, "refresh failed"),
+        };
+        var sut = new VolumesViewModel(service)
+        {
+            NewVolumeName = "vol-1",
+        };
+
+        // Act
+        await sut.CreateAsync();
+
+        // Assert
+        Assert.AreEqual("refresh failed", sut.ErrorMessage);
+        Assert.IsNull(sut.StatusMessage);
+    }
+
+    [TestMethod]
+    public async Task CreateAsync_OperationIsRunning_IsCreatingIsTrueThenFalse()
+    {
+        // Arrange
+        var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var service = new FakeVolumeManagementService
+        {
+            CreateResult = CreateVolume("vol-1"),
+            CreateGate = gate,
+        };
+        var sut = new VolumesViewModel(service)
+        {
+            NewVolumeName = "vol-1",
+        };
+
+        // Act
+        var createTask = sut.CreateAsync();
+
+        // Assert
+        Assert.IsTrue(sut.IsCreating);
+        gate.SetResult(true);
+        await createTask;
+        Assert.IsFalse(sut.IsCreating);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_ServiceSucceeds_RemovesVolumeRowAndUpdatesIsEmpty()
+    {
+        // Arrange
+        var service = new FakeVolumeManagementService
+        {
+            DefaultVolumes = [CreateVolume("vol-1")],
+        };
+        var sut = new VolumesViewModel(service);
+        await sut.RefreshAsync();
+        var row = sut.Volumes[0];
+
+        // Act
+        await sut.DeleteAsync(row);
+
+        // Assert
+        Assert.IsEmpty(sut.Volumes);
+        Assert.IsTrue(sut.IsEmpty);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_ServiceThrows_ErrorMessageIsSetAndRowRemains()
+    {
+        // Arrange
+        var service = new FakeVolumeManagementService
+        {
+            DefaultVolumes = [CreateVolume("vol-1")],
+            DeleteException = new ContainerRuntimeException("delete", 1, "delete failed"),
+        };
+        var sut = new VolumesViewModel(service);
+        await sut.RefreshAsync();
+        var row = sut.Volumes[0];
+
+        // Act
+        await sut.DeleteAsync(row);
+
+        // Assert
+        Assert.AreEqual("delete failed", sut.ErrorMessage);
+        Assert.HasCount(1, sut.Volumes);
+        Assert.AreSame(row, sut.Volumes[0]);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_InUseRow_DoesNotCallServiceAndShowsError()
+    {
+        // Arrange
+        var service = new FakeVolumeManagementService
+        {
+            DefaultVolumes = [CreateVolume("vol-1", "web")],
+        };
+        var sut = new VolumesViewModel(service);
+        await sut.RefreshAsync();
+        var row = sut.Volumes[0];
+
+        // Act
+        await sut.DeleteAsync(row);
+
+        // Assert
+        Assert.AreEqual("Volume 'vol-1' is in use by: web", sut.ErrorMessage);
+        Assert.IsEmpty(service.DeleteCalls);
+        Assert.HasCount(1, sut.Volumes);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_VolumeInUseException_UsesExceptionNamesInErrorMessage()
+    {
+        // Arrange
+        var service = new FakeVolumeManagementService
+        {
+            DefaultVolumes = [CreateVolume("vol-1")],
+            DeleteException = new VolumeInUseException("vol-1", ["web", "db"]),
+        };
+        var sut = new VolumesViewModel(service);
+        await sut.RefreshAsync();
+        var row = sut.Volumes[0];
+
+        // Act
+        await sut.DeleteAsync(row);
+
+        // Assert
+        Assert.AreEqual("Volume 'vol-1' is in use by: web, db", sut.ErrorMessage);
+        Assert.HasCount(1, sut.Volumes);
+    }
+}

--- a/tests/WslContainersDesktop.Application.Tests/Fakes/FakeContainerRuntimeClient.cs
+++ b/tests/WslContainersDesktop.Application.Tests/Fakes/FakeContainerRuntimeClient.cs
@@ -14,6 +14,10 @@ internal sealed class FakeContainerRuntimeClient : IContainerRuntimeClient
 
     public IReadOnlyList<ContainerImage> Images { get; set; } = [];
 
+    public IReadOnlyList<ContainerVolume> Volumes { get; set; } = [];
+
+    public IReadOnlyDictionary<string, ContainerDetail> ContainerDetailsById { get; set; } = new Dictionary<string, ContainerDetail>();
+
     public Exception? ExceptionToThrow { get; set; }
 
     public Exception? PullException { get; set; }
@@ -29,6 +33,10 @@ internal sealed class FakeContainerRuntimeClient : IContainerRuntimeClient
     public Exception? GetContainerLogsException { get; set; }
 
     public Exception? FollowContainerLogsException { get; set; }
+
+    public Exception? GetContainerDetailException { get; set; }
+
+    public Exception? DeleteVolumeException { get; set; }
 
     public Func<string, CancellationToken, Task<IReadOnlyList<string>>>? GetContainerLogsAsyncFunc { get; set; }
 
@@ -51,6 +59,10 @@ internal sealed class FakeContainerRuntimeClient : IContainerRuntimeClient
     public List<string> OpenExecSessionCalls { get; } = [];
 
     public List<string> FollowContainerLogsCalls { get; } = [];
+
+    public List<string> CreateVolumeCalls { get; } = [];
+
+    public List<string> DeleteVolumeCalls { get; } = [];
 
     public Task<IReadOnlyList<Container>> ListContainersAsync(CancellationToken cancellationToken = default)
     {
@@ -136,6 +148,16 @@ internal sealed class FakeContainerRuntimeClient : IContainerRuntimeClient
     public Task<ContainerDetail> GetContainerDetailAsync(string containerId, CancellationToken cancellationToken = default)
     {
         GetContainerDetailCalls.Add(containerId);
+        if (GetContainerDetailException is not null)
+        {
+            throw GetContainerDetailException;
+        }
+
+        if (ContainerDetailsById.TryGetValue(containerId, out var detail))
+        {
+            return Task.FromResult(detail);
+        }
+
         return Task.FromResult(ContainerDetail!);
     }
 
@@ -172,5 +194,27 @@ internal sealed class FakeContainerRuntimeClient : IContainerRuntimeClient
 
             yield return line;
         }
+    }
+
+    public Task<IReadOnlyList<ContainerVolume>> ListVolumesAsync(CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(Volumes);
+    }
+
+    public Task CreateVolumeAsync(string name, CancellationToken cancellationToken = default)
+    {
+        CreateVolumeCalls.Add(name);
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteVolumeAsync(string name, CancellationToken cancellationToken = default)
+    {
+        DeleteVolumeCalls.Add(name);
+        if (DeleteVolumeException is not null)
+        {
+            throw DeleteVolumeException;
+        }
+
+        return Task.CompletedTask;
     }
 }

--- a/tests/WslContainersDesktop.Application.Tests/Services/VolumeManagementServiceTests.cs
+++ b/tests/WslContainersDesktop.Application.Tests/Services/VolumeManagementServiceTests.cs
@@ -1,0 +1,206 @@
+using WslContainersDesktop.Application.Exceptions;
+using WslContainersDesktop.Application.Ports;
+using WslContainersDesktop.Application.Services;
+using WslContainersDesktop.Application.Tests.Fakes;
+using WslContainersDesktop.Domain;
+
+namespace WslContainersDesktop.Application.Tests.Services;
+
+[TestClass]
+public sealed class VolumeManagementServiceTests
+{
+    private static Container CreateContainer(string id) => new(
+        Id: id,
+        Name: $"name-{id}",
+        Image: "nginx:latest",
+        State: ContainerState.Running,
+        CreatedAt: new DateTimeOffset(2026, 7, 2, 9, 0, 0, TimeSpan.Zero));
+
+    private static ContainerDetail CreateDetail(string containerId, string containerName, params ContainerMount[] mounts) => new(
+        Id: containerId,
+        Name: containerName,
+        Image: "nginx:latest",
+        State: ContainerState.Running,
+        CreatedAt: new DateTimeOffset(2026, 7, 2, 9, 0, 0, TimeSpan.Zero),
+        Command: null,
+        Entrypoint: null,
+        Ports: [],
+        Environment: [],
+        Mounts: mounts,
+        Networks: [],
+        RunState: new ContainerRunState(null, null, null, null));
+
+    [TestMethod]
+    public async Task GetVolumesAsync_RuntimeReturnsVolumesAndInspectableContainerReferencesVolume_ReturnsVolumeWithReferencingContainerName()
+    {
+        // Arrange
+        var createdAt = new DateTimeOffset(2026, 7, 2, 9, 0, 0, TimeSpan.Zero);
+        var client = new FakeContainerRuntimeClient
+        {
+            Containers = [CreateContainer("c1")],
+            ContainerDetailsById = new Dictionary<string, ContainerDetail>
+            {
+                ["c1"] = CreateDetail("c1", "web", new ContainerMount("bind", "/var/lib/docker/volumes/vol-demo/_data", "/data", false)),
+            },
+            Volumes = [new ContainerVolume("vol-demo", "guest", createdAt, [])],
+        };
+        var sut = new VolumeManagementService(client);
+
+        // Act
+        var volumes = await sut.GetVolumesAsync();
+
+        // Assert
+        Assert.HasCount(1, volumes);
+        Assert.AreEqual("vol-demo", volumes[0].Name);
+        CollectionAssert.AreEqual(new[] { "web" }, volumes[0].ReferencingContainerNames.ToList());
+    }
+
+    [TestMethod]
+    public async Task GetVolumesAsync_ContainerDetailFails_ReturnsVolumesWithoutThrowing()
+    {
+        // Arrange
+        var createdAt = new DateTimeOffset(2026, 7, 2, 9, 0, 0, TimeSpan.Zero);
+        var client = new FakeContainerRuntimeClient
+        {
+            Containers = [CreateContainer("c1")],
+            GetContainerDetailException = new ContainerRuntimeException("detail", 1, "detail failed"),
+            Volumes = [new ContainerVolume("vol-demo", "guest", createdAt, [])],
+        };
+        var sut = new VolumeManagementService(client);
+
+        // Act
+        var volumes = await sut.GetVolumesAsync();
+
+        // Assert
+        Assert.HasCount(1, volumes);
+        Assert.IsEmpty(volumes[0].ReferencingContainerNames);
+    }
+
+    [TestMethod]
+    public async Task GetVolumesAsync_SameContainerReferencesVolumeTwice_ReferencesContainerOnce()
+    {
+        // Arrange
+        var createdAt = new DateTimeOffset(2026, 7, 2, 9, 0, 0, TimeSpan.Zero);
+        var client = new FakeContainerRuntimeClient
+        {
+            Containers = [CreateContainer("c1")],
+            ContainerDetailsById = new Dictionary<string, ContainerDetail>
+            {
+                ["c1"] = CreateDetail(
+                    "c1",
+                    "web",
+                    new ContainerMount("bind", "/var/lib/docker/volumes/vol-demo/_data", "/data", false),
+                    new ContainerMount("bind", "/mnt/vol-demo", "/data2", false)),
+            },
+            Volumes = [new ContainerVolume("vol-demo", "guest", createdAt, [])],
+        };
+        var sut = new VolumeManagementService(client);
+
+        // Act
+        var volumes = await sut.GetVolumesAsync();
+
+        // Assert
+        CollectionAssert.AreEqual(new[] { "web" }, volumes[0].ReferencingContainerNames.ToList());
+    }
+
+    [TestMethod]
+    public async Task GetVolumesAsync_TwoContainersReferenceSameVolume_ReferencesAreSortedByName()
+    {
+        // Arrange
+        var createdAt = new DateTimeOffset(2026, 7, 2, 9, 0, 0, TimeSpan.Zero);
+        var client = new FakeContainerRuntimeClient
+        {
+            Containers = [CreateContainer("c1"), CreateContainer("c2")],
+            ContainerDetailsById = new Dictionary<string, ContainerDetail>
+            {
+                ["c1"] = CreateDetail("c1", "web", new ContainerMount("bind", "/var/lib/docker/volumes/vol-demo/_data", "/data", false)),
+                ["c2"] = CreateDetail("c2", "api", new ContainerMount("bind", "/var/lib/docker/volumes/vol-demo/_data", "/data", false)),
+            },
+            Volumes = [new ContainerVolume("vol-demo", "guest", createdAt, [])],
+        };
+        var sut = new VolumeManagementService(client);
+
+        // Act
+        var volumes = await sut.GetVolumesAsync();
+
+        // Assert
+        CollectionAssert.AreEqual(new[] { "api", "web" }, volumes[0].ReferencingContainerNames.ToList());
+    }
+
+    [TestMethod]
+    public async Task CreateAsync_NameHasWhitespace_TrimsAndCallsClientCreateVolume()
+    {
+        // Arrange
+        var client = new FakeContainerRuntimeClient();
+        var sut = new VolumeManagementService(client);
+
+        // Act
+        await sut.CreateAsync("  vol-demo  ");
+
+        // Assert
+        CollectionAssert.AreEqual(new[] { "vol-demo" }, client.CreateVolumeCalls);
+    }
+
+    [TestMethod]
+    public async Task CreateAsync_NameIsWhitespace_ThrowsArgumentExceptionAndDoesNotCallClient()
+    {
+        // Arrange
+        var client = new FakeContainerRuntimeClient();
+        var sut = new VolumeManagementService(client);
+
+        // Act & Assert
+        await Assert.ThrowsExactlyAsync<ArgumentException>(() => sut.CreateAsync("   "));
+        Assert.IsEmpty(client.CreateVolumeCalls);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_UnusedVolume_CallsClientDeleteVolume()
+    {
+        // Arrange
+        var client = new FakeContainerRuntimeClient();
+        var sut = new VolumeManagementService(client);
+
+        // Act
+        await sut.DeleteAsync("vol-demo");
+
+        // Assert
+        CollectionAssert.AreEqual(new[] { "vol-demo" }, client.DeleteVolumeCalls);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_InUseVolume_ThrowsVolumeInUseExceptionAndDoesNotCallClient()
+    {
+        // Arrange
+        var client = new FakeContainerRuntimeClient
+        {
+            Containers = [CreateContainer("c1")],
+            ContainerDetailsById = new Dictionary<string, ContainerDetail>
+            {
+                ["c1"] = CreateDetail("c1", "web", new ContainerMount("bind", "/var/lib/docker/volumes/vol-demo/_data", "/data", false)),
+            },
+        };
+        var sut = new VolumeManagementService(client);
+
+        // Act & Assert
+        var ex = await Assert.ThrowsExactlyAsync<VolumeInUseException>(() => sut.DeleteAsync("vol-demo"));
+        Assert.AreEqual("vol-demo", ex.VolumeName);
+        CollectionAssert.AreEqual(new[] { "web" }, ex.ReferencingContainerNames.ToList());
+        Assert.IsEmpty(client.DeleteVolumeCalls);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_ClientRejectsInUseVolume_ExceptionPropagates()
+    {
+        // Arrange
+        var runtimeException = new ContainerRuntimeException("delete", 1, "volume is in use");
+        var client = new FakeContainerRuntimeClient
+        {
+            DeleteVolumeException = runtimeException,
+        };
+        var sut = new VolumeManagementService(client);
+
+        // Act & Assert
+        var actual = await Assert.ThrowsExactlyAsync<ContainerRuntimeException>(() => sut.DeleteAsync("vol-demo"));
+        Assert.AreSame(runtimeException, actual);
+    }
+}

--- a/tests/WslContainersDesktop.Domain.Tests/ContainerVolumeTests.cs
+++ b/tests/WslContainersDesktop.Domain.Tests/ContainerVolumeTests.cs
@@ -1,0 +1,31 @@
+using WslContainersDesktop.Domain;
+
+namespace WslContainersDesktop.Domain.Tests;
+
+[TestClass]
+public sealed class ContainerVolumeTests
+{
+    [TestMethod]
+    public void ContainerVolume_NoReferences_IsUnusedAndCanDelete()
+    {
+        // Arrange
+        var createdAt = new DateTimeOffset(2026, 7, 2, 9, 0, 0, TimeSpan.Zero);
+        var sut = new ContainerVolume("vol-demo", "guest", createdAt, []);
+
+        // Act & Assert
+        Assert.IsFalse(sut.IsInUse);
+        Assert.IsTrue(sut.CanDelete);
+    }
+
+    [TestMethod]
+    public void ContainerVolume_WithReferences_IsInUseAndCannotDelete()
+    {
+        // Arrange
+        var createdAt = new DateTimeOffset(2026, 7, 2, 9, 0, 0, TimeSpan.Zero);
+        var sut = new ContainerVolume("vol-demo", "guest", createdAt, ["web", "db"]);
+
+        // Act & Assert
+        Assert.IsTrue(sut.IsInUse);
+        Assert.IsFalse(sut.CanDelete);
+    }
+}

--- a/tests/WslContainersDesktop.Infrastructure.Tests/Clients/VolumeManagementInfrastructureTests.cs
+++ b/tests/WslContainersDesktop.Infrastructure.Tests/Clients/VolumeManagementInfrastructureTests.cs
@@ -1,0 +1,168 @@
+using WslContainersDesktop.Application.Exceptions;
+using WslContainersDesktop.Infrastructure.Cli;
+using WslContainersDesktop.Infrastructure.Clients;
+using WslContainersDesktop.Infrastructure.Tests.Fakes;
+
+namespace WslContainersDesktop.Infrastructure.Tests.Clients;
+
+[TestClass]
+public sealed class VolumeManagementInfrastructureTests
+{
+    [TestMethod]
+    public async Task ListVolumesAsync_CliReturnsVolumesAndInspectReturnsCreatedAt_MapsJsonToContainerVolumes()
+    {
+        // Arrange
+        const string listJson = "[{\"Driver\":\"guest\",\"Name\":\"vol-demo\"}]";
+        const string inspectJson = "[{\"CreatedAt\":\"2026-07-02T09:00:00Z\",\"Driver\":\"guest\",\"Name\":\"vol-demo\"}]";
+        var runner = new FakeWslcCliRunner();
+        runner.RunAsyncFunc = (arguments, cancellationToken) =>
+        {
+            if (arguments.SequenceEqual(new[] { "volume", "list", "--format", "json" }))
+            {
+                return Task.FromResult(new CliResult(0, listJson, string.Empty));
+            }
+
+            if (arguments.SequenceEqual(new[] { "volume", "inspect", "vol-demo" }))
+            {
+                return Task.FromResult(new CliResult(0, inspectJson, string.Empty));
+            }
+
+            return Task.FromResult(new CliResult(0, string.Empty, string.Empty));
+        };
+        var sut = new WslcCliContainerRuntimeClient(runner);
+
+        // Act
+        var volumes = await sut.ListVolumesAsync();
+
+        // Assert
+        Assert.HasCount(1, volumes);
+        Assert.AreEqual("vol-demo", volumes[0].Name);
+        Assert.AreEqual("guest", volumes[0].Driver);
+        Assert.AreEqual(DateTimeOffset.Parse("2026-07-02T09:00:00Z"), volumes[0].CreatedAt);
+    }
+
+    [TestMethod]
+    public async Task ListVolumesAsync_CliArguments_AreVolumeListJsonThenVolumeInspectForEachName()
+    {
+        // Arrange
+        var runner = new FakeWslcCliRunner { Result = new(0, "[]", string.Empty) };
+        var sut = new WslcCliContainerRuntimeClient(runner);
+
+        // Act
+        await sut.ListVolumesAsync();
+
+        // Assert
+        CollectionAssert.AreEqual(new[] { "volume", "list", "--format", "json" }, runner.Calls[0].ToList());
+    }
+
+    [TestMethod]
+    public async Task ListVolumesAsync_InspectReturnsEmptyArray_UsesMinValueCreatedAtAndKeepsVolume()
+    {
+        // Arrange
+        var runner = new FakeWslcCliRunner();
+        runner.RunAsyncFunc = (arguments, cancellationToken) =>
+        {
+            if (arguments.SequenceEqual(new[] { "volume", "list", "--format", "json" }))
+            {
+                return Task.FromResult(new CliResult(0, "[{\"Driver\":\"guest\",\"Name\":\"vol-demo\"}]", string.Empty));
+            }
+
+            return Task.FromResult(new CliResult(0, "[]", string.Empty));
+        };
+        var sut = new WslcCliContainerRuntimeClient(runner);
+
+        // Act
+        var volumes = await sut.ListVolumesAsync();
+
+        // Assert
+        Assert.HasCount(1, volumes);
+        Assert.AreEqual(DateTimeOffset.MinValue, volumes[0].CreatedAt);
+        Assert.AreEqual("vol-demo", volumes[0].Name);
+    }
+
+    [TestMethod]
+    public async Task ListVolumesAsync_ListMalformedJson_ThrowsContainerRuntimeExceptionWithInnerException()
+    {
+        // Arrange
+        var runner = new FakeWslcCliRunner { Result = new(0, "not-json", string.Empty) };
+        var sut = new WslcCliContainerRuntimeClient(runner);
+
+        // Act & Assert
+        var ex = await Assert.ThrowsExactlyAsync<ContainerRuntimeException>(() => sut.ListVolumesAsync());
+        Assert.IsNotNull(ex.InnerException);
+    }
+
+    [TestMethod]
+    public async Task ListVolumesAsync_InspectMalformedJson_ThrowsContainerRuntimeExceptionWithInnerException()
+    {
+        // Arrange
+        var runner = new FakeWslcCliRunner();
+        runner.RunAsyncFunc = (arguments, cancellationToken) =>
+        {
+            if (arguments.SequenceEqual(new[] { "volume", "list", "--format", "json" }))
+            {
+                return Task.FromResult(new CliResult(0, "[{\"Driver\":\"guest\",\"Name\":\"vol-demo\"}]", string.Empty));
+            }
+
+            return Task.FromResult(new CliResult(0, "not-json", string.Empty));
+        };
+        var sut = new WslcCliContainerRuntimeClient(runner);
+
+        // Act & Assert
+        var ex = await Assert.ThrowsExactlyAsync<ContainerRuntimeException>(() => sut.ListVolumesAsync());
+        Assert.IsNotNull(ex.InnerException);
+    }
+
+    [TestMethod]
+    public async Task ListVolumesAsync_InspectCreatedAtIsEmpty_UsesMinValueCreatedAt()
+    {
+        // Arrange
+        var runner = new FakeWslcCliRunner();
+        runner.RunAsyncFunc = (arguments, cancellationToken) =>
+        {
+            if (arguments.SequenceEqual(new[] { "volume", "list", "--format", "json" }))
+            {
+                return Task.FromResult(new CliResult(0, "[{\"Driver\":\"guest\",\"Name\":\"vol-demo\"}]", string.Empty));
+            }
+
+            return Task.FromResult(new CliResult(0, "[{\"CreatedAt\":\"\",\"Driver\":\"guest\",\"Name\":\"vol-demo\"}]", string.Empty));
+        };
+        var sut = new WslcCliContainerRuntimeClient(runner);
+
+        // Act
+        var volumes = await sut.ListVolumesAsync();
+
+        // Assert
+        Assert.AreEqual(DateTimeOffset.MinValue, volumes[0].CreatedAt);
+    }
+
+    [TestMethod]
+    public async Task CreateVolumeAsync_CliArguments_AreVolumeCreateWithName()
+    {
+        // Arrange
+        var runner = new FakeWslcCliRunner { Result = new(0, string.Empty, string.Empty) };
+        var sut = new WslcCliContainerRuntimeClient(runner);
+
+        // Act
+        await sut.CreateVolumeAsync("vol-demo");
+
+        // Assert
+        CollectionAssert.AreEqual(new[] { "volume", "create", "vol-demo" }, runner.Calls[0].ToList());
+    }
+
+    [TestMethod]
+    public async Task DeleteVolumeAsync_CliArguments_AreVolumeRemoveWithoutForce()
+    {
+        // Arrange
+        var runner = new FakeWslcCliRunner { Result = new(0, string.Empty, string.Empty) };
+        var sut = new WslcCliContainerRuntimeClient(runner);
+
+        // Act
+        await sut.DeleteVolumeAsync("vol-demo");
+
+        // Assert
+        var arguments = runner.Calls[0].ToList();
+        CollectionAssert.AreEqual(new[] { "volume", "remove", "vol-demo" }, arguments);
+        CollectionAssert.DoesNotContain(arguments, "--force");
+    }
+}


### PR DESCRIPTION
WSL Containers DesktopでボリュームをGUI管理できるようにします。Issue #9のスコープとして、ローカルボリュームの一覧、作成、削除、使用状況表示を追加します。

## Summary
- Add `ContainerVolume` and volume management use cases across Domain/Application.
- Extend the `wslc` CLI client with `volume list`, `volume inspect`, `volume create`, and `volume remove` support.
- Add the Volumes WinUI page, navigation, resources, ViewModels, tests, and design docs.

## Notes
Current `wslc container inspect` does not expose a stable named-volume identifier, so usage is inferred conservatively from mount source paths. Deletion still uses `wslc volume remove` without force, so the runtime remains the final safety guard.

## Testing
- `dotnet test WslContainersDesktop.slnx --no-restore`
- WinUI E2E with `winapp ui`: navigation, validation, real volume create/delete, AutomationId coverage, and screenshot review

Fixes: #9