### PR TITLE
Add network management page

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -21,6 +21,7 @@
 | [`containers-view.md`](containers-view.md) | コンテナ一覧ViewModel（`ContainersViewModel`）の行操作・ログ表示状態管理の現在のスナップショット |
 | [`images-view.md`](images-view.md) | イメージ一覧ViewModel（`ImagesViewModel`）のpull・削除・状態管理の現在のスナップショット |
 | [`volumes-view.md`](volumes-view.md) | ボリューム一覧ViewModel（`VolumesViewModel`）の作成・削除・使用状況表示の現在のスナップショット |
+| [`networks-view.md`](networks-view.md) | ネットワーク一覧ViewModel（`NetworksViewModel`）の作成・削除・使用状況表示の現在のスナップショット |
 | (機能追加に応じて追加) | 個別機能の設計ドキュメントは `docs/design/<feature-name>.md` として追加していく |
 
 ## 更新のタイミング

--- a/docs/design/architecture-overview.md
+++ b/docs/design/architecture-overview.md
@@ -10,18 +10,19 @@
 
 | プロジェクト | 種別 | 内容 |
 |---|---|---|
-| `src/WslContainersDesktop.Domain` | classlib | コンテナ/イメージ/ボリュームエンティティ・状態・詳細情報値オブジェクト・状態別操作可否 |
-| `src/WslContainersDesktop.Application` | classlib | コンテナ/イメージ/ボリューム管理ユースケース、execセッション抽象、Inbound/Outboundポート |
+| `src/WslContainersDesktop.Domain` | classlib | コンテナ/イメージ/ボリューム/ネットワークエンティティ・状態・詳細情報値オブジェクト・状態別操作可否 |
+| `src/WslContainersDesktop.Application` | classlib | コンテナ/イメージ/ボリューム/ネットワーク管理ユースケース、execセッション抽象、Inbound/Outboundポート |
 | `src/WslContainersDesktop.Infrastructure` | classlib | `wslc` CLIラッパーによるWSL Containers連携 |
-| `src/WslContainersDesktop.App` | WinUI3 MSIXパッケージアプリ（net10.0-windows） | Presentation層。ナビゲーション、ローカライズ、DI構成、コンテナ一覧/詳細/ログ/シェル表示、イメージ一覧/pull/削除、ボリューム一覧/作成/削除を実装済み |
+| `src/WslContainersDesktop.App` | WinUI3 MSIXパッケージアプリ（net10.0-windows） | Presentation層。ナビゲーション、ローカライズ、DI構成、コンテナ一覧/詳細/ログ/シェル表示、イメージ一覧/pull/削除、ボリューム一覧/作成/削除、ネットワーク一覧/作成/削除を実装済み |
 | `tests/WslContainersDesktop.Domain.Tests` | MSTest | Domain層の単体テスト |
 | `tests/WslContainersDesktop.Application.Tests` | MSTest | Application層の単体テスト |
 | `tests/WslContainersDesktop.Infrastructure.Tests` | MSTest | Infrastructure層のCLIクライアント/ランナー単体テスト |
-| `tests/WslContainersDesktop.App.Tests` | MSTest | Presentation層（ナビゲーション制御・コンテナ/イメージ/ボリューム一覧ViewModel）の単体テスト |
+| `tests/WslContainersDesktop.App.Tests` | MSTest | Presentation層（ナビゲーション制御・コンテナ/イメージ/ボリューム/ネットワーク一覧ViewModel）の単体テスト |
 
 現在の主要な振る舞いは、コンテナ一覧取得、起動・停止・再起動・削除、詳細情報表示、ログの
 スナップショット表示とライブ追跡、稼働中コンテナへの対話的execシェル、イメージ一覧取得、
-イメージpull、イメージ削除、ボリューム一覧取得、ボリューム作成、ボリューム削除である。
+イメージpull、イメージ削除、ボリューム一覧取得、ボリューム作成、ボリューム削除、
+ネットワーク一覧取得、ネットワーク作成、ネットワーク削除である。
 
 ## 層構成
 
@@ -54,6 +55,9 @@ flowchart TB
   表示名を`DisplayName`として提供する。
 - `ContainerVolume`はローカルボリュームの名前、ドライバー、作成日時、参照中コンテナ名を保持し、
   参照有無に応じた削除可否を提供する。
+- `ContainerNetworkResource`はコンテナーネットワークの名前、ドライバー、作成日時、
+  接続中コンテナ名、システムネットワークかどうかを保持し、接続有無とシステム種別に応じた
+  削除可否を提供する。
 
 ### Application
 
@@ -77,6 +81,10 @@ flowchart TB
 - `IVolumeManagementService`はPresentation層向けのInboundポートであり、ボリューム一覧取得、作成、
   削除を提供する。`VolumeManagementService`は一覧取得時にコンテナ詳細のマウント情報から参照中
   コンテナ名を推定し、削除前にも再評価して参照中ボリュームの削除を拒否する。
+- `INetworkManagementService`はPresentation層向けのInboundポートであり、ネットワーク一覧取得、作成、
+  削除を提供する。`NetworkManagementService`は一覧取得時にコンテナ詳細のネットワーク情報から接続中
+  コンテナ名を推定し、予約済みネットワーク名（`bridge`, `host`, `none`）をシステムネットワークとして
+  扱う。削除前にも再評価して、システムネットワークと接続中ネットワークの削除を拒否する。
 
 ### Infrastructure
 
@@ -95,6 +103,13 @@ flowchart TB
   `wslc volume inspect <name>`から作成日時を補完して`ContainerVolume`へ変換する。作成は
   `wslc volume create <name>`、削除は`wslc volume remove <name>`を呼び出す。削除時は強制削除フラグを
   付けず、ランタイム側の拒否はApplication/Presentation層へ伝播する。
+- ネットワーク一覧は`wslc network list --format json`のJSONを基点に、各ネットワークの
+  `wslc network inspect <name>`から取得できる詳細を補完して`ContainerNetworkResource`へ変換する。
+  作成日時が取得できない場合は未設定値として扱い、Presentation層では`Unknown`として表示する。
+  システムネットワーク判定は、ランタイムが返す種別情報とApplication層の予約済みネットワーク名
+  （`bridge`, `host`, `none`）の判定を組み合わせる。作成は`wslc network create <name>`、削除は
+  `wslc network remove <name>`を呼び出す。削除時は強制削除フラグを付けず、ランタイム側の拒否は
+  Application/Presentation層へ伝播する。
 - コンテナ詳細は`wslc container inspect <container-id>`のJSON配列を`ContainerDetail`へ変換する。
 - execシェルは`wslc container exec -i <container-id> /bin/sh`を対話プロセスとして起動する。
   標準入力はLFでコマンドを終端してフラッシュし、標準出力/標準エラーは行ではなくチャンク単位で
@@ -118,6 +133,7 @@ flowchart TB
   [`docs/design/containers-view.md`](containers-view.md) を参照。
 - イメージ一覧ViewModelの状態管理の詳細は [`docs/design/images-view.md`](images-view.md) を参照。
 - ボリューム一覧ViewModelの状態管理の詳細は [`docs/design/volumes-view.md`](volumes-view.md) を参照。
+- ネットワーク一覧ViewModelの状態管理の詳細は [`docs/design/networks-view.md`](networks-view.md) を参照。
 
 ## テスト戦略との対応
 

--- a/docs/design/networks-view.md
+++ b/docs/design/networks-view.md
@@ -1,0 +1,60 @@
+# Presentation層: ネットワーク一覧ViewModelの状態管理
+
+> このドキュメントは現時点のスナップショットです。経緯・検討過程は書きません。
+
+## 概要
+
+`NetworksViewModel`（`ViewModels/NetworksViewModel.cs`）は、コンテナーネットワーク一覧の取得、
+新規作成、不要ネットワークの削除を担うViewModel。Application層の`INetworkManagementService`にのみ
+依存し、`wslc` CLIの具体的な呼び出し方法には依存しない。
+
+## 一覧UI
+
+- `NetworksPage`はコンテナーネットワーク一覧を表示する。各行は`NetworkRowViewModel`で、ネットワーク名、
+  ドライバー、作成日時、接続コンテナ数、種別、使用状況、削除操作を表示する。
+- 作成日時がランタイムから取得できない場合は`Unknown`として表示する。
+- 使用状況は、接続中コンテナ名がある場合はコンテナ名をカンマ区切りで表示し、接続がない場合は
+  `Unused`として表示する。
+- 種別はシステムネットワークを`System`、ユーザー作成ネットワークを`User-created`として表示する。
+- 一覧行は`ListView`の幅いっぱいに横方向へ広げ、ヘッダー列と行内容の幅を揃える。
+- システムネットワークまたは接続中ネットワークの削除ボタンは無効化する。
+- ネットワークが存在しない場合は空状態テキストを表示する。
+- ユーザー作成ネットワークが存在しない場合は、システムネットワークは表示対象だが削除できないことを
+  `InfoBar`で表示する。
+
+## 更新とエラー表示
+
+- `RefreshAsync`は`INetworkManagementService.GetNetworksAsync`で最新状態を取得し、成功時に`Networks`を
+  全件置き換える。
+- 更新失敗時は既存の一覧を保持し、`ErrorMessage`に例外メッセージを設定する。
+- 新しい操作を開始する際は古い成功メッセージをクリアし、エラーと成功メッセージが矛盾して同時表示されない
+  ようにする。
+
+## 作成操作
+
+- `NewNetworkName`はユーザーが入力したネットワーク名を保持する。`NetworksPage`のTextBoxは
+  `Mode=TwoWay, UpdateSourceTrigger=PropertyChanged`でバインドする。
+- `NewNetworkName`が空または空白だけの場合、`CreateAsync`はApplication層を呼び出さず、入力必須エラーを
+  `ErrorMessage`として表示する。
+- `CreateAsync`は開始時に`IsCreating`を`true`にし、入力欄とCreateボタンを無効化し、
+  `ProgressRing`を表示する。
+- 作成成功後は`NewNetworkName`を空にし、成功メッセージを表示してから一覧を再取得する。
+- 作成失敗時は入力値と既存一覧を保持し、`ErrorMessage`に失敗理由を表示する。
+
+## 削除操作
+
+- `NetworksPage`の削除ボタンは、`ContentDialog`で確認を取ってから`NetworksViewModel.DeleteCommand`を
+  実行する。
+- `DeleteAsync`は対象行の`IsBusy`を`true`にして二重操作を防ぎ、成功時はライブの`Networks`から対象行を
+  取り除く。
+- `NetworkRowViewModel`がシステムネットワークとして保持している行に対してはApplication層を呼び出さず、
+  削除不可エラーを表示する。
+- `NetworkRowViewModel`が接続中として保持している行に対してはApplication層を呼び出さず、接続中
+  コンテナ名を含むエラーを表示する。
+- 削除直前のApplication層再評価でシステムネットワークと判定された場合は
+  `SystemNetworkDeletionException`を捕捉し、例外メッセージを表示する。
+- 削除直前のApplication層再評価で接続中と判定された場合は`NetworkInUseException`を捕捉し、
+  例外が保持する接続中コンテナ名をエラーとして表示する。
+- 削除は`wslc network remove <name>`に委譲され、強制削除フラグは付けない。ランタイム不調や
+  Application層で推定できない拒否は例外としてPresentation層へ伝播し、`ErrorMessage`に表示する。
+- 削除失敗時は対象行を一覧に残し、`IsBusy`を解除する。

--- a/docs/design/presentation-navigation.md
+++ b/docs/design/presentation-navigation.md
@@ -15,7 +15,7 @@ UI文字列はすべて `.resw` リソースに外出しされ、コードやXAM
 
 | 型 | 場所 | 役割 |
 |---|---|---|
-| `NavigationPageKey` | `Navigation/NavigationPageKey.cs` | ページを表す `enum`（`Containers`, `Images`, `Volumes`, `Settings`）。string/Tagベースの遷移は使わない。 |
+| `NavigationPageKey` | `Navigation/NavigationPageKey.cs` | ページを表す `enum`（`Containers`, `Images`, `Volumes`, `Networks`, `Settings`）。string/Tagベースの遷移は使わない。 |
 | `NavigationPageKeyExtensions.EnsureDefined` | `Navigation/NavigationPageKeyExtensions.cs` | `NavigationPageKey` が定義済みの値であることを検証する拡張メソッド。未定義値なら `ArgumentOutOfRangeException` を送出する。`NavigationPageRegistry`・`NavigationViewModel` の双方から共通利用する。 |
 | `NavigationPageRegistry` | `Navigation/NavigationPageRegistry.cs` | `NavigationPageKey → Page派生型` のマッピングを一元管理する、XAML非依存の素のC#クラス。 |
 | `NavigationViewModel` | `ViewModels/NavigationViewModel.cs` | 現在表示中のページキー（`CurrentPageKey`、setterはprivate）を保持するObservableObject。`NavigateToCommand`でのみ変更できる。 |
@@ -44,7 +44,8 @@ Composition Rootは`App.xaml.cs`に置く。`Microsoft.Extensions.DependencyInje
 `IContainerRuntimeClient`→`WslcCliContainerRuntimeClient`、
 `IContainerManagementService`→`ContainerManagementService`、
 `IImageManagementService`→`ImageManagementService`、
-`IVolumeManagementService`→`VolumeManagementService`、`IWslcCliRunner`→`WslcCliRunner`、
+`IVolumeManagementService`→`VolumeManagementService`、
+`INetworkManagementService`→`NetworkManagementService`、`IWslcCliRunner`→`WslcCliRunner`、
 `IUiDispatcher`→`DispatcherQueueUiDispatcher`を登録する。
 
 トップレベルページは`Frame.Navigate(Type)`から生成されるためパラメーターレスコンストラクタを持つ。

--- a/src/WslContainersDesktop.App/App.xaml.cs
+++ b/src/WslContainersDesktop.App/App.xaml.cs
@@ -51,6 +51,7 @@ public partial class App : Application
         services.AddSingleton<IContainerManagementService, ContainerManagementService>();
         services.AddSingleton<IImageManagementService, ImageManagementService>();
         services.AddSingleton<IVolumeManagementService, VolumeManagementService>();
+        services.AddSingleton<INetworkManagementService, NetworkManagementService>();
         services.AddSingleton<IUiDispatcher>(_ => new DispatcherQueueUiDispatcher(DispatcherQueue.GetForCurrentThread()));
 
         // トップレベルページのViewModelはNavigationViewModelと同様、アプリケーション
@@ -58,6 +59,7 @@ public partial class App : Application
         services.AddSingleton<ContainersViewModel>();
         services.AddSingleton<ImagesViewModel>();
         services.AddSingleton<VolumesViewModel>();
+        services.AddSingleton<NetworksViewModel>();
 
         return services.BuildServiceProvider();
     }

--- a/src/WslContainersDesktop.App/MainWindow.xaml
+++ b/src/WslContainersDesktop.App/MainWindow.xaml
@@ -61,6 +61,14 @@
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
                 <NavigationViewItem
+                    x:Name="NavItemNetworks"
+                    x:Uid="NavItemNetworks"
+                    AutomationProperties.AutomationId="NavItemNetworks">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="&#xE774;" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+                <NavigationViewItem
                     x:Name="NavItemSettings"
                     x:Uid="NavItemSettings"
                     AutomationProperties.AutomationId="NavItemSettings">

--- a/src/WslContainersDesktop.App/MainWindow.xaml.cs
+++ b/src/WslContainersDesktop.App/MainWindow.xaml.cs
@@ -34,6 +34,7 @@ public sealed partial class MainWindow : Window
             [NavItemContainers] = NavigationPageKey.Containers,
             [NavItemImages] = NavigationPageKey.Images,
             [NavItemVolumes] = NavigationPageKey.Volumes,
+            [NavItemNetworks] = NavigationPageKey.Networks,
             [NavItemSettings] = NavigationPageKey.Settings,
         };
 

--- a/src/WslContainersDesktop.App/Navigation/NavigationPageKey.cs
+++ b/src/WslContainersDesktop.App/Navigation/NavigationPageKey.cs
@@ -17,6 +17,9 @@ public enum NavigationPageKey
     /// <summary>コンテナーボリューム一覧ページ。</summary>
     Volumes,
 
+    /// <summary>コンテナーネットワーク一覧ページ。</summary>
+    Networks,
+
     /// <summary>設定ページ。</summary>
     Settings,
 }

--- a/src/WslContainersDesktop.App/Navigation/NavigationPageRegistry.cs
+++ b/src/WslContainersDesktop.App/Navigation/NavigationPageRegistry.cs
@@ -25,6 +25,7 @@ public static class NavigationPageRegistry
             NavigationPageKey.Containers => typeof(ContainersPage),
             NavigationPageKey.Images => typeof(ImagesPage),
             NavigationPageKey.Volumes => typeof(VolumesPage),
+            NavigationPageKey.Networks => typeof(NetworksPage),
             NavigationPageKey.Settings => typeof(SettingsPage),
             _ => throw new ArgumentOutOfRangeException(nameof(pageKey), pageKey, "未定義のNavigationPageKeyです。"),
         };

--- a/src/WslContainersDesktop.App/Pages/ImagesPage.xaml
+++ b/src/WslContainersDesktop.App/Pages/ImagesPage.xaml
@@ -33,17 +33,22 @@
             CornerRadius="{StaticResource OverlayCornerRadius}">
             <Grid ColumnSpacing="16">
                 <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="4" />
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
-                <StackPanel Grid.Column="0">
+                <Border
+                    Grid.Column="0"
+                    Background="{ThemeResource WslContainersAccentFillColorDefaultBrush}"
+                    CornerRadius="{StaticResource ControlCornerRadius}" />
+                <StackPanel Grid.Column="1">
                     <TextBlock x:Name="TxtImagesPageTitle" x:Uid="ImagesPageTitle" Style="{StaticResource TitleTextBlockStyle}" />
                     <TextBlock x:Name="TxtImagesPageDescription" x:Uid="ImagesPageDescription" />
                 </StackPanel>
                 <Button
                     x:Name="BtnRefreshImages"
                     x:Uid="BtnRefreshImages"
-                    Grid.Column="1"
+                    Grid.Column="2"
                     VerticalAlignment="Bottom"
                     AutomationProperties.AutomationId="BtnRefreshImages"
                     Command="{x:Bind ViewModel.RefreshCommand}" />
@@ -90,37 +95,70 @@
         </StackPanel>
 
         <Grid Grid.Row="3">
-            <ListView
-                x:Name="LstImages"
-                AutomationProperties.AutomationId="LstImages"
-                ItemsSource="{x:Bind ViewModel.Images, Mode=OneWay}"
-                SelectionMode="None"
+            <Border
+                Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                BorderThickness="{ThemeResource WslContainersSurfaceBorderThickness}"
+                CornerRadius="{StaticResource OverlayCornerRadius}"
                 Visibility="{x:Bind ToVisibleWhenFalse(ViewModel.IsEmpty), Mode=OneWay}">
-                <ListView.ItemTemplate>
-                    <DataTemplate x:DataType="vm:ImageRowViewModel">
-                        <Grid Padding="8" ColumnSpacing="12">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="2*" />
-                                <ColumnDefinition Width="2*" />
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="Auto" />
-                            </Grid.ColumnDefinitions>
-                            <TextBlock Grid.Column="0" VerticalAlignment="Center" Text="{x:Bind DisplayName}" />
-                            <TextBlock Grid.Column="1" VerticalAlignment="Center" Text="{x:Bind Id}" />
-                            <TextBlock Grid.Column="2" VerticalAlignment="Center" Text="{x:Bind SizeBytes}" />
-                            <TextBlock Grid.Column="3" VerticalAlignment="Center" Text="{x:Bind CreatedAt, Converter={StaticResource CreatedAtConverter}}" />
-                            <Button
-                                x:Uid="BtnDeleteImage"
-                                Grid.Column="4"
-                                VerticalAlignment="Center"
-                                AutomationProperties.AutomationId="{x:Bind Id, Mode=OneWay, Converter={StaticResource AutomationIdConverter}, ConverterParameter=BtnDeleteImage}"
-                                CommandParameter="{x:Bind}"
-                                Click="BtnDeleteImage_Click" />
-                        </Grid>
-                    </DataTemplate>
-                </ListView.ItemTemplate>
-            </ListView>
+                <Grid RowSpacing="4">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+
+                    <Grid Grid.Row="0" Padding="12,8" ColumnSpacing="12">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="2*" />
+                            <ColumnDefinition Width="2*" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock x:Name="TxtImageColumnName" x:Uid="TxtImageColumnName" Grid.Column="0" FontWeight="SemiBold" />
+                        <TextBlock x:Name="TxtImageColumnId" x:Uid="TxtImageColumnId" Grid.Column="1" FontWeight="SemiBold" />
+                        <TextBlock x:Name="TxtImageColumnSize" x:Uid="TxtImageColumnSize" Grid.Column="2" FontWeight="SemiBold" />
+                        <TextBlock x:Name="TxtImageColumnCreatedAt" x:Uid="TxtImageColumnCreatedAt" Grid.Column="3" FontWeight="SemiBold" />
+                    </Grid>
+
+                    <ListView
+                        x:Name="LstImages"
+                        Grid.Row="1"
+                        AutomationProperties.AutomationId="LstImages"
+                        ItemsSource="{x:Bind ViewModel.Images, Mode=OneWay}"
+                        SelectionMode="None">
+                        <ListView.ItemContainerStyle>
+                            <Style TargetType="ListViewItem">
+                                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                            </Style>
+                        </ListView.ItemContainerStyle>
+                        <ListView.ItemTemplate>
+                            <DataTemplate x:DataType="vm:ImageRowViewModel">
+                                <Grid Padding="8" ColumnSpacing="12" HorizontalAlignment="Stretch">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="2*" />
+                                        <ColumnDefinition Width="2*" />
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" VerticalAlignment="Center" Text="{x:Bind DisplayName}" />
+                                    <TextBlock Grid.Column="1" VerticalAlignment="Center" Text="{x:Bind Id}" />
+                                    <TextBlock Grid.Column="2" VerticalAlignment="Center" Text="{x:Bind SizeBytes}" />
+                                    <TextBlock Grid.Column="3" VerticalAlignment="Center" Text="{x:Bind CreatedAt, Converter={StaticResource CreatedAtConverter}}" />
+                                    <Button
+                                        x:Uid="BtnDeleteImage"
+                                        Grid.Column="4"
+                                        VerticalAlignment="Center"
+                                        AutomationProperties.AutomationId="{x:Bind Id, Mode=OneWay, Converter={StaticResource AutomationIdConverter}, ConverterParameter=BtnDeleteImage}"
+                                        CommandParameter="{x:Bind}"
+                                        Click="BtnDeleteImage_Click" />
+                                </Grid>
+                            </DataTemplate>
+                        </ListView.ItemTemplate>
+                    </ListView>
+                </Grid>
+            </Border>
 
             <TextBlock
                 x:Name="TxtImagesEmptyState"

--- a/src/WslContainersDesktop.App/Pages/NetworksPage.xaml
+++ b/src/WslContainersDesktop.App/Pages/NetworksPage.xaml
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Page
+    x:Class="WslContainersDesktop_App.Pages.NetworksPage"
+    x:Name="RootPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:conv="using:WslContainersDesktop_App.Converters"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:WslContainersDesktop_App.Pages"
+    xmlns:vm="using:WslContainersDesktop_App.ViewModels"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Page.Resources>
+        <conv:AutomationIdConverter x:Key="AutomationIdConverter" />
+    </Page.Resources>
+
+    <Grid Padding="24,16,24,16" RowSpacing="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <Border
+            Grid.Row="0"
+            Padding="16"
+            Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+            BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+            BorderThickness="{ThemeResource WslContainersSurfaceBorderThickness}"
+            CornerRadius="{StaticResource OverlayCornerRadius}">
+            <Grid ColumnSpacing="16">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="4" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <Border
+                    Grid.Column="0"
+                    Background="{ThemeResource WslContainersAccentFillColorDefaultBrush}"
+                    CornerRadius="{StaticResource ControlCornerRadius}" />
+                <StackPanel Grid.Column="1">
+                    <TextBlock x:Name="TxtNetworksPageTitle" x:Uid="NetworksPageTitle" Style="{StaticResource TitleTextBlockStyle}" />
+                    <TextBlock x:Name="TxtNetworksPageDescription" x:Uid="NetworksPageDescription" />
+                </StackPanel>
+                <Button
+                    x:Name="BtnRefreshNetworks"
+                    x:Uid="BtnRefreshNetworks"
+                    Grid.Column="2"
+                    VerticalAlignment="Bottom"
+                    AutomationProperties.AutomationId="BtnRefreshNetworks"
+                    Command="{x:Bind ViewModel.RefreshCommand}" />
+            </Grid>
+        </Border>
+
+        <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="8">
+            <TextBox
+                x:Name="TxtNewNetworkName"
+                x:Uid="TxtNewNetworkName"
+                Width="320"
+                AutomationProperties.AutomationId="TxtNewNetworkName"
+                IsEnabled="{x:Bind ViewModel.CanCreate, Mode=OneWay}"
+                Text="{x:Bind ViewModel.NewNetworkName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+            <Button
+                x:Name="BtnCreateNetwork"
+                x:Uid="BtnCreateNetwork"
+                VerticalAlignment="Bottom"
+                AutomationProperties.AutomationId="BtnCreateNetwork"
+                Command="{x:Bind ViewModel.CreateCommand}"
+                IsEnabled="{x:Bind ViewModel.CanCreate, Mode=OneWay}" />
+            <ProgressRing
+                x:Name="PrgCreateNetwork"
+                Width="24"
+                Height="24"
+                AutomationProperties.AutomationId="PrgCreateNetwork"
+                IsActive="{x:Bind ViewModel.IsCreating, Mode=OneWay}"
+                Visibility="{x:Bind ToVisibleWhenTrue(ViewModel.IsCreating), Mode=OneWay}" />
+        </StackPanel>
+
+        <StackPanel Grid.Row="2" Spacing="8">
+            <InfoBar
+                x:Name="InfoBarNetworkError"
+                Severity="Error"
+                IsClosable="False"
+                IsOpen="{x:Bind ViewModel.IsErrorMessageVisible, Mode=OneWay}"
+                Message="{x:Bind ViewModel.ErrorMessage, Mode=OneWay}" />
+            <InfoBar
+                x:Name="InfoBarNetworkStatus"
+                Severity="Success"
+                IsClosable="False"
+                IsOpen="{x:Bind ViewModel.IsStatusMessageVisible, Mode=OneWay}"
+                Message="{x:Bind ViewModel.StatusMessage, Mode=OneWay}" />
+        </StackPanel>
+
+        <Grid Grid.Row="3" RowSpacing="8">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+
+            <InfoBar
+                x:Name="InfoBarNoUserNetworks"
+                x:Uid="InfoBarNoUserNetworks"
+                Grid.Row="0"
+                Severity="Informational"
+                IsClosable="False"
+                IsOpen="{x:Bind ViewModel.IsNoUserNetworksInfoVisible, Mode=OneWay}" />
+
+            <Grid Grid.Row="1">
+                <Border
+                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="{ThemeResource WslContainersSurfaceBorderThickness}"
+                    CornerRadius="{StaticResource OverlayCornerRadius}"
+                    Visibility="{x:Bind ToVisibleWhenTrue(ViewModel.HasNetworks), Mode=OneWay}">
+                    <Grid RowSpacing="4">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+
+                        <Grid Grid.Row="0" Padding="12,8" ColumnSpacing="12">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="180" />
+                                <ColumnDefinition Width="120" />
+                                <ColumnDefinition Width="180" />
+                                <ColumnDefinition Width="96" />
+                                <ColumnDefinition Width="120" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock x:Name="TxtNetworkColumnName" x:Uid="TxtNetworkColumnName" Grid.Column="0" FontWeight="SemiBold" />
+                            <TextBlock x:Name="TxtNetworkColumnDriver" x:Uid="TxtNetworkColumnDriver" Grid.Column="1" FontWeight="SemiBold" />
+                            <TextBlock x:Name="TxtNetworkColumnCreatedAt" x:Uid="TxtNetworkColumnCreatedAt" Grid.Column="2" FontWeight="SemiBold" />
+                            <TextBlock x:Name="TxtNetworkColumnContainers" x:Uid="TxtNetworkColumnContainers" Grid.Column="3" FontWeight="SemiBold" />
+                            <TextBlock x:Name="TxtNetworkColumnType" x:Uid="TxtNetworkColumnType" Grid.Column="4" FontWeight="SemiBold" />
+                            <TextBlock x:Name="TxtNetworkColumnUsage" x:Uid="TxtNetworkColumnUsage" Grid.Column="5" FontWeight="SemiBold" />
+                        </Grid>
+
+                        <ListView
+                            x:Name="LstNetworks"
+                            Grid.Row="1"
+                            AutomationProperties.AutomationId="LstNetworks"
+                            ItemsSource="{x:Bind ViewModel.Networks, Mode=OneWay}"
+                            SelectionMode="None">
+                            <ListView.ItemContainerStyle>
+                                <Style TargetType="ListViewItem">
+                                    <!-- HorizontalContentAlignment="Stretch" lets each row fill the ListView width. -->
+                                    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                                </Style>
+                            </ListView.ItemContainerStyle>
+                            <ListView.ItemTemplate>
+                                <DataTemplate x:DataType="vm:NetworkRowViewModel">
+                                    <Grid Padding="8" ColumnSpacing="12" HorizontalAlignment="Stretch">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="180" />
+                                            <ColumnDefinition Width="120" />
+                                            <ColumnDefinition Width="180" />
+                                            <ColumnDefinition Width="96" />
+                                            <ColumnDefinition Width="120" />
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Grid.Column="0" VerticalAlignment="Center" Text="{x:Bind Name}" />
+                                        <TextBlock Grid.Column="1" VerticalAlignment="Center" Text="{x:Bind Driver}" />
+                                        <TextBlock Grid.Column="2" VerticalAlignment="Center" Text="{x:Bind CreatedAtText}" />
+                                        <TextBlock Grid.Column="3" VerticalAlignment="Center" Text="{x:Bind ConnectedContainerCountText}" />
+                                        <TextBlock Grid.Column="4" VerticalAlignment="Center" Text="{x:Bind TypeText}" />
+                                        <TextBlock Grid.Column="5" VerticalAlignment="Center" Text="{x:Bind UsageText}" />
+                                        <Button
+                                            x:Name="BtnDeleteNetwork"
+                                            x:Uid="BtnDeleteNetwork"
+                                            Grid.Column="6"
+                                            VerticalAlignment="Center"
+                                            AutomationProperties.AutomationId="{x:Bind Name, Mode=OneWay, Converter={StaticResource AutomationIdConverter}, ConverterParameter=BtnDeleteNetwork}"
+                                            CommandParameter="{x:Bind}"
+                                            Click="BtnDeleteNetwork_Click"
+                                            IsEnabled="{x:Bind CanDelete, Mode=OneWay}" />
+                                    </Grid>
+                                </DataTemplate>
+                            </ListView.ItemTemplate>
+                        </ListView>
+                    </Grid>
+                </Border>
+
+                <Border
+                    x:Name="BorderNetworksEmptyState"
+                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="{ThemeResource WslContainersSurfaceBorderThickness}"
+                    CornerRadius="{StaticResource OverlayCornerRadius}"
+                    Visibility="{x:Bind ToVisibleWhenFalse(ViewModel.HasNetworks), Mode=OneWay}">
+                    <TextBlock
+                        x:Name="TxtNetworksEmptyState"
+                        x:Uid="TxtNetworksEmptyState"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center" />
+                </Border>
+            </Grid>
+        </Grid>
+    </Grid>
+</Page>

--- a/src/WslContainersDesktop.App/Pages/NetworksPage.xaml.cs
+++ b/src/WslContainersDesktop.App/Pages/NetworksPage.xaml.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using WslContainersDesktop_App.ViewModels;
+using Windows.ApplicationModel.Resources;
+
+namespace WslContainersDesktop_App.Pages;
+
+/// <summary>
+/// コンテナーネットワーク一覧ページ。
+/// </summary>
+public sealed partial class NetworksPage : Page
+{
+    private readonly ResourceLoader _resourceLoader = new();
+
+    /// <summary>
+    /// <see cref="NetworksPage"/> の新しいインスタンスを初期化する。
+    /// </summary>
+    public NetworksPage()
+    {
+        ViewModel = ((App)Application.Current).Services.GetRequiredService<NetworksViewModel>();
+
+        InitializeComponent();
+
+        Loaded += NetworksPage_Loaded;
+    }
+
+    /// <summary>
+    /// ページのViewModel。
+    /// </summary>
+    public NetworksViewModel ViewModel { get; }
+
+    private async void NetworksPage_Loaded(object sender, RoutedEventArgs e)
+    {
+        await ViewModel.RefreshCommand.ExecuteAsync(null);
+    }
+
+    private async void BtnDeleteNetwork_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button { CommandParameter: NetworkRowViewModel row })
+        {
+            return;
+        }
+
+        var dialog = new ContentDialog
+        {
+            XamlRoot = XamlRoot,
+            Title = _resourceLoader.GetString("DeleteNetworkConfirmationDialog_Title"),
+            Content = string.Format(_resourceLoader.GetString("DeleteNetworkConfirmationDialog_Message"), row.Name),
+            PrimaryButtonText = _resourceLoader.GetString("DeleteNetworkConfirmationDialog_PrimaryButtonText"),
+            CloseButtonText = _resourceLoader.GetString("DeleteNetworkConfirmationDialog_CloseButtonText"),
+            DefaultButton = ContentDialogButton.Close,
+        };
+
+        var result = await dialog.ShowAsync();
+        if (result == ContentDialogResult.Primary)
+        {
+            await ViewModel.DeleteCommand.ExecuteAsync(row);
+        }
+    }
+
+    /// <summary>
+    /// x:Bind用のbool→Visibility変換関数。値がtrueのとき表示する。
+    /// </summary>
+    /// <param name="value">変換元の値。</param>
+    /// <returns>対応する <see cref="Visibility"/>。</returns>
+    public Visibility ToVisibleWhenTrue(bool value) => value ? Visibility.Visible : Visibility.Collapsed;
+
+    /// <summary>
+    /// x:Bind用のbool→Visibility変換関数。値がfalseのとき表示する。
+    /// </summary>
+    /// <param name="value">変換元の値。</param>
+    /// <returns>対応する <see cref="Visibility"/>。</returns>
+    public Visibility ToVisibleWhenFalse(bool value) => value ? Visibility.Collapsed : Visibility.Visible;
+}

--- a/src/WslContainersDesktop.App/Pages/VolumesPage.xaml
+++ b/src/WslContainersDesktop.App/Pages/VolumesPage.xaml
@@ -32,17 +32,22 @@
             CornerRadius="{StaticResource OverlayCornerRadius}">
             <Grid ColumnSpacing="16">
                 <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="4" />
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
-                <StackPanel Grid.Column="0">
+                <Border
+                    Grid.Column="0"
+                    Background="{ThemeResource WslContainersAccentFillColorDefaultBrush}"
+                    CornerRadius="{StaticResource ControlCornerRadius}" />
+                <StackPanel Grid.Column="1">
                     <TextBlock x:Name="TxtVolumesPageTitle" x:Uid="VolumesPageTitle" Style="{StaticResource TitleTextBlockStyle}" />
                     <TextBlock x:Name="TxtVolumesPageDescription" x:Uid="VolumesPageDescription" />
                 </StackPanel>
                 <Button
                     x:Name="BtnRefreshVolumes"
                     x:Uid="BtnRefreshVolumes"
-                    Grid.Column="1"
+                    Grid.Column="2"
                     VerticalAlignment="Bottom"
                     AutomationProperties.AutomationId="BtnRefreshVolumes"
                     Command="{x:Bind ViewModel.RefreshCommand}" />

--- a/src/WslContainersDesktop.App/Strings/en-US/Resources.resw
+++ b/src/WslContainersDesktop.App/Strings/en-US/Resources.resw
@@ -132,6 +132,9 @@
   <data name="NavItemVolumes.Content" xml:space="preserve">
     <value>Volumes</value>
   </data>
+  <data name="NavItemNetworks.Content" xml:space="preserve">
+    <value>Networks</value>
+  </data>
   <data name="NavItemSettings.Content" xml:space="preserve">
     <value>Settings</value>
   </data>
@@ -264,6 +267,18 @@
   <data name="TxtImagesEmptyState.Text" xml:space="preserve">
     <value>No images.</value>
   </data>
+  <data name="TxtImageColumnName.Text" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="TxtImageColumnId.Text" xml:space="preserve">
+    <value>ID</value>
+  </data>
+  <data name="TxtImageColumnSize.Text" xml:space="preserve">
+    <value>Size</value>
+  </data>
+  <data name="TxtImageColumnCreatedAt.Text" xml:space="preserve">
+    <value>Created</value>
+  </data>
   <data name="VolumesPageTitle.Text" xml:space="preserve">
     <value>Volumes</value>
   </data>
@@ -296,6 +311,51 @@
   </data>
   <data name="TxtVolumesEmptyState.Text" xml:space="preserve">
     <value>No volumes.</value>
+  </data>
+  <data name="NetworksPageTitle.Text" xml:space="preserve">
+    <value>Networks</value>
+  </data>
+  <data name="NetworksPageDescription.Text" xml:space="preserve">
+    <value>Create and remove container networks.</value>
+  </data>
+  <data name="BtnRefreshNetworks.Content" xml:space="preserve">
+    <value>Refresh</value>
+  </data>
+  <data name="TxtNewNetworkName.Header" xml:space="preserve">
+    <value>Network name</value>
+  </data>
+  <data name="BtnCreateNetwork.Content" xml:space="preserve">
+    <value>Create</value>
+  </data>
+  <data name="InfoBarNoUserNetworks.Title" xml:space="preserve">
+    <value>No user-created networks</value>
+  </data>
+  <data name="InfoBarNoUserNetworks.Message" xml:space="preserve">
+    <value>System networks are shown and cannot be deleted.</value>
+  </data>
+  <data name="TxtNetworkColumnName.Text" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="TxtNetworkColumnDriver.Text" xml:space="preserve">
+    <value>Driver</value>
+  </data>
+  <data name="TxtNetworkColumnCreatedAt.Text" xml:space="preserve">
+    <value>Created</value>
+  </data>
+  <data name="TxtNetworkColumnContainers.Text" xml:space="preserve">
+    <value>Containers</value>
+  </data>
+  <data name="TxtNetworkColumnType.Text" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="TxtNetworkColumnUsage.Text" xml:space="preserve">
+    <value>Usage</value>
+  </data>
+  <data name="BtnDeleteNetwork.Content" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="TxtNetworksEmptyState.Text" xml:space="preserve">
+    <value>No networks.</value>
   </data>
   <data name="ContainerState_Running" xml:space="preserve">
     <value>Running</value>
@@ -349,6 +409,18 @@
     <value>Delete</value>
   </data>
   <data name="DeleteVolumeConfirmationDialog_CloseButtonText" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="DeleteNetworkConfirmationDialog_Title" xml:space="preserve">
+    <value>Delete network</value>
+  </data>
+  <data name="DeleteNetworkConfirmationDialog_Message" xml:space="preserve">
+    <value>Are you sure you want to delete network '{0}'? This action cannot be undone.</value>
+  </data>
+  <data name="DeleteNetworkConfirmationDialog_PrimaryButtonText" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="DeleteNetworkConfirmationDialog_CloseButtonText" xml:space="preserve">
     <value>Cancel</value>
   </data>
   <data name="SettingsPageTitle.Text" xml:space="preserve">

--- a/src/WslContainersDesktop.App/ViewModels/NetworkRowViewModel.cs
+++ b/src/WslContainersDesktop.App/ViewModels/NetworkRowViewModel.cs
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using WslContainersDesktop.Domain;
+
+namespace WslContainersDesktop_App.ViewModels;
+
+/// <summary>
+/// XAMLバインディング用に <see cref="ContainerNetworkResource"/> をラップする行ViewModel。
+/// </summary>
+public sealed partial class NetworkRowViewModel : ObservableObject
+{
+    /// <summary>
+    /// <see cref="NetworkRowViewModel"/> の新しいインスタンスを初期化する。
+    /// </summary>
+    /// <param name="network">初期状態の元となるコンテナーネットワーク。</param>
+    public NetworkRowViewModel(ContainerNetworkResource network)
+    {
+        Name = network.Name;
+        Driver = network.Driver;
+        CreatedAt = network.CreatedAt;
+        ConnectedContainerNames = network.ConnectedContainerNames;
+        ConnectedContainerCount = network.ConnectedContainerCount;
+        IsSystem = network.IsSystem;
+        IsInUse = network.IsInUse;
+    }
+
+    /// <summary>
+    /// ネットワーク名。
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// ネットワークドライバー名。
+    /// </summary>
+    public string Driver { get; }
+
+    /// <summary>
+    /// 作成日時。
+    /// </summary>
+    public DateTimeOffset CreatedAt { get; }
+
+    /// <summary>
+    /// 作成日時の表示用テキスト。
+    /// </summary>
+    public string CreatedAtText => CreatedAt == DateTimeOffset.MinValue
+        ? "Unknown"
+        : CreatedAt.ToString("u", System.Globalization.CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// このネットワークに接続しているコンテナ名の一覧。
+    /// </summary>
+    public IReadOnlyList<string> ConnectedContainerNames { get; }
+
+    /// <summary>
+    /// このネットワークに接続しているコンテナ数。
+    /// </summary>
+    public int ConnectedContainerCount { get; }
+
+    /// <summary>
+    /// 接続コンテナ数の表示用テキスト。
+    /// </summary>
+    public string ConnectedContainerCountText => ConnectedContainerCount.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// システムネットワークかどうか。
+    /// </summary>
+    public bool IsSystem { get; }
+
+    /// <summary>
+    /// ネットワークがいずれかのコンテナから使用されているかどうか。
+    /// </summary>
+    public bool IsInUse { get; }
+
+    /// <summary>
+    /// ネットワークを削除できるかどうか。
+    /// </summary>
+    public bool CanDelete => !IsSystem && !IsInUse && !IsBusy;
+
+    /// <summary>
+    /// 使用状況の表示用テキスト。
+    /// </summary>
+    public string UsageText => IsInUse ? string.Join(", ", ConnectedContainerNames) : "Unused";
+
+    /// <summary>
+    /// 種別の表示用テキスト。
+    /// </summary>
+    public string TypeText => IsSystem ? "System" : "User-created";
+
+    /// <summary>
+    /// この行に対する操作が進行中かどうか。
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanDelete))]
+    public partial bool IsBusy { get; set; }
+}

--- a/src/WslContainersDesktop.App/ViewModels/NetworksViewModel.cs
+++ b/src/WslContainersDesktop.App/ViewModels/NetworksViewModel.cs
@@ -1,0 +1,239 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using WslContainersDesktop.Application.Exceptions;
+using WslContainersDesktop.Application.Ports;
+using WslContainersDesktop.Domain;
+
+namespace WslContainersDesktop_App.ViewModels;
+
+/// <summary>
+/// コンテナーネットワーク一覧の表示・操作を管理するViewModel。
+/// </summary>
+public sealed partial class NetworksViewModel(INetworkManagementService networkManagementService) : ObservableObject
+{
+    private const string CreatingStatusMessage = "Creating network...";
+    private const string CreateCompletedStatusMessage = "Network created.";
+    private const string EmptyNetworkNameMessage = "Network name is required.";
+
+    /// <summary>
+    /// 現在表示中のコンテナーネットワーク一覧。
+    /// </summary>
+    public ObservableCollection<NetworkRowViewModel> Networks { get; } = [];
+
+    /// <summary>
+    /// 作成する新しいネットワーク名。
+    /// </summary>
+    [ObservableProperty]
+    public partial string NewNetworkName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 直近の操作で発生したエラーメッセージ。エラーがない場合は <see langword="null"/>。
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsErrorMessageVisible))]
+    public partial string? ErrorMessage { get; private set; }
+
+    /// <summary>
+    /// 直近の成功操作を表すステータスメッセージ。
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsStatusMessageVisible))]
+    public partial string? StatusMessage { get; private set; }
+
+    /// <summary>
+    /// エラーメッセージを表示するかどうか。
+    /// </summary>
+    public bool IsErrorMessageVisible => !string.IsNullOrEmpty(ErrorMessage);
+
+    /// <summary>
+    /// 成功または進行中ステータスメッセージを表示するかどうか。
+    /// </summary>
+    public bool IsStatusMessageVisible => !string.IsNullOrEmpty(StatusMessage);
+
+    /// <summary>
+    /// ネットワーク作成操作が進行中かどうか。
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanCreate))]
+    public partial bool IsCreating { get; private set; }
+
+    /// <summary>
+    /// ネットワーク作成操作を開始できるかどうか。
+    /// </summary>
+    public bool CanCreate => !IsCreating;
+
+    /// <summary>
+    /// 表示対象のネットワークが存在するかどうか。
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsNoUserNetworksInfoVisible))]
+    public partial bool HasNetworks { get; private set; }
+
+    /// <summary>
+    /// ユーザー作成ネットワークが存在しないかどうか。
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsNoUserNetworksInfoVisible))]
+    public partial bool HasNoUserNetworks { get; private set; } = true;
+
+    /// <summary>
+    /// ユーザー作成ネットワークが存在しないことを示す情報バーを表示するかどうか。
+    /// </summary>
+    public bool IsNoUserNetworksInfoVisible => HasNetworks && HasNoUserNetworks;
+
+    /// <summary>
+    /// コンテナーネットワーク一覧を手動で再取得する。
+    /// </summary>
+    [RelayCommand]
+    public async Task RefreshAsync()
+    {
+        StatusMessage = null;
+        try
+        {
+            var networks = await networkManagementService.GetNetworksAsync();
+            ReplaceNetworks(networks);
+            ErrorMessage = null;
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = ex.Message;
+            StatusMessage = null;
+        }
+    }
+
+    /// <summary>
+    /// 入力されたネットワーク名で新しいネットワークを作成し、成功後に一覧を再取得する。
+    /// </summary>
+    [RelayCommand]
+    public async Task CreateAsync()
+    {
+        var networkName = NewNetworkName.Trim();
+        StatusMessage = null;
+        ErrorMessage = null;
+        if (networkName.Length == 0)
+        {
+            ErrorMessage = EmptyNetworkNameMessage;
+            return;
+        }
+
+        StatusMessage = CreatingStatusMessage;
+        IsCreating = true;
+        try
+        {
+            var created = await networkManagementService.CreateAsync(networkName);
+            NewNetworkName = string.Empty;
+            StatusMessage = CreateCompletedStatusMessage;
+            ErrorMessage = null;
+            await RefreshNetworksAfterCreateAsync(created);
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = ex.Message;
+            StatusMessage = null;
+        }
+        finally
+        {
+            IsCreating = false;
+        }
+    }
+
+    /// <summary>
+    /// 指定したコンテナーネットワークを削除する。
+    /// </summary>
+    /// <param name="row">対象の行。</param>
+    [RelayCommand]
+    public async Task DeleteAsync(NetworkRowViewModel row)
+    {
+        StatusMessage = null;
+        if (row.IsSystem)
+        {
+            ErrorMessage = FormatSystemNetworkMessage(row.Name);
+            return;
+        }
+
+        if (row.IsInUse)
+        {
+            ErrorMessage = FormatInUseMessage(row.Name, row.ConnectedContainerNames);
+            return;
+        }
+
+        row.IsBusy = true;
+        try
+        {
+            await networkManagementService.DeleteAsync(row.Name);
+            var liveRow = Networks.FirstOrDefault(network => network.Name == row.Name);
+            if (liveRow is not null)
+            {
+                liveRow.IsBusy = false;
+                Networks.Remove(liveRow);
+            }
+            else
+            {
+                row.IsBusy = false;
+            }
+
+            UpdateNetworkFlags();
+            ErrorMessage = null;
+        }
+        catch (NetworkInUseException ex)
+        {
+            row.IsBusy = false;
+            ErrorMessage = FormatInUseMessage(ex.NetworkName, ex.ConnectedContainerNames);
+        }
+        catch (SystemNetworkDeletionException ex)
+        {
+            row.IsBusy = false;
+            ErrorMessage = ex.Message;
+        }
+        catch (Exception ex)
+        {
+            row.IsBusy = false;
+            ErrorMessage = ex.Message;
+        }
+    }
+
+    private async Task RefreshNetworksAfterCreateAsync(ContainerNetworkResource created)
+    {
+        try
+        {
+            var networks = await networkManagementService.GetNetworksAsync();
+            ReplaceNetworks(networks.Count == 0 ? [created] : networks);
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = ex.Message;
+            StatusMessage = null;
+        }
+    }
+
+    private void ReplaceNetworks(IReadOnlyList<ContainerNetworkResource> networks)
+    {
+        Networks.Clear();
+        foreach (var network in networks)
+        {
+            Networks.Add(new NetworkRowViewModel(network));
+        }
+
+        UpdateNetworkFlags();
+    }
+
+    private void UpdateNetworkFlags()
+    {
+        HasNetworks = Networks.Count > 0;
+        HasNoUserNetworks = !Networks.Any(network => !network.IsSystem);
+    }
+
+    private static string FormatInUseMessage(string networkName, IReadOnlyList<string> connectedContainerNames)
+    {
+        return $"Network '{networkName}' is in use by: {string.Join(", ", connectedContainerNames)}";
+    }
+
+    private static string FormatSystemNetworkMessage(string networkName)
+    {
+        return $"Network '{networkName}' is a system network and cannot be deleted.";
+    }
+}

--- a/src/WslContainersDesktop.Application/Exceptions/NetworkInUseException.cs
+++ b/src/WslContainersDesktop.Application/Exceptions/NetworkInUseException.cs
@@ -1,0 +1,29 @@
+namespace WslContainersDesktop.Application.Exceptions;
+
+/// <summary>
+/// 接続中のコンテナーが存在するネットワークに対して削除が要求されたことを表す例外。
+/// </summary>
+public sealed class NetworkInUseException : ContainerManagementException
+{
+    /// <summary>
+    /// <see cref="NetworkInUseException"/> の新しいインスタンスを初期化する。
+    /// </summary>
+    /// <param name="networkName">削除対象のネットワーク名。</param>
+    /// <param name="connectedContainerNames">対象ネットワークに接続しているコンテナ名。</param>
+    public NetworkInUseException(string networkName, IReadOnlyList<string> connectedContainerNames)
+        : base($"Network '{networkName}' is in use by: {string.Join(", ", connectedContainerNames)}")
+    {
+        NetworkName = networkName;
+        ConnectedContainerNames = connectedContainerNames;
+    }
+
+    /// <summary>
+    /// 削除対象のネットワーク名。
+    /// </summary>
+    public string NetworkName { get; }
+
+    /// <summary>
+    /// 対象ネットワークに接続しているコンテナ名。
+    /// </summary>
+    public IReadOnlyList<string> ConnectedContainerNames { get; }
+}

--- a/src/WslContainersDesktop.Application/Exceptions/SystemNetworkDeletionException.cs
+++ b/src/WslContainersDesktop.Application/Exceptions/SystemNetworkDeletionException.cs
@@ -1,0 +1,22 @@
+namespace WslContainersDesktop.Application.Exceptions;
+
+/// <summary>
+/// システムネットワークに対して削除が要求されたことを表す例外。
+/// </summary>
+public sealed class SystemNetworkDeletionException : ContainerManagementException
+{
+    /// <summary>
+    /// <see cref="SystemNetworkDeletionException"/> の新しいインスタンスを初期化する。
+    /// </summary>
+    /// <param name="networkName">削除対象のネットワーク名。</param>
+    public SystemNetworkDeletionException(string networkName)
+        : base($"Network '{networkName}' is a system network and cannot be deleted.")
+    {
+        NetworkName = networkName;
+    }
+
+    /// <summary>
+    /// 削除対象のネットワーク名。
+    /// </summary>
+    public string NetworkName { get; }
+}

--- a/src/WslContainersDesktop.Application/Ports/IContainerRuntimeClient.cs
+++ b/src/WslContainersDesktop.Application/Ports/IContainerRuntimeClient.cs
@@ -55,6 +55,26 @@ public interface IContainerRuntimeClient
     Task DeleteVolumeAsync(string name, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// 現在存在するすべてのコンテナーネットワークを取得する。
+    /// </summary>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    Task<IReadOnlyList<ContainerNetworkResource>> ListNetworksAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 指定した名前のコンテナーネットワークを作成する。
+    /// </summary>
+    /// <param name="name">作成するネットワーク名。</param>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    Task CreateNetworkAsync(string name, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 指定したコンテナーネットワークを削除する。
+    /// </summary>
+    /// <param name="name">削除するネットワーク名。</param>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    Task DeleteNetworkAsync(string name, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// 指定したコンテナを起動する。
     /// </summary>
     /// <param name="containerId">対象コンテナのID。</param>

--- a/src/WslContainersDesktop.Application/Ports/INetworkManagementService.cs
+++ b/src/WslContainersDesktop.Application/Ports/INetworkManagementService.cs
@@ -1,0 +1,30 @@
+using WslContainersDesktop.Domain;
+
+namespace WslContainersDesktop.Application.Ports;
+
+/// <summary>
+/// コンテナーネットワーク管理ユースケースを提供するインバウンドポート。
+/// </summary>
+public interface INetworkManagementService
+{
+    /// <summary>
+    /// 現在存在するすべてのコンテナーネットワークを取得する。
+    /// </summary>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    Task<IReadOnlyList<ContainerNetworkResource>> GetNetworksAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 指定した名前のコンテナーネットワークを作成する。
+    /// </summary>
+    /// <param name="name">作成するネットワーク名。</param>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    /// <returns>作成したネットワーク。</returns>
+    Task<ContainerNetworkResource> CreateAsync(string name, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 指定したコンテナーネットワークを削除する。
+    /// </summary>
+    /// <param name="name">削除するネットワーク名。</param>
+    /// <param name="cancellationToken">キャンセルトークン。</param>
+    Task DeleteAsync(string name, CancellationToken cancellationToken = default);
+}

--- a/src/WslContainersDesktop.Application/Services/NetworkManagementService.cs
+++ b/src/WslContainersDesktop.Application/Services/NetworkManagementService.cs
@@ -1,0 +1,142 @@
+using WslContainersDesktop.Application.Exceptions;
+using WslContainersDesktop.Application.Ports;
+using WslContainersDesktop.Domain;
+
+namespace WslContainersDesktop.Application.Services;
+
+/// <summary>
+/// <see cref="INetworkManagementService"/> の実装。
+/// </summary>
+public sealed class NetworkManagementService(IContainerRuntimeClient runtimeClient) : INetworkManagementService
+{
+    private static readonly HashSet<string> ReservedSystemNetworkNames = new(StringComparer.Ordinal)
+    {
+        "bridge",
+        "host",
+        "none",
+    };
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<ContainerNetworkResource>> GetNetworksAsync(CancellationToken cancellationToken = default)
+    {
+        var networks = await runtimeClient.ListNetworksAsync(cancellationToken);
+        if (networks.Count == 0)
+        {
+            return networks;
+        }
+
+        var connectedContainersByNetwork = await GetConnectedContainersByNetworkAsync(
+            networks.Select(network => network.Name),
+            cancellationToken);
+
+        return networks
+            .Select(network => network with
+            {
+                ConnectedContainerNames = connectedContainersByNetwork.TryGetValue(network.Name, out var connections)
+                    ? connections
+                    : [],
+                IsSystem = network.IsSystem || IsReservedSystemNetworkName(network.Name),
+            })
+            .ToList();
+    }
+
+    /// <inheritdoc />
+    public async Task<ContainerNetworkResource> CreateAsync(string name, CancellationToken cancellationToken = default)
+    {
+        var trimmed = ValidateNotWhiteSpace(name, nameof(name));
+        await runtimeClient.CreateNetworkAsync(trimmed, cancellationToken);
+
+        var networks = await GetNetworksAsync(cancellationToken);
+        return networks.FirstOrDefault(network => network.Name == trimmed)
+            ?? new ContainerNetworkResource(trimmed, string.Empty, DateTimeOffset.MinValue, [], false);
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteAsync(string name, CancellationToken cancellationToken = default)
+    {
+        var trimmed = ValidateNotWhiteSpace(name, nameof(name));
+        var networks = await GetNetworksAsync(cancellationToken);
+        var target = networks.FirstOrDefault(network => network.Name == trimmed);
+        if (target is not null)
+        {
+            if (target.IsSystem)
+            {
+                throw new SystemNetworkDeletionException(trimmed);
+            }
+
+            if (target.IsInUse)
+            {
+                throw new NetworkInUseException(trimmed, target.ConnectedContainerNames);
+            }
+        }
+
+        await runtimeClient.DeleteNetworkAsync(trimmed, cancellationToken);
+    }
+
+    private async Task<Dictionary<string, IReadOnlyList<string>>> GetConnectedContainersByNetworkAsync(
+        IEnumerable<string> networkNames,
+        CancellationToken cancellationToken)
+    {
+        var networkNameList = networkNames
+            .Where(name => name.Length > 0)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+        var connectionSets = networkNameList.ToDictionary(
+            networkName => networkName,
+            _ => new SortedSet<string>(StringComparer.Ordinal),
+            StringComparer.Ordinal);
+
+        if (networkNameList.Count == 0)
+        {
+            return ToConnectionMap(connectionSets);
+        }
+
+        var containers = await runtimeClient.ListContainersAsync(cancellationToken);
+        foreach (var container in containers)
+        {
+            ContainerDetail detail;
+            try
+            {
+                detail = await runtimeClient.GetContainerDetailAsync(container.Id, cancellationToken);
+            }
+            catch (ContainerManagementException)
+            {
+                continue;
+            }
+
+            foreach (var containerNetwork in detail.Networks)
+            {
+                if (connectionSets.TryGetValue(containerNetwork.Name, out var connectedContainerNames))
+                {
+                    connectedContainerNames.Add(detail.Name);
+                }
+            }
+        }
+
+        return ToConnectionMap(connectionSets);
+    }
+
+    private static Dictionary<string, IReadOnlyList<string>> ToConnectionMap(Dictionary<string, SortedSet<string>> connectionSets)
+    {
+        return connectionSets.ToDictionary(
+            item => item.Key,
+            item => (IReadOnlyList<string>)item.Value.ToList(),
+            StringComparer.Ordinal);
+    }
+
+    private static bool IsReservedSystemNetworkName(string name)
+    {
+        return ReservedSystemNetworkNames.Contains(name);
+    }
+
+    private static string ValidateNotWhiteSpace(string value, string parameterName)
+    {
+        var trimmed = value.Trim();
+        if (trimmed.Length == 0)
+        {
+            throw new ArgumentException("値を空白だけにすることはできません。", parameterName);
+        }
+
+        return trimmed;
+    }
+}

--- a/src/WslContainersDesktop.Domain/ContainerNetworkResource.cs
+++ b/src/WslContainersDesktop.Domain/ContainerNetworkResource.cs
@@ -1,0 +1,32 @@
+namespace WslContainersDesktop.Domain;
+
+/// <summary>
+/// WSL Containers上のコンテナーネットワークを表すエンティティ。
+/// </summary>
+/// <param name="Name">ネットワーク名。</param>
+/// <param name="Driver">ネットワークドライバー名。</param>
+/// <param name="CreatedAt">作成日時。</param>
+/// <param name="ConnectedContainerNames">このネットワークに接続しているコンテナ名の一覧。</param>
+/// <param name="IsSystem">システムネットワークかどうか。</param>
+public sealed record ContainerNetworkResource(
+    string Name,
+    string Driver,
+    DateTimeOffset CreatedAt,
+    IReadOnlyList<string> ConnectedContainerNames,
+    bool IsSystem)
+{
+    /// <summary>
+    /// このネットワークに接続しているコンテナ数。
+    /// </summary>
+    public int ConnectedContainerCount => ConnectedContainerNames.Count;
+
+    /// <summary>
+    /// ネットワークがいずれかのコンテナから使用されているかどうか。
+    /// </summary>
+    public bool IsInUse => ConnectedContainerCount > 0;
+
+    /// <summary>
+    /// ネットワークを削除できるかどうか。
+    /// </summary>
+    public bool CanDelete => !IsSystem && !IsInUse;
+}

--- a/src/WslContainersDesktop.Infrastructure/Clients/NetworkInspectDto.cs
+++ b/src/WslContainersDesktop.Infrastructure/Clients/NetworkInspectDto.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace WslContainersDesktop.Infrastructure.Clients;
+
+/// <summary>
+/// <c>wslc network inspect</c> の1要素に対応するJSON DTO。
+/// </summary>
+internal sealed class NetworkInspectDto
+{
+    [JsonPropertyName("Name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("Driver")]
+    public string Driver { get; set; } = string.Empty;
+
+    [JsonPropertyName("CreatedAt")]
+    public string CreatedAt { get; set; } = string.Empty;
+
+    [JsonPropertyName("IsSystem")]
+    public bool IsSystem { get; set; }
+}

--- a/src/WslContainersDesktop.Infrastructure/Clients/NetworkListItemDto.cs
+++ b/src/WslContainersDesktop.Infrastructure/Clients/NetworkListItemDto.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Serialization;
+
+namespace WslContainersDesktop.Infrastructure.Clients;
+
+/// <summary>
+/// <c>wslc network list --format json</c> の1要素に対応するJSON DTO。
+/// </summary>
+internal sealed class NetworkListItemDto
+{
+    [JsonPropertyName("Name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("Driver")]
+    public string Driver { get; set; } = string.Empty;
+
+    [JsonPropertyName("IsSystem")]
+    public bool IsSystem { get; set; }
+}

--- a/src/WslContainersDesktop.Infrastructure/Clients/WslcCliContainerRuntimeClient.cs
+++ b/src/WslContainersDesktop.Infrastructure/Clients/WslcCliContainerRuntimeClient.cs
@@ -106,6 +106,38 @@ public sealed class WslcCliContainerRuntimeClient(IWslcCliRunner cliRunner) : IC
         return RunAsync(["volume", "remove", name], cancellationToken);
     }
 
+    public async Task<IReadOnlyList<ContainerNetworkResource>> ListNetworksAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await RunAsync(["network", "list", "--format", "json"], cancellationToken);
+
+        var items = DeserializeJsonList<NetworkListItemDto>(
+            result,
+            command: "network list --format json",
+            failureMessage: "コンテナーネットワーク一覧の解析に失敗しました。");
+        if (items is null)
+        {
+            return [];
+        }
+
+        var networks = new List<ContainerNetworkResource>();
+        foreach (var item in items)
+        {
+            networks.Add(await InspectNetworkAsync(item, cancellationToken));
+        }
+
+        return networks;
+    }
+
+    public Task CreateNetworkAsync(string name, CancellationToken cancellationToken = default)
+    {
+        return RunAsync(["network", "create", name], cancellationToken);
+    }
+
+    public Task DeleteNetworkAsync(string name, CancellationToken cancellationToken = default)
+    {
+        return RunAsync(["network", "remove", name], cancellationToken);
+    }
+
     public Task StartAsync(string containerId, CancellationToken cancellationToken = default)
     {
         return RunAsync(["container", "start", containerId], cancellationToken);
@@ -231,6 +263,28 @@ public sealed class WslcCliContainerRuntimeClient(IWslcCliRunner cliRunner) : IC
             Driver: string.IsNullOrEmpty(item.Driver) ? listItem.Driver : item.Driver,
             CreatedAt: ParseDateTimeOffsetOrDefault(item.CreatedAt),
             ReferencingContainerNames: []);
+    }
+
+    private async Task<ContainerNetworkResource> InspectNetworkAsync(NetworkListItemDto listItem, CancellationToken cancellationToken)
+    {
+        var result = await RunAsync(["network", "inspect", listItem.Name], cancellationToken);
+
+        var items = DeserializeJsonList<NetworkInspectDto>(
+            result,
+            command: $"network inspect {listItem.Name}",
+            failureMessage: "コンテナーネットワーク詳細情報の解析に失敗しました。");
+        var item = items?.FirstOrDefault();
+        if (item is null)
+        {
+            return new ContainerNetworkResource(listItem.Name, listItem.Driver, DateTimeOffset.MinValue, [], listItem.IsSystem);
+        }
+
+        return new ContainerNetworkResource(
+            Name: string.IsNullOrEmpty(item.Name) ? listItem.Name : item.Name,
+            Driver: string.IsNullOrEmpty(item.Driver) ? listItem.Driver : item.Driver,
+            CreatedAt: ParseDateTimeOffsetOrDefault(item.CreatedAt),
+            ConnectedContainerNames: [],
+            IsSystem: listItem.IsSystem || item.IsSystem);
     }
 
     private static IReadOnlyList<string> SplitLogLines(string text)

--- a/tests/WslContainersDesktop.App.Tests/Fakes/FakeNetworkManagementService.cs
+++ b/tests/WslContainersDesktop.App.Tests/Fakes/FakeNetworkManagementService.cs
@@ -1,0 +1,60 @@
+using WslContainersDesktop.Application.Ports;
+using WslContainersDesktop.Domain;
+
+namespace WslContainersDesktop_App_Tests.Fakes;
+
+internal sealed class FakeNetworkManagementService : INetworkManagementService
+{
+    public IReadOnlyList<ContainerNetworkResource> DefaultNetworks { get; set; } = [];
+
+    public ContainerNetworkResource? CreateResult { get; set; }
+
+    public Exception? GetNetworksException { get; set; }
+
+    public Exception? CreateException { get; set; }
+
+    public Exception? DeleteException { get; set; }
+
+    public TaskCompletionSource<bool>? CreateGate { get; set; }
+
+    public List<string> CreateCalls { get; } = [];
+
+    public List<string> DeleteCalls { get; } = [];
+
+    public Task<IReadOnlyList<ContainerNetworkResource>> GetNetworksAsync(CancellationToken cancellationToken = default)
+    {
+        if (GetNetworksException is not null)
+        {
+            throw GetNetworksException;
+        }
+
+        return Task.FromResult(DefaultNetworks);
+    }
+
+    public async Task<ContainerNetworkResource> CreateAsync(string name, CancellationToken cancellationToken = default)
+    {
+        CreateCalls.Add(name);
+        if (CreateGate is not null)
+        {
+            await CreateGate.Task;
+        }
+
+        if (CreateException is not null)
+        {
+            throw CreateException;
+        }
+
+        return CreateResult ?? new ContainerNetworkResource(name, "bridge", DateTimeOffset.UtcNow, [], false);
+    }
+
+    public Task DeleteAsync(string name, CancellationToken cancellationToken = default)
+    {
+        DeleteCalls.Add(name);
+        if (DeleteException is not null)
+        {
+            throw DeleteException;
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/tests/WslContainersDesktop.App.Tests/Navigation/NavigationPageRegistryTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/Navigation/NavigationPageRegistryTests.cs
@@ -10,6 +10,7 @@ public sealed class NavigationPageRegistryTests
     [DataRow(NavigationPageKey.Containers, typeof(ContainersPage))]
     [DataRow(NavigationPageKey.Images, typeof(ImagesPage))]
     [DataRow(NavigationPageKey.Volumes, typeof(VolumesPage))]
+    [DataRow(NavigationPageKey.Networks, typeof(NetworksPage))]
     [DataRow(NavigationPageKey.Settings, typeof(SettingsPage))]
     public void GetPageType_DefinedPageKey_ReturnsExpectedPageType(NavigationPageKey pageKey, Type expectedPageType)
     {

--- a/tests/WslContainersDesktop.App.Tests/Pages/ImagesPageSourceTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/Pages/ImagesPageSourceTests.cs
@@ -19,6 +19,33 @@ public sealed class ImagesPageSourceTests
     }
 
     [TestMethod]
+    public void ImagesPage_HeaderIncludesAccentBar()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Pages\ImagesPage.xaml");
+
+        // Assert
+        StringAssert.Contains(sourceText, "<ColumnDefinition Width=\"4\" />");
+        StringAssert.Contains(sourceText, "Background=\"{ThemeResource WslContainersAccentFillColorDefaultBrush}\"");
+        StringAssert.Contains(sourceText, "CornerRadius=\"{StaticResource ControlCornerRadius}\"");
+    }
+
+    [TestMethod]
+    public void ImagesPage_ListSectionIncludesColumnHeaders()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Pages\ImagesPage.xaml");
+
+        // Assert
+        StringAssert.Contains(sourceText, "x:Name=\"TxtImageColumnName\"");
+        StringAssert.Contains(sourceText, "x:Name=\"TxtImageColumnId\"");
+        StringAssert.Contains(sourceText, "x:Name=\"TxtImageColumnSize\"");
+        StringAssert.Contains(sourceText, "x:Name=\"TxtImageColumnCreatedAt\"");
+        StringAssert.Contains(sourceText, "Grid.Row=\"1\"");
+        StringAssert.Contains(sourceText, "Background=\"{ThemeResource CardBackgroundFillColorDefaultBrush}\"");
+    }
+
+    [TestMethod]
     public void ImagesPage_DeleteClickShowsConfirmationBeforeExecutingDeleteCommand()
     {
         // Arrange

--- a/tests/WslContainersDesktop.App.Tests/Pages/NetworksPageSourceTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/Pages/NetworksPageSourceTests.cs
@@ -1,0 +1,124 @@
+using System.Text.RegularExpressions;
+
+namespace WslContainersDesktop_App_Tests.Pages;
+
+[TestClass]
+public sealed class NetworksPageSourceTests
+{
+    [TestMethod]
+    public void NetworksPage_XamlDisplaysRequiredNetworkFields()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Pages\NetworksPage.xaml");
+
+        // Assert
+        StringAssert.Contains(sourceText, "Text=\"{x:Bind Name}\"");
+        StringAssert.Contains(sourceText, "Text=\"{x:Bind Driver}\"");
+        StringAssert.Contains(sourceText, "Text=\"{x:Bind CreatedAtText}\"");
+        StringAssert.Contains(sourceText, "Text=\"{x:Bind ConnectedContainerCountText}\"");
+        StringAssert.Contains(sourceText, "Text=\"{x:Bind TypeText}\"");
+    }
+
+    [TestMethod]
+    public void NetworksPage_HeaderIncludesAccentBar()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Pages\NetworksPage.xaml");
+
+        // Assert
+        StringAssert.Contains(sourceText, "<ColumnDefinition Width=\"4\" />");
+        StringAssert.Contains(sourceText, "Background=\"{ThemeResource WslContainersAccentFillColorDefaultBrush}\"");
+        StringAssert.Contains(sourceText, "CornerRadius=\"{StaticResource ControlCornerRadius}\"");
+    }
+
+    [TestMethod]
+    public void NetworksPage_ListViewItemsStretchHorizontally()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Pages\NetworksPage.xaml");
+
+        // Assert
+        StringAssert.Contains(sourceText, "<ListView.ItemContainerStyle>");
+        StringAssert.Contains(sourceText, "HorizontalContentAlignment=\"Stretch\"");
+        StringAssert.Contains(sourceText, "HorizontalAlignment=\"Stretch\"");
+    }
+
+    [TestMethod]
+    public void NetworksPage_EmptyStateUsesOpaqueCardBorderWhenNoNetworks()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Pages\NetworksPage.xaml");
+        var emptyStateBorderPattern = new Regex(
+            """
+            <Border\b[^>]*x:Name="BorderNetworksEmptyState"[^>]*Background="\{ThemeResource CardBackgroundFillColorDefaultBrush\}"[^>]*BorderBrush="\{ThemeResource CardStrokeColorDefaultBrush\}"[^>]*BorderThickness="\{ThemeResource WslContainersSurfaceBorderThickness\}"[^>]*CornerRadius="\{StaticResource OverlayCornerRadius\}"[^>]*\sVisibility="\{x:Bind ToVisibleWhenFalse\(ViewModel\.HasNetworks\), Mode=OneWay\}"[^>]*>(?s:.*?)<TextBlock\b[^>]*x:Name="TxtNetworksEmptyState"
+            """,
+            RegexOptions.Singleline);
+
+        // Assert
+        Assert.IsTrue(
+            emptyStateBorderPattern.IsMatch(sourceText),
+            "Expected the empty-state section to be wrapped in a named Border with card styling and the visible-when-false binding.");
+    }
+
+    [TestMethod]
+    public void NetworksPage_DeleteClickShowsConfirmationBeforeExecutingDeleteCommand()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Pages\NetworksPage.xaml.cs");
+
+        // Act
+        var handlerIndex = sourceText.IndexOf("BtnDeleteNetwork_Click", StringComparison.Ordinal);
+        var dialogIndex = sourceText.IndexOf("ContentDialog", StringComparison.Ordinal);
+        var primaryResultIndex = sourceText.IndexOf("ContentDialogResult.Primary", StringComparison.Ordinal);
+        var deleteCommandIndex = sourceText.IndexOf("DeleteCommand.ExecuteAsync", StringComparison.Ordinal);
+
+        // Assert
+        Assert.IsGreaterThanOrEqualTo(0, handlerIndex, "Expected NetworksPage to define BtnDeleteNetwork_Click.");
+        Assert.IsGreaterThanOrEqualTo(0, dialogIndex, "Expected network deletion to create a confirmation dialog.");
+        Assert.IsGreaterThanOrEqualTo(0, primaryResultIndex, "Expected network deletion to require primary confirmation.");
+        Assert.IsGreaterThanOrEqualTo(0, deleteCommandIndex, "Expected confirmed network deletion to execute DeleteCommand.");
+        Assert.IsTrue(
+            handlerIndex < dialogIndex && dialogIndex < deleteCommandIndex,
+            "Expected the delete confirmation dialog to be created before executing the delete command.");
+    }
+
+    [TestMethod]
+    public void MainWindow_SourceContainsNetworksNavigationItemAndMapping()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\MainWindow.xaml");
+        var codeBehindText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\MainWindow.xaml.cs");
+
+        // Assert
+        StringAssert.Contains(sourceText, "AutomationProperties.AutomationId=\"NavItemNetworks\"");
+        StringAssert.Contains(codeBehindText, "[NavItemNetworks] = NavigationPageKey.Networks");
+    }
+
+    private static string ReadRepositorySourceFile(string relativePath)
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var normalizedRelativePath = relativePath.Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar);
+        var fullPath = Path.Combine(repositoryRoot, normalizedRelativePath);
+
+        Assert.IsTrue(File.Exists(fullPath), $"Expected source file '{relativePath}' to exist at '{fullPath}'.");
+        return File.ReadAllText(fullPath);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var currentDirectory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (currentDirectory is not null)
+        {
+            var appProjectFilePath = Path.Combine(currentDirectory.FullName, "src", "WslContainersDesktop.App", "WslContainersDesktop.App.csproj");
+            if (File.Exists(appProjectFilePath))
+            {
+                return currentDirectory.FullName;
+            }
+
+            currentDirectory = currentDirectory.Parent;
+        }
+
+        Assert.Fail($"Could not locate repository root from '{AppContext.BaseDirectory}'.");
+        return string.Empty;
+    }
+}

--- a/tests/WslContainersDesktop.App.Tests/Pages/VolumesPageSourceTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/Pages/VolumesPageSourceTests.cs
@@ -17,6 +17,18 @@ public sealed class VolumesPageSourceTests
     }
 
     [TestMethod]
+    public void VolumesPage_HeaderIncludesAccentBar()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Pages\VolumesPage.xaml");
+
+        // Assert
+        StringAssert.Contains(sourceText, "<ColumnDefinition Width=\"4\" />");
+        StringAssert.Contains(sourceText, "Background=\"{ThemeResource WslContainersAccentFillColorDefaultBrush}\"");
+        StringAssert.Contains(sourceText, "CornerRadius=\"{StaticResource ControlCornerRadius}\"");
+    }
+
+    [TestMethod]
     public void VolumesPage_DeleteClickShowsConfirmationBeforeExecutingDeleteCommand()
     {
         // Arrange

--- a/tests/WslContainersDesktop.App.Tests/ViewModels/NavigationViewModelTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/ViewModels/NavigationViewModelTests.cs
@@ -20,6 +20,7 @@ public sealed class NavigationViewModelTests
     [DataRow(NavigationPageKey.Containers)]
     [DataRow(NavigationPageKey.Settings)]
     [DataRow(NavigationPageKey.Volumes)]
+    [DataRow(NavigationPageKey.Networks)]
     public void Constructor_InitialPageKeySpecified_CurrentPageKeyMatchesArgument(NavigationPageKey initialPageKey)
     {
         // Arrange & Act

--- a/tests/WslContainersDesktop.App.Tests/ViewModels/NetworkRowViewModelTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/ViewModels/NetworkRowViewModelTests.cs
@@ -1,0 +1,52 @@
+using WslContainersDesktop.Domain;
+using WslContainersDesktop_App.ViewModels;
+
+namespace WslContainersDesktop_App_Tests.ViewModels;
+
+[TestClass]
+public sealed class NetworkRowViewModelTests
+{
+    [TestMethod]
+    public void UsageText_UserNetworkWithoutConnectionsAndMinValueCreatedAt_ShowsUnusedAndDefaultValues()
+    {
+        // Arrange
+        var network = new ContainerNetworkResource("app-net", "bridge", DateTimeOffset.MinValue, [], false);
+
+        // Act
+        var sut = new NetworkRowViewModel(network);
+
+        // Assert
+        Assert.AreEqual("Unused", sut.UsageText);
+        Assert.AreEqual("0", sut.ConnectedContainerCountText);
+        Assert.AreEqual("User-created", sut.TypeText);
+        Assert.AreEqual("Unknown", sut.CreatedAtText);
+        Assert.IsTrue(sut.CanDelete);
+    }
+
+    [TestMethod]
+    public void CreatedAtText_UserNetworkWithRealCreatedAt_IsNotUnknown()
+    {
+        // Arrange
+        var network = new ContainerNetworkResource("app-net", "bridge", new DateTimeOffset(2026, 7, 4, 9, 0, 0, TimeSpan.Zero), [], false);
+
+        // Act
+        var sut = new NetworkRowViewModel(network);
+
+        // Assert
+        Assert.AreNotEqual("Unknown", sut.CreatedAtText);
+    }
+
+    [TestMethod]
+    public void TypeText_SystemNetwork_IsSystem()
+    {
+        // Arrange
+        var network = new ContainerNetworkResource("bridge", "bridge", new DateTimeOffset(2026, 7, 4, 9, 0, 0, TimeSpan.Zero), [], true);
+
+        // Act
+        var sut = new NetworkRowViewModel(network);
+
+        // Assert
+        Assert.AreEqual("System", sut.TypeText);
+        Assert.IsFalse(sut.CanDelete);
+    }
+}

--- a/tests/WslContainersDesktop.App.Tests/ViewModels/NetworksViewModelTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/ViewModels/NetworksViewModelTests.cs
@@ -1,0 +1,278 @@
+using WslContainersDesktop.Application.Exceptions;
+using WslContainersDesktop.Domain;
+using WslContainersDesktop_App.ViewModels;
+using WslContainersDesktop_App_Tests.Fakes;
+
+namespace WslContainersDesktop_App_Tests.ViewModels;
+
+[TestClass]
+public sealed class NetworksViewModelTests
+{
+    private static DateTimeOffset CreatedAt => new(2026, 7, 4, 9, 0, 0, TimeSpan.Zero);
+
+    private static ContainerNetworkResource CreateNetwork(string name, bool isSystem = false, params string[] connectedContainerNames) => new(
+        Name: name,
+        Driver: "bridge",
+        CreatedAt: CreatedAt,
+        ConnectedContainerNames: connectedContainerNames,
+        IsSystem: isSystem);
+
+    [TestMethod]
+    public async Task RefreshAsync_ServiceReturnsUserAndSystemNetworks_PopulatesRowsAndSetsHasNetworksAndNoUserNetworksFlags()
+    {
+        // Arrange
+        var service = new FakeNetworkManagementService { DefaultNetworks = [CreateNetwork("app-net"), CreateNetwork("bridge", true)] };
+        var sut = new NetworksViewModel(service);
+
+        // Act
+        await sut.RefreshAsync();
+
+        // Assert
+        Assert.HasCount(2, sut.Networks);
+        Assert.IsTrue(sut.HasNetworks);
+        Assert.IsFalse(sut.HasNoUserNetworks);
+        Assert.IsFalse(sut.IsNoUserNetworksInfoVisible);
+        Assert.IsNull(sut.ErrorMessage);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_ServiceReturnsOnlySystemNetworks_SetsNoUserNetworksFlag()
+    {
+        // Arrange
+        var service = new FakeNetworkManagementService { DefaultNetworks = [CreateNetwork("bridge", true)] };
+        var sut = new NetworksViewModel(service);
+
+        // Act
+        await sut.RefreshAsync();
+
+        // Assert
+        Assert.HasCount(1, sut.Networks);
+        Assert.IsTrue(sut.HasNetworks);
+        Assert.IsTrue(sut.HasNoUserNetworks);
+        Assert.IsTrue(sut.IsNoUserNetworksInfoVisible);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_ServiceReturnsEmptyList_ClearsNetworksAndSetsNoUserNetworksFlag()
+    {
+        // Arrange
+        var service = new FakeNetworkManagementService { DefaultNetworks = [] };
+        var sut = new NetworksViewModel(service);
+
+        // Act
+        await sut.RefreshAsync();
+
+        // Assert
+        Assert.IsEmpty(sut.Networks);
+        Assert.IsFalse(sut.HasNetworks);
+        Assert.IsTrue(sut.HasNoUserNetworks);
+        Assert.IsFalse(sut.IsNoUserNetworksInfoVisible);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_ServiceThrows_ErrorMessageIsSetAndExistingRowsArePreserved()
+    {
+        // Arrange
+        var service = new FakeNetworkManagementService { DefaultNetworks = [CreateNetwork("app-net")] };
+        var sut = new NetworksViewModel(service);
+        await sut.RefreshAsync();
+        service.GetNetworksException = new ContainerRuntimeException("list", 1, "refresh failed");
+
+        // Act
+        await sut.RefreshAsync();
+
+        // Assert
+        Assert.AreEqual("refresh failed", sut.ErrorMessage);
+        Assert.HasCount(1, sut.Networks);
+        Assert.AreEqual("app-net", sut.Networks[0].Name);
+    }
+
+    [TestMethod]
+    public async Task CreateAsync_ServiceSucceeds_ClearsInputSetsStatusAndRefreshesNetworks()
+    {
+        // Arrange
+        var service = new FakeNetworkManagementService { CreateResult = CreateNetwork("app-net") };
+        var sut = new NetworksViewModel(service) { NewNetworkName = "  app-net  " };
+
+        // Act
+        await sut.CreateAsync();
+
+        // Assert
+        Assert.AreEqual(string.Empty, sut.NewNetworkName);
+        Assert.AreEqual("Network created.", sut.StatusMessage);
+        Assert.HasCount(1, sut.Networks);
+        Assert.AreEqual("app-net", sut.Networks[0].Name);
+        Assert.IsFalse(sut.IsCreating);
+    }
+
+    [TestMethod]
+    public async Task CreateAsync_NewNetworkNameIsEmpty_ShowsValidationErrorAndDoesNotCallService()
+    {
+        // Arrange
+        var service = new FakeNetworkManagementService();
+        var sut = new NetworksViewModel(service) { NewNetworkName = string.Empty };
+
+        // Act
+        await sut.CreateAsync();
+
+        // Assert
+        Assert.AreEqual("Network name is required.", sut.ErrorMessage);
+        Assert.IsFalse(sut.IsCreating);
+        Assert.IsEmpty(service.CreateCalls);
+    }
+
+    [TestMethod]
+    public async Task CreateAsync_ServiceThrows_ErrorMessageIsSetAndInputIsPreserved()
+    {
+        // Arrange
+        var service = new FakeNetworkManagementService { CreateException = new ContainerRuntimeException("create", 1, "create failed") };
+        var sut = new NetworksViewModel(service) { NewNetworkName = "app-net" };
+
+        // Act
+        await sut.CreateAsync();
+
+        // Assert
+        Assert.AreEqual("create failed", sut.ErrorMessage);
+        Assert.AreEqual("app-net", sut.NewNetworkName);
+        Assert.IsFalse(sut.IsCreating);
+    }
+
+    [TestMethod]
+    public async Task CreateAsync_RefreshAfterCreateFails_ClearsSuccessStatusAndShowsRefreshError()
+    {
+        // Arrange
+        var service = new FakeNetworkManagementService { CreateResult = CreateNetwork("app-net"), GetNetworksException = new ContainerRuntimeException("list", 1, "refresh failed") };
+        var sut = new NetworksViewModel(service) { NewNetworkName = "app-net" };
+
+        // Act
+        await sut.CreateAsync();
+
+        // Assert
+        Assert.AreEqual("refresh failed", sut.ErrorMessage);
+        Assert.IsNull(sut.StatusMessage);
+    }
+
+    [TestMethod]
+    public async Task CreateAsync_OperationIsRunning_IsCreatingIsTrueThenFalse()
+    {
+        // Arrange
+        var gate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var service = new FakeNetworkManagementService { CreateResult = CreateNetwork("app-net"), CreateGate = gate };
+        var sut = new NetworksViewModel(service) { NewNetworkName = "app-net" };
+
+        // Act
+        var createTask = sut.CreateAsync();
+
+        // Assert
+        Assert.IsTrue(sut.IsCreating);
+        gate.SetResult(true);
+        await createTask;
+        Assert.IsFalse(sut.IsCreating);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_ServiceSucceeds_RemovesNetworkRowAndUpdatesHasNetworkFlags()
+    {
+        // Arrange
+        var service = new FakeNetworkManagementService { DefaultNetworks = [CreateNetwork("app-net")] };
+        var sut = new NetworksViewModel(service);
+        await sut.RefreshAsync();
+        var row = sut.Networks[0];
+
+        // Act
+        await sut.DeleteAsync(row);
+
+        // Assert
+        Assert.IsEmpty(sut.Networks);
+        Assert.IsFalse(sut.HasNetworks);
+        Assert.IsTrue(sut.HasNoUserNetworks);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_ServiceThrows_ErrorMessageIsSetAndRowRemains()
+    {
+        // Arrange
+        var service = new FakeNetworkManagementService { DefaultNetworks = [CreateNetwork("app-net")], DeleteException = new ContainerRuntimeException("delete", 1, "delete failed") };
+        var sut = new NetworksViewModel(service);
+        await sut.RefreshAsync();
+        var row = sut.Networks[0];
+
+        // Act
+        await sut.DeleteAsync(row);
+
+        // Assert
+        Assert.AreEqual("delete failed", sut.ErrorMessage);
+        Assert.HasCount(1, sut.Networks);
+        Assert.AreSame(row, sut.Networks[0]);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_ConnectedRow_DoesNotCallServiceAndShowsError()
+    {
+        // Arrange
+        var service = new FakeNetworkManagementService { DefaultNetworks = [CreateNetwork("app-net", false, "web")] };
+        var sut = new NetworksViewModel(service);
+        await sut.RefreshAsync();
+        var row = sut.Networks[0];
+
+        // Act
+        await sut.DeleteAsync(row);
+
+        // Assert
+        Assert.AreEqual("Network 'app-net' is in use by: web", sut.ErrorMessage);
+        Assert.IsEmpty(service.DeleteCalls);
+        Assert.HasCount(1, sut.Networks);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_SystemRow_DoesNotCallServiceAndShowsError()
+    {
+        // Arrange
+        var service = new FakeNetworkManagementService { DefaultNetworks = [CreateNetwork("bridge", true)] };
+        var sut = new NetworksViewModel(service);
+        await sut.RefreshAsync();
+        var row = sut.Networks[0];
+
+        // Act
+        await sut.DeleteAsync(row);
+
+        // Assert
+        Assert.AreEqual("Network 'bridge' is a system network and cannot be deleted.", sut.ErrorMessage);
+        Assert.IsEmpty(service.DeleteCalls);
+        Assert.HasCount(1, sut.Networks);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_NetworkInUseException_UsesExceptionNamesInErrorMessage()
+    {
+        // Arrange
+        var service = new FakeNetworkManagementService { DefaultNetworks = [CreateNetwork("app-net")], DeleteException = new NetworkInUseException("app-net", ["web", "db"]) };
+        var sut = new NetworksViewModel(service);
+        await sut.RefreshAsync();
+        var row = sut.Networks[0];
+
+        // Act
+        await sut.DeleteAsync(row);
+
+        // Assert
+        Assert.AreEqual("Network 'app-net' is in use by: web, db", sut.ErrorMessage);
+        Assert.HasCount(1, sut.Networks);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_SystemNetworkDeletionException_UsesExceptionMessage()
+    {
+        // Arrange
+        var service = new FakeNetworkManagementService { DefaultNetworks = [CreateNetwork("bridge", true)], DeleteException = new SystemNetworkDeletionException("bridge") };
+        var sut = new NetworksViewModel(service);
+        await sut.RefreshAsync();
+        var row = sut.Networks[0];
+
+        // Act
+        await sut.DeleteAsync(row);
+
+        // Assert
+        Assert.AreEqual("Network 'bridge' is a system network and cannot be deleted.", sut.ErrorMessage);
+        Assert.HasCount(1, sut.Networks);
+    }
+}

--- a/tests/WslContainersDesktop.Application.Tests/Fakes/FakeContainerRuntimeClient.cs
+++ b/tests/WslContainersDesktop.Application.Tests/Fakes/FakeContainerRuntimeClient.cs
@@ -16,6 +16,8 @@ internal sealed class FakeContainerRuntimeClient : IContainerRuntimeClient
 
     public IReadOnlyList<ContainerVolume> Volumes { get; set; } = [];
 
+    public IReadOnlyList<ContainerNetworkResource> Networks { get; set; } = [];
+
     public IReadOnlyDictionary<string, ContainerDetail> ContainerDetailsById { get; set; } = new Dictionary<string, ContainerDetail>();
 
     public Exception? ExceptionToThrow { get; set; }
@@ -37,6 +39,10 @@ internal sealed class FakeContainerRuntimeClient : IContainerRuntimeClient
     public Exception? GetContainerDetailException { get; set; }
 
     public Exception? DeleteVolumeException { get; set; }
+
+    public Exception? CreateNetworkException { get; set; }
+
+    public Exception? DeleteNetworkException { get; set; }
 
     public Func<string, CancellationToken, Task<IReadOnlyList<string>>>? GetContainerLogsAsyncFunc { get; set; }
 
@@ -63,6 +69,10 @@ internal sealed class FakeContainerRuntimeClient : IContainerRuntimeClient
     public List<string> CreateVolumeCalls { get; } = [];
 
     public List<string> DeleteVolumeCalls { get; } = [];
+
+    public List<string> CreateNetworkCalls { get; } = [];
+
+    public List<string> DeleteNetworkCalls { get; } = [];
 
     public Task<IReadOnlyList<Container>> ListContainersAsync(CancellationToken cancellationToken = default)
     {
@@ -213,6 +223,33 @@ internal sealed class FakeContainerRuntimeClient : IContainerRuntimeClient
         if (DeleteVolumeException is not null)
         {
             throw DeleteVolumeException;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<ContainerNetworkResource>> ListNetworksAsync(CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(Networks);
+    }
+
+    public Task CreateNetworkAsync(string name, CancellationToken cancellationToken = default)
+    {
+        CreateNetworkCalls.Add(name);
+        if (CreateNetworkException is not null)
+        {
+            throw CreateNetworkException;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteNetworkAsync(string name, CancellationToken cancellationToken = default)
+    {
+        DeleteNetworkCalls.Add(name);
+        if (DeleteNetworkException is not null)
+        {
+            throw DeleteNetworkException;
         }
 
         return Task.CompletedTask;

--- a/tests/WslContainersDesktop.Application.Tests/Services/NetworkManagementServiceTests.cs
+++ b/tests/WslContainersDesktop.Application.Tests/Services/NetworkManagementServiceTests.cs
@@ -1,0 +1,217 @@
+using WslContainersDesktop.Application.Exceptions;
+using WslContainersDesktop.Application.Ports;
+using WslContainersDesktop.Application.Services;
+using WslContainersDesktop.Domain;
+using WslContainersDesktop.Application.Tests.Fakes;
+
+namespace WslContainersDesktop.Application.Tests.Services;
+
+[TestClass]
+public sealed class NetworkManagementServiceTests
+{
+    private static DateTimeOffset CreatedAt => new(2026, 7, 4, 9, 0, 0, TimeSpan.Zero);
+
+    private static ContainerNetworkResource CreateNetwork(string name, bool isSystem = false, params string[] connectedContainerNames) => new(
+        Name: name,
+        Driver: "bridge",
+        CreatedAt: CreatedAt,
+        ConnectedContainerNames: connectedContainerNames,
+        IsSystem: isSystem);
+
+    private static Container CreateContainer(string id) => new(
+        Id: id,
+        Name: $"name-{id}",
+        Image: "nginx:latest",
+        State: ContainerState.Running,
+        CreatedAt: CreatedAt);
+
+    private static ContainerDetail CreateDetail(string containerId, string containerName, params ContainerNetwork[] networks) => new(
+        Id: containerId,
+        Name: containerName,
+        Image: "nginx:latest",
+        State: ContainerState.Running,
+        CreatedAt: CreatedAt,
+        Command: null,
+        Entrypoint: null,
+        Ports: [],
+        Environment: [],
+        Mounts: [],
+        Networks: networks,
+        RunState: new ContainerRunState(null, null, null, null));
+
+    [TestMethod]
+    public async Task GetNetworksAsync_RuntimeReturnsNetworksAndContainersReferenceNetwork_ReturnsNetworkWithConnectedContainerNamesAndUserNetworkIsNotSystem()
+    {
+        // Arrange
+        var client = new FakeContainerRuntimeClient
+        {
+            Containers = [CreateContainer("c1"), CreateContainer("c2")],
+            ContainerDetailsById = new Dictionary<string, ContainerDetail>
+            {
+                ["c1"] = CreateDetail("c1", "web", new ContainerNetwork("app-net", null)),
+                ["c2"] = CreateDetail("c2", "api", new ContainerNetwork("app-net", null), new ContainerNetwork("other", null)),
+            },
+            Networks = [CreateNetwork("app-net")],
+        };
+        var sut = new NetworkManagementService(client);
+
+        // Act
+        var networks = await sut.GetNetworksAsync();
+
+        // Assert
+        Assert.HasCount(1, networks);
+        Assert.AreEqual("app-net", networks[0].Name);
+        CollectionAssert.AreEqual(new[] { "api", "web" }, networks[0].ConnectedContainerNames.ToList());
+        Assert.AreEqual(2, networks[0].ConnectedContainerCount);
+        Assert.IsFalse(networks[0].IsSystem);
+        Assert.IsFalse(networks[0].CanDelete);
+    }
+
+    [TestMethod]
+    public async Task GetNetworksAsync_ContainerDetailFails_ReturnsNetworksWithoutThrowing()
+    {
+        // Arrange
+        var client = new FakeContainerRuntimeClient
+        {
+            Containers = [CreateContainer("c1")],
+            GetContainerDetailException = new ContainerRuntimeException("detail", 1, "detail failed"),
+            Networks = [CreateNetwork("app-net")],
+        };
+        var sut = new NetworkManagementService(client);
+
+        // Act
+        var networks = await sut.GetNetworksAsync();
+
+        // Assert
+        Assert.HasCount(1, networks);
+        Assert.IsEmpty(networks[0].ConnectedContainerNames);
+    }
+
+    [TestMethod]
+    public async Task GetNetworksAsync_SameContainerReferencesNetworkTwice_ReferencesContainerOnce()
+    {
+        // Arrange
+        var client = new FakeContainerRuntimeClient
+        {
+            Containers = [CreateContainer("c1")],
+            ContainerDetailsById = new Dictionary<string, ContainerDetail>
+            {
+                ["c1"] = CreateDetail("c1", "web", new ContainerNetwork("app-net", null), new ContainerNetwork("app-net", null)),
+            },
+            Networks = [CreateNetwork("app-net")],
+        };
+        var sut = new NetworkManagementService(client);
+
+        // Act
+        var networks = await sut.GetNetworksAsync();
+
+        // Assert
+        CollectionAssert.AreEqual(new[] { "web" }, networks[0].ConnectedContainerNames.ToList());
+    }
+
+    [DataTestMethod]
+    [DataRow("bridge")]
+    [DataRow("host")]
+    [DataRow("none")]
+    public async Task GetNetworksAsync_RuntimeReturnsReservedNames_MarksSystemNetworks(string reservedName)
+    {
+        // Arrange
+        var client = new FakeContainerRuntimeClient
+        {
+            Networks = [CreateNetwork(reservedName)],
+        };
+        var sut = new NetworkManagementService(client);
+
+        // Act
+        var networks = await sut.GetNetworksAsync();
+
+        // Assert
+        Assert.HasCount(1, networks);
+        Assert.IsTrue(networks[0].IsSystem);
+        Assert.IsFalse(networks[0].CanDelete);
+    }
+
+    [TestMethod]
+    public async Task CreateAsync_NameHasWhitespace_TrimsAndCallsClientCreateNetwork()
+    {
+        // Arrange
+        var client = new FakeContainerRuntimeClient();
+        var sut = new NetworkManagementService(client);
+
+        // Act
+        await sut.CreateAsync("  app-net  ");
+
+        // Assert
+        CollectionAssert.AreEqual(new[] { "app-net" }, client.CreateNetworkCalls);
+    }
+
+    [TestMethod]
+    public async Task CreateAsync_NameIsWhitespace_ThrowsArgumentExceptionAndDoesNotCallClient()
+    {
+        // Arrange
+        var client = new FakeContainerRuntimeClient();
+        var sut = new NetworkManagementService(client);
+
+        // Act & Assert
+        await Assert.ThrowsExactlyAsync<ArgumentException>(() => sut.CreateAsync("   "));
+        Assert.IsEmpty(client.CreateNetworkCalls);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_UnusedUserNetwork_CallsClientDeleteNetwork()
+    {
+        // Arrange
+        var client = new FakeContainerRuntimeClient
+        {
+            Networks = [CreateNetwork("app-net")],
+        };
+        var sut = new NetworkManagementService(client);
+
+        // Act
+        await sut.DeleteAsync("app-net");
+
+        // Assert
+        CollectionAssert.AreEqual(new[] { "app-net" }, client.DeleteNetworkCalls);
+    }
+
+    [TestMethod]
+    public async Task DeleteAsync_ConnectedNetwork_ThrowsNetworkInUseExceptionAndDoesNotCallClient()
+    {
+        // Arrange
+        var client = new FakeContainerRuntimeClient
+        {
+            Containers = [CreateContainer("c1")],
+            ContainerDetailsById = new Dictionary<string, ContainerDetail>
+            {
+                ["c1"] = CreateDetail("c1", "web", new ContainerNetwork("app-net", null)),
+            },
+            Networks = [CreateNetwork("app-net")],
+        };
+        var sut = new NetworkManagementService(client);
+
+        // Act & Assert
+        var ex = await Assert.ThrowsExactlyAsync<NetworkInUseException>(() => sut.DeleteAsync("app-net"));
+        Assert.AreEqual("app-net", ex.NetworkName);
+        CollectionAssert.AreEqual(new[] { "web" }, ex.ConnectedContainerNames.ToList());
+        Assert.IsEmpty(client.DeleteNetworkCalls);
+    }
+
+    [DataTestMethod]
+    [DataRow("bridge")]
+    [DataRow("host")]
+    [DataRow("none")]
+    public async Task DeleteAsync_SystemNetwork_ThrowsSystemNetworkDeletionExceptionAndDoesNotCallClient(string reservedName)
+    {
+        // Arrange
+        var client = new FakeContainerRuntimeClient
+        {
+            Networks = [CreateNetwork(reservedName, isSystem: true)],
+        };
+        var sut = new NetworkManagementService(client);
+
+        // Act & Assert
+        var ex = await Assert.ThrowsExactlyAsync<SystemNetworkDeletionException>(() => sut.DeleteAsync(reservedName));
+        Assert.AreEqual(reservedName, ex.NetworkName);
+        Assert.IsEmpty(client.DeleteNetworkCalls);
+    }
+}

--- a/tests/WslContainersDesktop.Domain.Tests/ContainerNetworkResourceTests.cs
+++ b/tests/WslContainersDesktop.Domain.Tests/ContainerNetworkResourceTests.cs
@@ -1,0 +1,44 @@
+using WslContainersDesktop.Domain;
+
+namespace WslContainersDesktop.Domain.Tests;
+
+[TestClass]
+public sealed class ContainerNetworkResourceTests
+{
+    private static DateTimeOffset CreatedAt => new(2026, 7, 4, 9, 0, 0, TimeSpan.Zero);
+
+    [TestMethod]
+    public void Constructor_UserNetworkWithoutConnections_IsUnusedAndCanDelete()
+    {
+        // Arrange
+        var sut = new ContainerNetworkResource("app-net", "bridge", CreatedAt, [], false);
+
+        // Act & Assert
+        Assert.IsFalse(sut.IsInUse);
+        Assert.AreEqual(0, sut.ConnectedContainerCount);
+        Assert.IsTrue(sut.CanDelete);
+    }
+
+    [TestMethod]
+    public void Constructor_UserNetworkWithConnections_IsInUseAndCannotDelete()
+    {
+        // Arrange
+        var sut = new ContainerNetworkResource("app-net", "bridge", CreatedAt, ["web", "db"], false);
+
+        // Act & Assert
+        Assert.AreEqual(2, sut.ConnectedContainerCount);
+        Assert.IsTrue(sut.IsInUse);
+        Assert.IsFalse(sut.CanDelete);
+    }
+
+    [TestMethod]
+    public void Constructor_SystemNetworkWithoutConnections_IsSystemAndCannotDelete()
+    {
+        // Arrange
+        var sut = new ContainerNetworkResource("bridge", "bridge", CreatedAt, [], true);
+
+        // Act & Assert
+        Assert.IsTrue(sut.IsSystem);
+        Assert.IsFalse(sut.CanDelete);
+    }
+}

--- a/tests/WslContainersDesktop.Infrastructure.Tests/Clients/NetworkManagementInfrastructureTests.cs
+++ b/tests/WslContainersDesktop.Infrastructure.Tests/Clients/NetworkManagementInfrastructureTests.cs
@@ -1,0 +1,146 @@
+using WslContainersDesktop.Application.Exceptions;
+using WslContainersDesktop.Infrastructure.Cli;
+using WslContainersDesktop.Infrastructure.Clients;
+using WslContainersDesktop.Infrastructure.Tests.Fakes;
+
+namespace WslContainersDesktop.Infrastructure.Tests.Clients;
+
+[TestClass]
+public sealed class NetworkManagementInfrastructureTests
+{
+    [TestMethod]
+    public async Task ListNetworksAsync_CliReturnsNetworkAndInspectWithoutCreatedAt_MapsJsonToContainerNetworkWithMinValueAndUserNetworkIsNotSystem()
+    {
+        // Arrange
+        const string listJson = "[{\"Driver\":\"bridge\",\"Id\":\"abc\",\"Name\":\"app-net\"}]";
+        const string inspectJson = "[{\"Driver\":\"bridge\",\"Id\":\"abc\",\"IPAM\":{},\"Internal\":false,\"Labels\":{},\"Name\":\"app-net\",\"Scope\":\"local\"}]";
+        var runner = new FakeWslcCliRunner();
+        runner.RunAsyncFunc = (arguments, cancellationToken) =>
+        {
+            if (arguments.SequenceEqual(new[] { "network", "list", "--format", "json" }))
+            {
+                return Task.FromResult(new CliResult(0, listJson, string.Empty));
+            }
+
+            if (arguments.SequenceEqual(new[] { "network", "inspect", "app-net" }))
+            {
+                return Task.FromResult(new CliResult(0, inspectJson, string.Empty));
+            }
+
+            return Task.FromResult(new CliResult(0, string.Empty, string.Empty));
+        };
+        var sut = new WslcCliContainerRuntimeClient(runner);
+
+        // Act
+        var networks = await sut.ListNetworksAsync();
+
+        // Assert
+        Assert.HasCount(1, networks);
+        Assert.AreEqual("app-net", networks[0].Name);
+        Assert.AreEqual("bridge", networks[0].Driver);
+        Assert.AreEqual(DateTimeOffset.MinValue, networks[0].CreatedAt);
+        Assert.IsFalse(networks[0].IsSystem);
+    }
+
+    [TestMethod]
+    public async Task ListNetworksAsync_CliArguments_AreNetworkListJsonThenNetworkInspectForEachName()
+    {
+        // Arrange
+        var runner = new FakeWslcCliRunner { Result = new(0, "[]", string.Empty) };
+        var sut = new WslcCliContainerRuntimeClient(runner);
+
+        // Act
+        await sut.ListNetworksAsync();
+
+        // Assert
+        CollectionAssert.AreEqual(new[] { "network", "list", "--format", "json" }, runner.Calls[0].ToList());
+    }
+
+    [TestMethod]
+    public async Task ListNetworksAsync_ListMalformedJson_ThrowsContainerRuntimeExceptionWithInnerException()
+    {
+        // Arrange
+        var runner = new FakeWslcCliRunner { Result = new(0, "not-json", string.Empty) };
+        var sut = new WslcCliContainerRuntimeClient(runner);
+
+        // Act & Assert
+        var ex = await Assert.ThrowsExactlyAsync<ContainerRuntimeException>(() => sut.ListNetworksAsync());
+        Assert.IsNotNull(ex.InnerException);
+    }
+
+    [TestMethod]
+    public async Task ListNetworksAsync_InspectMalformedJson_ThrowsContainerRuntimeExceptionWithInnerException()
+    {
+        // Arrange
+        var runner = new FakeWslcCliRunner();
+        runner.RunAsyncFunc = (arguments, cancellationToken) =>
+        {
+            if (arguments.SequenceEqual(new[] { "network", "list", "--format", "json" }))
+            {
+                return Task.FromResult(new CliResult(0, "[{\"Driver\":\"bridge\",\"Name\":\"app-net\"}]", string.Empty));
+            }
+
+            return Task.FromResult(new CliResult(0, "not-json", string.Empty));
+        };
+        var sut = new WslcCliContainerRuntimeClient(runner);
+
+        // Act & Assert
+        var ex = await Assert.ThrowsExactlyAsync<ContainerRuntimeException>(() => sut.ListNetworksAsync());
+        Assert.IsNotNull(ex.InnerException);
+    }
+
+    [TestMethod]
+    public async Task ListNetworksAsync_InspectReturnsEmptyArray_UsesMinValueAndKeepsNetwork()
+    {
+        // Arrange
+        var runner = new FakeWslcCliRunner();
+        runner.RunAsyncFunc = (arguments, cancellationToken) =>
+        {
+            if (arguments.SequenceEqual(new[] { "network", "list", "--format", "json" }))
+            {
+                return Task.FromResult(new CliResult(0, "[{\"Driver\":\"bridge\",\"Name\":\"app-net\"}]", string.Empty));
+            }
+
+            return Task.FromResult(new CliResult(0, "[]", string.Empty));
+        };
+        var sut = new WslcCliContainerRuntimeClient(runner);
+
+        // Act
+        var networks = await sut.ListNetworksAsync();
+
+        // Assert
+        Assert.HasCount(1, networks);
+        Assert.AreEqual(DateTimeOffset.MinValue, networks[0].CreatedAt);
+        Assert.AreEqual("app-net", networks[0].Name);
+    }
+
+    [TestMethod]
+    public async Task CreateNetworkAsync_CliArguments_AreNetworkCreateWithName()
+    {
+        // Arrange
+        var runner = new FakeWslcCliRunner { Result = new(0, string.Empty, string.Empty) };
+        var sut = new WslcCliContainerRuntimeClient(runner);
+
+        // Act
+        await sut.CreateNetworkAsync("app-net");
+
+        // Assert
+        CollectionAssert.AreEqual(new[] { "network", "create", "app-net" }, runner.Calls[0].ToList());
+    }
+
+    [TestMethod]
+    public async Task DeleteNetworkAsync_CliArguments_AreNetworkRemoveWithoutForce()
+    {
+        // Arrange
+        var runner = new FakeWslcCliRunner { Result = new(0, string.Empty, string.Empty) };
+        var sut = new WslcCliContainerRuntimeClient(runner);
+
+        // Act
+        await sut.DeleteNetworkAsync("app-net");
+
+        // Assert
+        var arguments = runner.Calls[0].ToList();
+        CollectionAssert.AreEqual(new[] { "network", "remove", "app-net" }, arguments);
+        CollectionAssert.DoesNotContain(arguments, "--force");
+    }
+}


### PR DESCRIPTION
Adds the missing network management surface so users can create, view, and safely delete WSL container networks from the desktop app alongside containers, images, and volumes.

## Summary
- Add domain, application, and infrastructure support for network resources over `wslc network list/create/remove/inspect`.
- Add Networks navigation, page/viewmodels, localized strings, and delete confirmation/safety states.
- Guard deletion of system networks and networks with connected containers; show `Unknown` when preview `wslc` does not return `CreatedAt`.
- Align resource page header accents and restore the Images list column headers.

## Notes
`wslc network inspect` currently does not expose `CreatedAt`, so the UI intentionally displays `Unknown` for that field when absent. System networks are recognized by reserved names when the CLI does not emit an explicit system flag.

## Validation
- `dotnet test .\WslContainersDesktop.slnx --no-restore --verbosity minimal`
- WinUI UI automation for the network flow passed locally.
- Real `wslc` probe confirmed container inspect network names match network list names for connected-count enrichment.

Fixes: #8