### PR TITLE
一覧ViewModelを差分更新にしコンテナ操作の途中状態を表示 (#28)

### DIFF
--- a/docs/adr/0013-adopt-differential-updates-for-list-views.md
+++ b/docs/adr/0013-adopt-differential-updates-for-list-views.md
@@ -1,0 +1,69 @@
+# 0013. 一覧ViewModelの更新に差分更新（ObservableCollectionReconciler）を採用する
+
+## Status
+
+Accepted
+
+## Context
+
+- [Issue #28 UIブラッシュアップ part2](https://github.com/runceel/wsl-containers-desktop/issues/28)
+  で次の2点の改善が求められた。
+  1. Containers/Images/Networks/Volumes の各一覧が、更新のたびに全体リフレッシュされる。
+  2. コンテナの Stop 実行時に途中状態（Stopping）が一覧に表示されず、Stopped になって初めて表示が変わる。
+- 各一覧ViewModelの `Replace*`（`ReplaceContainers` など）は `ObservableCollection.Clear()` の後に
+  全件を `Add()` していた。これは `CollectionChanged` の Reset を発生させ、`ListView` が全項目を
+  破棄・再生成する。結果として選択状態・スクロール位置が失われ、ちらつきの原因になっていた。
+- スコープ2の直接原因は別にあった。`ContainersPage.xaml` の状態列は
+  `Text="{x:Bind DisplayState}"`（Mode未指定）で、`x:Bind` の既定は `OneTime` のため、
+  `BeginBusy` が設定する途中状態（`PendingOperation=Stopping` 等）が反映されない。全件再構築の
+  タイミングで最終状態だけが見えていた。途中状態をその場で反映するには行インスタンスが維持され、
+  かつバインドが `OneWay` である必要がある。
+- 検討した代替案:
+  - **毎回全件 Clear+Add のまま維持**: 実装は単純だが Reset によるちらつき・選択喪失が解消できず、
+    途中状態のインプレース反映もできない（今回の要求を満たせない）。
+  - **`ObservableCollection` 差し替え／`INotifyCollectionChanged` の独自実装**: WinUI公式の
+    MVVMガイドラインが `ObservableCollection` の差し替えを避けるよう求めており、独自実装は
+    バグの温床になりやすい。
+  - **ドメイン `record` を直接キーにする差分更新**: `record` の自動等価は `IReadOnlyList<string>`
+    （`ConnectedContainerNames` 等）を参照比較するため、内容が同じでも別インスタンスなら不一致に
+    なり、意図しない行の作り直しが起きる。
+
+## Decision
+
+Presentation層に汎用の差分更新ヘルパー
+`ObservableCollectionReconciler.Reconcile(...)`（`WslContainersDesktop.App/Collections/`）を追加し、
+Containers/Images/Networks/Volumes の各一覧ViewModelの更新をこれに置き換える。
+
+- リコンサイラはキー一致で既存の行インスタンスを維持し、追加・削除・並び替え・（任意の）
+  インプレース更新のみを適用する。`Clear()` を使わないため Reset が発生しない。同一内容の
+  再取得では `CollectionChanged` を一切発生させない。ソースキーは一意であることを前提とし、
+  重複時は例外を投げる。
+- キー選択:
+  - **Container**: `Id ∣ Name ∣ Image ∣ CreatedAt`。`State` はキーに含めず、キー一致時に
+    `ApplyFrom` でインプレース更新する。これにより状態遷移は同一インスタンスのまま反映され、
+    他の表示フィールドが変わった行だけが作り直される。
+  - **Image / Network / Volume**: 表示・使用するフィールドを連結した**構造的な文字列キー**を用いる
+    （ドメイン `record` を直接キーにはしない）。インプレース更新は行わず、内容が変われば別キーとして
+    該当行のみ remove+add で作り直す。
+- スコープ2対応として、行インスタンスが維持されることを前提に `ContainersPage.xaml` の状態列を
+  `Mode=OneWay` に変更し、`_pendingOperations` を単一の情報源として busy/途中状態を差分更新の
+  新規・更新いずれの経路でも復元する。
+
+この方針は Issue #28 以降のすべての一覧ViewModelに適用する。
+
+## Consequences
+
+- 一覧更新時の Reset が解消され、ちらつき・選択喪失・スクロール位置の喪失がなくなる。
+- 行インスタンスが維持されるため、`OneWay` バインドと `_pendingOperations` の復元により、
+  コンテナ操作の途中状態（Stopping 等）を全件再構築を待たずにその場で表示できる。
+- リコンサイラの契約として「更新コールバックで扱わない表示フィールドはすべてキーに含める」必要がある。
+  含め忘れると当該フィールドの表示が陳腐化する（Container のキーに Name/Image/CreatedAt を含めるのは
+  このため）。
+- Network/Volume は背景での自動再同期や `_pendingOperations` 相当の busy 追跡を持たない。ユーザー起因の
+  削除中に別のリフレッシュが走り、当該行のキーが変わって作り直された場合は行の busy 表示が失われ得るが、
+  これは従来の Clear+Add（再同期のたびに必ず busy 表示を失っていた）より悪化しておらず、
+  名前単位の pending 追跡導入はスコープ外とした。
+- 影響を受ける設計ドキュメント: [`docs/design/containers-view.md`](../design/containers-view.md)、
+  [`docs/design/images-view.md`](../design/images-view.md)、
+  [`docs/design/networks-view.md`](../design/networks-view.md)、
+  [`docs/design/volumes-view.md`](../design/volumes-view.md)。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -63,5 +63,6 @@ docs/adr/NNNN-kebab-case-title.md
 | [0010](0010-adopt-di-container-for-presentation.md) | PresentationにDIコンテナ(Microsoft.Extensions.DependencyInjection)を導入する | Accepted |
 | [0011](0011-do-not-auto-restart-wsl-on-settings-change.md) | 設定変更時にWSLを自動再起動せず案内のみ行う | Accepted |
 | [0012](0012-wsl-environment-detection-and-wslconfig-editing.md) | WSL環境検出と`.wslconfig`編集の方式を採用する | Accepted |
+| [0013](0013-adopt-differential-updates-for-list-views.md) | 一覧ViewModelの更新に差分更新(ObservableCollectionReconciler)を採用する | Accepted |
 
 新しいADRを追加したら、この表にも1行追加すること。

--- a/docs/design/containers-view.md
+++ b/docs/design/containers-view.md
@@ -6,7 +6,7 @@
 
 `ContainersViewModel`（`ViewModels/ContainersViewModel.cs`）は、コンテナ一覧の取得・起動・停止・
 再起動・削除・詳細表示・ログ表示・対話的シェル表示を担うViewModel。各操作は非同期に実行され、
-`await` 中に一覧全体が再構築されるケース（ユーザーによる手動更新、他操作完了に伴う
+`await` 中に一覧が差分更新されるケース（ユーザーによる手動更新、他操作完了に伴う
 バックグラウンド再同期）を考慮した設計になっている。
 
 ## 一覧UI
@@ -22,14 +22,22 @@
 - 詳細・ログ・シェルは一覧の下ではなく右側の補助ペインに表示する。複数パネルが開いても一覧領域の高さを
   維持し、補助ペイン側だけを縦スクロールさせる。
 
-## 行インスタンスの非永続性と再検索
+## 一覧の差分更新と行インスタンスの維持
 
 - `Containers`（`ObservableCollection<ContainerRowViewModel>`）は `ReplaceContainers` によって
-  丸ごと作り直される。個々の `ContainerRowViewModel` インスタンスは再構築のたびに新しくなり、
-  以前のインスタンスは破棄される。
-- そのため、非同期操作の開始時にコマンド引数として受け取った行インスタンス（`row`）は、
-  `await` の後には既にライブの `Containers` に存在しない可能性がある。この行インスタンスは
-  操作対象の `Id` を得る以外の目的で使い続けない。
+  **差分更新**される。汎用ヘルパー `ObservableCollectionReconciler.Reconcile`（`Collections/`）が、
+  キー一致で既存の `ContainerRowViewModel` インスタンスを維持したまま、追加・削除・並び替え・
+  インプレース更新のみを適用する（`ObservableCollection.Clear()` を使わないため `ListView` の
+  Reset が発生せず、選択やスクロール位置が保たれる）。差分更新を採用した理由と、他の一覧
+  （Images/Networks/Volumes）を含む一覧全体での方針は [ADR-0013](../adr/0013-adopt-differential-updates-for-list-views.md) を参照。
+- 行キーは `BuildContainerKey`（`Id ∣ Name ∣ Image ∣ CreatedAt`）。`State` はキーに含めず、
+  キー一致時に `ApplyFrom` でインプレース更新する。これにより状態遷移（例: Stopped→Running）は
+  同一インスタンスのまま反映され、Name/Image/CreatedAt など他の表示フィールドが変わった場合のみ
+  該当行が作り直される（外部改名などによる表示の陳腐化を防ぐ）。
+- 行インスタンスは基本的に維持されるが、上記のキー変化や、サーバー応答からの消失・再出現に
+  よって作り直される場合がある。そのため、非同期操作の開始時にコマンド引数として受け取った
+  行インスタンス（`row`）は、`await` の後には既にライブの `Containers` に存在しない可能性がある。
+  この行インスタンスは操作対象の `Id` を得る以外の目的で使い続けない。
 - `FindLiveRow(string containerId)` が、その時点でのライブな `Containers` からIDで行を
   再検索する唯一の手段。`await` をまたいだ後の状態反映（busy解除、`ApplyFrom` によるプロパティ
   反映、削除時の `Containers.Remove`）は必ずこのメソッドで取得した行に対して行う。
@@ -38,17 +46,21 @@
 
 - 行の `IsBusy`・`PendingOperation`（進行中の操作種別。`ContainerRowOperation`の`None`/`Starting`/
   `Stopping`/`Restarting`/`Deleting`のいずれか）は `ContainerRowViewModel` インスタンスに紐づく
-  プロパティだが、上記の通りインスタンスは再構築で失われる。
+  プロパティだが、差分更新で行が作り直されたり、一覧から一時的に消えて再出現したりする場合がある。
 - `ContainersViewModel` はコンテナID単位で `_pendingOperations`（`Dictionary<string, ContainerRowOperation>`）
   に進行中操作を保持する。キーが存在すること自体がbusy中を表し、値がその操作種別を表す
   （busy状態と操作種別は必ず一致するため単一の辞書で一元管理する）。`BeginBusy(id, operation)`/
-  `EndBusy(id)` で追加・削除する。`ReplaceContainers` は新しい行を作る際にこの辞書を参照し、
-  該当IDがあれば新しい行にも `IsBusy = true` と `PendingOperation` を復元する。
+  `EndBusy(id)` で追加・削除する。`ReplaceContainers` は差分更新の際、行を新規生成するときも
+  既存行を更新するときも `ApplyPendingOperation` を通じてこの辞書を参照し、該当IDがあれば
+  `IsBusy = true` と `PendingOperation` を復元し、なければ解除する。
 - `EndBusy` は、対応する `TryRefreshSilentlyAsync`（内部で `ReplaceContainers` を呼ぶ）より
-  必ず前に呼び出す。順序を守らないと、再同期後の新しい行が古い記録を見て、実際には完了した
-  操作の途中状態表示を解除できなくなる。
+  必ず前に呼び出す。順序を守らないと、再同期時に `_pendingOperations` に残ったままの古い記録を
+  見て、実際には完了した操作の途中状態表示を解除できなくなる。
 - 行の表示用状態 `DisplayState`（`ContainerRowDisplayState`。`State`と`PendingOperation`の組み合わせ）
-  は、`State`・`PendingOperation`いずれの変更でも再計算される。State列のコンバーターは
+  は、`State`・`PendingOperation`いずれの変更でも再計算される。差分更新で行インスタンスが維持される
+  ため、`ContainersPage.xaml` の State列は `Text="{x:Bind DisplayState, Mode=OneWay}"` とし
+  （`x:Bind` の既定 `OneTime` では途中状態が反映されない）、`BeginBusy` による `Stopping` などの
+  途中状態がその場で一覧に反映される。State列のコンバーターは
   `ContainerDisplayStateResourceKeySelector.GetResourceKey(DisplayState)` でリソースキーを選択し
   （`PendingOperation`が`None`以外ならその操作種別を優先、`None`なら`State`から選択）、
   `ResourceLoader` でローカライズ済みテキストへ変換する。

--- a/docs/design/images-view.md
+++ b/docs/design/images-view.md
@@ -20,7 +20,11 @@ pull、不要イメージの削除を担うViewModel。Application層の`IImageM
 ## 更新とエラー表示
 
 - `RefreshAsync`は`IImageManagementService.GetImagesAsync`で最新状態を取得し、成功時に`Images`を
-  全件置き換える。
+  差分更新する（`ObservableCollectionReconciler.Reconcile`。`Clear()` を使わず既存の行インスタンスを
+  維持し、追加・削除・並び替えのみを適用するため `ListView` の Reset を避けられる。詳細は
+  [ADR-0013](../adr/0013-adopt-differential-updates-for-list-views.md)）。行キーは表示・使用する
+  フィールドを連結した構造的な文字列キー（`Id ∣ Repository ∣ Tag`。イメージIDは内容ダイジェストのため
+  サイズ・作成日時はIDに従属する）で、内容が変われば別キーとして当該行のみ作り直す。
 - 更新失敗時は既存の一覧を保持し、`ErrorMessage`に例外メッセージを設定する。
 - 新しい操作を開始する際は古い成功メッセージをクリアし、エラーと成功メッセージが矛盾して同時表示されない
   ようにする。

--- a/docs/design/networks-view.md
+++ b/docs/design/networks-view.md
@@ -25,7 +25,12 @@
 ## 更新とエラー表示
 
 - `RefreshAsync`は`INetworkManagementService.GetNetworksAsync`で最新状態を取得し、成功時に`Networks`を
-  全件置き換える。
+  差分更新する（`ObservableCollectionReconciler.Reconcile`。`Clear()` を使わず既存の行インスタンスを
+  維持し、追加・削除・並び替えのみを適用するため `ListView` の Reset を避けられる。詳細は
+  [ADR-0013](../adr/0013-adopt-differential-updates-for-list-views.md)）。行キーは表示・使用する
+  フィールドを連結した構造的な文字列キー（`Name ∣ Driver ∣ CreatedAt ∣ IsSystem ∣ 接続コンテナ名の連結`）で、
+  内容が変われば別キーとして当該行のみ作り直す。`record` の自動等価は `IReadOnlyList<string>` を
+  参照比較するため、ドメインレコードを直接キーにはしない。
 - 更新失敗時は既存の一覧を保持し、`ErrorMessage`に例外メッセージを設定する。
 - 新しい操作を開始する際は古い成功メッセージをクリアし、エラーと成功メッセージが矛盾して同時表示されない
   ようにする。

--- a/docs/design/volumes-view.md
+++ b/docs/design/volumes-view.md
@@ -20,7 +20,12 @@
 ## 更新とエラー表示
 
 - `RefreshAsync`は`IVolumeManagementService.GetVolumesAsync`で最新状態を取得し、成功時に`Volumes`を
-  全件置き換える。
+  差分更新する（`ObservableCollectionReconciler.Reconcile`。`Clear()` を使わず既存の行インスタンスを
+  維持し、追加・削除・並び替えのみを適用するため `ListView` の Reset を避けられる。詳細は
+  [ADR-0013](../adr/0013-adopt-differential-updates-for-list-views.md)）。行キーは表示・使用する
+  フィールドを連結した構造的な文字列キー（`Name ∣ Driver ∣ CreatedAt ∣ 参照コンテナ名の連結`）で、
+  内容が変われば別キーとして当該行のみ作り直す。`record` の自動等価は `IReadOnlyList<string>` を
+  参照比較するため、ドメインレコードを直接キーにはしない。
 - 更新失敗時は既存の一覧を保持し、`ErrorMessage`に例外メッセージを設定する。
 - 新しい操作を開始する際は古い成功メッセージをクリアし、エラーと成功メッセージが矛盾して同時表示されない
   ようにする。

--- a/src/WslContainersDesktop.App/Collections/ObservableCollectionReconciler.cs
+++ b/src/WslContainersDesktop.App/Collections/ObservableCollectionReconciler.cs
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.ObjectModel;
+
+namespace WslContainersDesktop_App.Collections;
+
+/// <summary>
+/// <see cref="ObservableCollection{T}"/> を、キー一致に基づいて差分更新するためのヘルパー。
+/// </summary>
+/// <remarks>
+/// <see cref="ObservableCollection{T}.Clear"/> による全項目リセットを避け、
+/// 変更のない行インスタンスを維持したまま追加・削除・並び替え・インプレース更新のみを行う。
+/// これにより <c>ListView</c> の全体再構築（ちらつき・選択状態や途中状態の喪失）を防ぐ。
+/// キーはソース内で一意であることを前提とする。
+/// </remarks>
+public static class ObservableCollectionReconciler
+{
+    /// <summary>
+    /// <paramref name="target"/> の内容を <paramref name="source"/> に一致するよう差分更新する。
+    /// </summary>
+    /// <typeparam name="TItem">対象コレクションの要素型。</typeparam>
+    /// <typeparam name="TSource">ソースの要素型。</typeparam>
+    /// <typeparam name="TKey">一致判定に用いるキーの型。</typeparam>
+    /// <param name="target">差分更新される対象のコレクション。</param>
+    /// <param name="source">あるべき状態を表すソース。</param>
+    /// <param name="targetKeySelector">対象要素からキーを取り出す関数。</param>
+    /// <param name="sourceKeySelector">ソース要素からキーを取り出す関数。</param>
+    /// <param name="create">ソース要素から新しい対象要素を生成する関数。</param>
+    /// <param name="update">
+    /// キーが一致した既存要素をインプレース更新する関数。省略時は何もしない。
+    /// </param>
+    /// <exception cref="ArgumentException"><paramref name="source"/> に重複するキーが含まれる場合。</exception>
+    public static void Reconcile<TItem, TSource, TKey>(
+        ObservableCollection<TItem> target,
+        IReadOnlyList<TSource> source,
+        Func<TItem, TKey> targetKeySelector,
+        Func<TSource, TKey> sourceKeySelector,
+        Func<TSource, TItem> create,
+        Action<TItem, TSource>? update = null)
+        where TKey : notnull
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(targetKeySelector);
+        ArgumentNullException.ThrowIfNull(sourceKeySelector);
+        ArgumentNullException.ThrowIfNull(create);
+
+        var sourceKeys = new HashSet<TKey>(source.Count);
+        foreach (var sourceItem in source)
+        {
+            if (!sourceKeys.Add(sourceKeySelector(sourceItem)))
+            {
+                throw new ArgumentException("ソースに重複するキーが含まれています。", nameof(source));
+            }
+        }
+
+        // Pass 1: ソースに存在しないキーの要素を末尾から削除する。
+        for (var i = target.Count - 1; i >= 0; i--)
+        {
+            if (!sourceKeys.Contains(targetKeySelector(target[i])))
+            {
+                target.RemoveAt(i);
+            }
+        }
+
+        // Pass 2: ソース順に走査し、対象コレクションを整列させる。
+        for (var i = 0; i < source.Count; i++)
+        {
+            var sourceItem = source[i];
+            var key = sourceKeySelector(sourceItem);
+
+            var matchIndex = -1;
+            for (var j = i; j < target.Count; j++)
+            {
+                if (EqualityComparer<TKey>.Default.Equals(targetKeySelector(target[j]), key))
+                {
+                    matchIndex = j;
+                    break;
+                }
+            }
+
+            if (matchIndex < 0)
+            {
+                target.Insert(i, create(sourceItem));
+                continue;
+            }
+
+            if (matchIndex != i)
+            {
+                target.Move(matchIndex, i);
+            }
+
+            update?.Invoke(target[i], sourceItem);
+        }
+    }
+}

--- a/src/WslContainersDesktop.App/Pages/ContainersPage.xaml
+++ b/src/WslContainersDesktop.App/Pages/ContainersPage.xaml
@@ -117,7 +117,7 @@
                                     </Grid.ColumnDefinitions>
                                     <TextBlock Grid.Column="0" VerticalAlignment="Center" Text="{x:Bind Name}" />
                                     <TextBlock Grid.Column="1" VerticalAlignment="Center" Text="{x:Bind Image}" />
-                                    <TextBlock Grid.Column="2" VerticalAlignment="Center" Text="{x:Bind DisplayState, Converter={StaticResource StateToDisplayTextConverter}}" />
+                                    <TextBlock Grid.Column="2" VerticalAlignment="Center" Text="{x:Bind DisplayState, Mode=OneWay, Converter={StaticResource StateToDisplayTextConverter}}" />
                                     <TextBlock Grid.Column="3" VerticalAlignment="Center" Text="{x:Bind CreatedAt, Converter={StaticResource CreatedAtConverter}}" />
                                     <StackPanel Grid.Column="4" Orientation="Horizontal">
                                         <Button

--- a/src/WslContainersDesktop.App/ViewModels/ContainersViewModel.cs
+++ b/src/WslContainersDesktop.App/ViewModels/ContainersViewModel.cs
@@ -2,11 +2,13 @@
 // Licensed under the MIT License.
 
 using System.Collections.ObjectModel;
+using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using WslContainersDesktop.Application.Exceptions;
 using WslContainersDesktop.Application.Ports;
 using WslContainersDesktop.Domain;
+using WslContainersDesktop_App.Collections;
 
 namespace WslContainersDesktop_App.ViewModels;
 
@@ -883,11 +885,13 @@ public sealed partial class ContainersViewModel(IContainerManagementService cont
 
     /// <summary>
     /// 指定したコンテナIDをbusy状態にし、進行中の操作種別を記録する。
-    /// <see cref="_pendingOperations"/> にID→操作種別を記録することで、
-    /// 操作の完了前に <see cref="ReplaceContainers"/> が呼ばれて行インスタンスが再生成されても
-    /// busy状態と操作種別を復元できるようにする。あわせて、その時点でのライブの
-    /// <see cref="Containers"/> に該当行が存在すれば、その行の <see cref="ContainerRowViewModel.IsBusy"/>
-    /// と <see cref="ContainerRowViewModel.PendingOperation"/> も直接設定する。
+    /// <see cref="_pendingOperations"/> にID→操作種別を記録することで、操作の完了前に
+    /// <see cref="ReplaceContainers"/> が呼ばれても busy状態と操作種別を復元できるようにする
+    /// （差分更新では行インスタンスは基本的に維持されるが、表示フィールドの変化でキーが変われば
+    /// 該当行が作り直されたり、一覧から一時的に消えて再出現したりする場合があるため）。
+    /// あわせて、その時点でのライブの <see cref="Containers"/> に該当行が存在すれば、その行の
+    /// <see cref="ContainerRowViewModel.IsBusy"/> と <see cref="ContainerRowViewModel.PendingOperation"/>
+    /// も直接設定する。
     /// </summary>
     /// <param name="containerId">busy状態にするコンテナID。</param>
     /// <param name="operation">進行中の操作種別。</param>
@@ -907,11 +911,12 @@ public sealed partial class ContainersViewModel(IContainerManagementService cont
     /// </summary>
     /// <remarks>
     /// 呼び出し側は、成功・失敗どちらの分岐であっても、この呼び出しを <c>finally</c> 節ではなく
-    /// 各分岐の中で <see cref="TryRefreshSilentlyAsync"/>（内部で行インスタンスを再生成する
-    /// <see cref="ReplaceContainers"/> を呼ぶ）より前に行う必要がある。もし <c>finally</c> で
-    /// （＝再同期の後で）解除すると、再同期によって作られた新しい行インスタンスは
-    /// <see cref="_pendingOperations"/> に残ったままの古い記録を見てbusy状態・操作種別を
-    /// 復元してしまい、実際には完了した操作の途中状態表示が解除されなくなる。
+    /// 各分岐の中で <see cref="TryRefreshSilentlyAsync"/>（内部で <see cref="ReplaceContainers"/> を
+    /// 呼び、維持・新規どちらの行にも <see cref="ApplyPendingOperation"/> で
+    /// <see cref="_pendingOperations"/> の内容を反映する）より前に行う必要がある。もし <c>finally</c> で
+    /// （＝再同期の後で）解除すると、再同期時に <see cref="_pendingOperations"/> に残ったままの古い記録を
+    /// 見てbusy状態・操作種別が再適用されてしまい、実際には完了した操作の途中状態表示が
+    /// 解除されなくなる。
     /// </remarks>
     /// <param name="containerId">busy状態を解除するコンテナID。</param>
     private void EndBusy(string containerId)
@@ -927,8 +932,9 @@ public sealed partial class ContainersViewModel(IContainerManagementService cont
 
     /// <summary>
     /// その時点でのライブの <see cref="Containers"/> から、コンテナIDに一致する行インスタンスを探す。
-    /// <see cref="ReplaceContainers"/> によって行インスタンスが再生成された後は、操作開始時に
-    /// 捕まえていた行インスタンスがすでにライブのコレクションに存在しない場合があるため、
+    /// 差分更新（<see cref="ReplaceContainers"/>）では行インスタンスはキー一致で基本的に維持されるが、
+    /// 操作開始時に捕まえていた行が await をまたいだ後には（キー変化による作り直しや、
+    /// 一覧からの一時的な消失などで）ライブのコレクションに存在しない場合があるため、
     /// await をまたいだ後の行操作は必ずこのメソッドで再検索した行に対して行う。
     /// </summary>
     /// <param name="containerId">検索するコンテナID。</param>
@@ -937,27 +943,61 @@ public sealed partial class ContainersViewModel(IContainerManagementService cont
 
     private void ReplaceContainers(IReadOnlyList<Container> containers)
     {
-        Containers.Clear();
-        foreach (var container in containers)
-        {
-            if (_pendingDeleteContainerIds.Contains(container.Id))
-            {
-                // 削除操作が進行中のコンテナは、サーバーからまだ削除完了前の状態が
-                // 返ってきていても一覧に含めない（削除の楽観的更新）。
-                continue;
-            }
+        var source = containers
+            .Where(container => !_pendingDeleteContainerIds.Contains(container.Id))
+            .ToList();
 
-            var row = new ContainerRowViewModel(container);
-            if (_pendingOperations.TryGetValue(container.Id, out var operation))
-            {
-                row.IsBusy = true;
-                row.PendingOperation = operation;
-            }
-
-            Containers.Add(row);
-        }
+        ObservableCollectionReconciler.Reconcile(
+            Containers,
+            source,
+            targetKeySelector: static row => BuildContainerKey(row.Id, row.Name, row.Image, row.CreatedAt),
+            sourceKeySelector: static container => BuildContainerKey(container.Id, container.Name, container.Image, container.CreatedAt),
+            create: CreateContainerRow,
+            update: UpdateContainerRow);
 
         IsEmpty = Containers.Count == 0;
+    }
+
+    /// <summary>
+    /// 差分更新用の行キーを組み立てる。<see cref="ContainerRowViewModel"/> がインプレース更新する
+    /// <see cref="ContainerState"/> は含めず、行が保持する読み取り専用の表示フィールド
+    /// （Id / Name / Image / CreatedAt）をすべて含める。State 以外の表示フィールドが変われば
+    /// キーが変わり該当行だけが作り直されるため、外部での改名などによる表示の陳腐化を防ぐ。
+    /// </summary>
+    private static string BuildContainerKey(string id, string name, string image, DateTimeOffset createdAt)
+        => string.Join('\u001f', id, name, image, createdAt.UtcTicks.ToString(CultureInfo.InvariantCulture));
+
+    private ContainerRowViewModel CreateContainerRow(Container container)
+    {
+        var row = new ContainerRowViewModel(container);
+        ApplyPendingOperation(row);
+        return row;
+    }
+
+    private void UpdateContainerRow(ContainerRowViewModel row, Container container)
+    {
+        row.ApplyFrom(container);
+        ApplyPendingOperation(row);
+    }
+
+    /// <summary>
+    /// <see cref="_pendingOperations"/> を単一の情報源として、行の busy 状態・進行中の操作種別を反映する。
+    /// 差分更新（<see cref="ReplaceContainers"/>）で行インスタンスが維持されても新規生成されても、
+    /// 進行中の操作があれば復元し、なければ解除することで一貫した表示を保つ。
+    /// </summary>
+    /// <param name="row">反映先の行。</param>
+    private void ApplyPendingOperation(ContainerRowViewModel row)
+    {
+        if (_pendingOperations.TryGetValue(row.Id, out var operation))
+        {
+            row.IsBusy = true;
+            row.PendingOperation = operation;
+        }
+        else
+        {
+            row.IsBusy = false;
+            row.PendingOperation = ContainerRowOperation.None;
+        }
     }
 
     private sealed class ExecSessionState(string containerId, IContainerExecSession session) : IDisposable

--- a/src/WslContainersDesktop.App/ViewModels/ImagesViewModel.cs
+++ b/src/WslContainersDesktop.App/ViewModels/ImagesViewModel.cs
@@ -6,6 +6,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using WslContainersDesktop.Application.Ports;
 using WslContainersDesktop.Domain;
+using WslContainersDesktop_App.Collections;
 
 namespace WslContainersDesktop_App.ViewModels;
 
@@ -174,12 +175,16 @@ public sealed partial class ImagesViewModel(IImageManagementService imageManagem
 
     private void ReplaceImages(IReadOnlyList<ContainerImage> images)
     {
-        Images.Clear();
-        foreach (var image in images)
-        {
-            Images.Add(new ImageRowViewModel(image));
-        }
+        ObservableCollectionReconciler.Reconcile(
+            Images,
+            images,
+            row => BuildImageKey(row.Id, row.Repository, row.Tag),
+            image => BuildImageKey(image.Id, image.Repository, image.Tag),
+            image => new ImageRowViewModel(image));
 
         IsEmpty = Images.Count == 0;
     }
+
+    private static string BuildImageKey(string id, string repository, string tag)
+        => string.Join('\u001f', id, repository, tag);
 }

--- a/src/WslContainersDesktop.App/ViewModels/NetworksViewModel.cs
+++ b/src/WslContainersDesktop.App/ViewModels/NetworksViewModel.cs
@@ -2,11 +2,13 @@
 // Licensed under the MIT License.
 
 using System.Collections.ObjectModel;
+using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using WslContainersDesktop.Application.Exceptions;
 using WslContainersDesktop.Application.Ports;
 using WslContainersDesktop.Domain;
+using WslContainersDesktop_App.Collections;
 
 namespace WslContainersDesktop_App.ViewModels;
 
@@ -212,14 +214,24 @@ public sealed partial class NetworksViewModel(INetworkManagementService networkM
 
     private void ReplaceNetworks(IReadOnlyList<ContainerNetworkResource> networks)
     {
-        Networks.Clear();
-        foreach (var network in networks)
-        {
-            Networks.Add(new NetworkRowViewModel(network));
-        }
+        ObservableCollectionReconciler.Reconcile(
+            Networks,
+            networks,
+            row => BuildNetworkKey(row.Name, row.Driver, row.CreatedAt, row.IsSystem, row.ConnectedContainerNames),
+            network => BuildNetworkKey(network.Name, network.Driver, network.CreatedAt, network.IsSystem, network.ConnectedContainerNames),
+            network => new NetworkRowViewModel(network));
 
         UpdateNetworkFlags();
     }
+
+    private static string BuildNetworkKey(string name, string driver, DateTimeOffset createdAt, bool isSystem, IReadOnlyList<string> connectedContainerNames)
+        => string.Join(
+            '\u001f',
+            name,
+            driver,
+            createdAt.UtcTicks.ToString(CultureInfo.InvariantCulture),
+            isSystem,
+            string.Join('\u001e', connectedContainerNames));
 
     private void UpdateNetworkFlags()
     {

--- a/src/WslContainersDesktop.App/ViewModels/VolumesViewModel.cs
+++ b/src/WslContainersDesktop.App/ViewModels/VolumesViewModel.cs
@@ -1,9 +1,11 @@
 using System.Collections.ObjectModel;
+using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using WslContainersDesktop.Application.Exceptions;
 using WslContainersDesktop.Application.Ports;
 using WslContainersDesktop.Domain;
+using WslContainersDesktop_App.Collections;
 
 namespace WslContainersDesktop_App.ViewModels;
 
@@ -185,14 +187,23 @@ public sealed partial class VolumesViewModel(IVolumeManagementService volumeMana
 
     private void ReplaceVolumes(IReadOnlyList<ContainerVolume> volumes)
     {
-        Volumes.Clear();
-        foreach (var volume in volumes)
-        {
-            Volumes.Add(new VolumeRowViewModel(volume));
-        }
+        ObservableCollectionReconciler.Reconcile(
+            Volumes,
+            volumes,
+            row => BuildVolumeKey(row.Name, row.Driver, row.CreatedAt, row.ReferencingContainerNames),
+            volume => BuildVolumeKey(volume.Name, volume.Driver, volume.CreatedAt, volume.ReferencingContainerNames),
+            volume => new VolumeRowViewModel(volume));
 
         IsEmpty = Volumes.Count == 0;
     }
+
+    private static string BuildVolumeKey(string name, string driver, DateTimeOffset createdAt, IReadOnlyList<string> referencingContainerNames)
+        => string.Join(
+            '\u001f',
+            name,
+            driver,
+            createdAt.UtcTicks.ToString(CultureInfo.InvariantCulture),
+            string.Join('\u001e', referencingContainerNames));
 
     private static string FormatInUseMessage(string volumeName, IReadOnlyList<string> referencingContainerNames)
     {

--- a/tests/WslContainersDesktop.App.Tests/Collections/ObservableCollectionReconcilerTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/Collections/ObservableCollectionReconcilerTests.cs
@@ -1,0 +1,239 @@
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using WslContainersDesktop_App.Collections;
+
+namespace WslContainersDesktop_App_Tests.Collections;
+
+[TestClass]
+public sealed class ObservableCollectionReconcilerTests
+{
+    private sealed class Item(string key, int value)
+    {
+        public string Key { get; } = key;
+
+        public int Value { get; set; } = value;
+    }
+
+    private static void Reconcile(ObservableCollection<Item> target, IReadOnlyList<Item> source, bool applyUpdate = true) =>
+        ObservableCollectionReconciler.Reconcile(
+            target,
+            source,
+            targetKeySelector: static item => item.Key,
+            sourceKeySelector: static item => item.Key,
+            create: static item => new Item(item.Key, item.Value),
+            update: applyUpdate ? static (item, source) => item.Value = source.Value : null);
+
+    private static List<NotifyCollectionChangedAction> RecordActions(ObservableCollection<Item> target)
+    {
+        var actions = new List<NotifyCollectionChangedAction>();
+        target.CollectionChanged += (_, e) => actions.Add(e.Action);
+        return actions;
+    }
+
+    [TestMethod]
+    public void Reconcile_EmptyTargetNonEmptySource_AddsAllInSourceOrder()
+    {
+        // Arrange
+        var target = new ObservableCollection<Item>();
+        var source = new[] { new Item("a", 1), new Item("b", 2), new Item("c", 3) };
+
+        // Act
+        Reconcile(target, source);
+
+        // Assert
+        CollectionAssert.AreEqual(new[] { "a", "b", "c" }, target.Select(i => i.Key).ToArray());
+    }
+
+    [TestMethod]
+    public void Reconcile_IdenticalKeysSameOrder_PreservesAllInstances()
+    {
+        // Arrange
+        var target = new ObservableCollection<Item> { new("a", 1), new("b", 2), new("c", 3) };
+        var originals = target.ToArray();
+        var source = new[] { new Item("a", 1), new Item("b", 2), new Item("c", 3) };
+
+        // Act
+        Reconcile(target, source);
+
+        // Assert
+        Assert.AreSame(originals[0], target[0]);
+        Assert.AreSame(originals[1], target[1]);
+        Assert.AreSame(originals[2], target[2]);
+    }
+
+    [TestMethod]
+    public void Reconcile_IdenticalContent_RaisesNoCollectionChanged()
+    {
+        // Arrange
+        var target = new ObservableCollection<Item> { new("a", 1), new("b", 2), new("c", 3) };
+        var actions = RecordActions(target);
+        var source = new[] { new Item("a", 1), new Item("b", 2), new Item("c", 3) };
+
+        // Act
+        Reconcile(target, source);
+
+        // Assert
+        Assert.IsEmpty(actions);
+    }
+
+    [TestMethod]
+    public void Reconcile_MatchingKeyDifferentValue_UpdateAppliedInPlaceSameInstance()
+    {
+        // Arrange
+        var target = new ObservableCollection<Item> { new("a", 1) };
+        var original = target[0];
+        var actions = RecordActions(target);
+        var source = new[] { new Item("a", 42) };
+
+        // Act
+        Reconcile(target, source);
+
+        // Assert
+        Assert.AreSame(original, target[0]);
+        Assert.AreEqual(42, target[0].Value);
+        Assert.IsEmpty(actions);
+    }
+
+    [TestMethod]
+    public void Reconcile_NewKeyInMiddle_InsertsAtCorrectPositionPreservingOthers()
+    {
+        // Arrange
+        var target = new ObservableCollection<Item> { new("a", 1), new("c", 3) };
+        var originalA = target[0];
+        var originalC = target[1];
+        var actions = RecordActions(target);
+        var source = new[] { new Item("a", 1), new Item("b", 2), new Item("c", 3) };
+
+        // Act
+        Reconcile(target, source);
+
+        // Assert
+        CollectionAssert.AreEqual(new[] { "a", "b", "c" }, target.Select(i => i.Key).ToArray());
+        Assert.AreSame(originalA, target[0]);
+        Assert.AreSame(originalC, target[2]);
+        Assert.AreEqual(1, actions.Count(a => a == NotifyCollectionChangedAction.Add));
+    }
+
+    [TestMethod]
+    public void Reconcile_KeyRemovedFromMiddle_RemovesItAndPreservesOthers()
+    {
+        // Arrange
+        var target = new ObservableCollection<Item> { new("a", 1), new("b", 2), new("c", 3) };
+        var originalA = target[0];
+        var originalC = target[2];
+        var actions = RecordActions(target);
+        var source = new[] { new Item("a", 1), new Item("c", 3) };
+
+        // Act
+        Reconcile(target, source);
+
+        // Assert
+        CollectionAssert.AreEqual(new[] { "a", "c" }, target.Select(i => i.Key).ToArray());
+        Assert.AreSame(originalA, target[0]);
+        Assert.AreSame(originalC, target[1]);
+        Assert.AreEqual(1, actions.Count(a => a == NotifyCollectionChangedAction.Remove));
+    }
+
+    [TestMethod]
+    public void Reconcile_SourceReordered_ReflectsNewOrderPreservingInstances()
+    {
+        // Arrange
+        var target = new ObservableCollection<Item> { new("a", 1), new("b", 2), new("c", 3) };
+        var originalA = target[0];
+        var originalB = target[1];
+        var originalC = target[2];
+        var actions = RecordActions(target);
+        var source = new[] { new Item("c", 3), new Item("a", 1), new Item("b", 2) };
+
+        // Act
+        Reconcile(target, source);
+
+        // Assert
+        CollectionAssert.AreEqual(new[] { "c", "a", "b" }, target.Select(i => i.Key).ToArray());
+        Assert.AreSame(originalC, target[0]);
+        Assert.AreSame(originalA, target[1]);
+        Assert.AreSame(originalB, target[2]);
+        CollectionAssert.DoesNotContain(actions, NotifyCollectionChangedAction.Reset, "リセットを発生させてはならない。");
+        CollectionAssert.DoesNotContain(actions, NotifyCollectionChangedAction.Add, "並び替えで追加を発生させてはならない。");
+        CollectionAssert.DoesNotContain(actions, NotifyCollectionChangedAction.Remove, "並び替えで削除を発生させてはならない。");
+        CollectionAssert.Contains(actions, NotifyCollectionChangedAction.Move, "並び替えはMoveで反映されるべき。");
+    }
+
+    [TestMethod]
+    public void Reconcile_SourceEmpty_ClearsAllRows()
+    {
+        // Arrange
+        var target = new ObservableCollection<Item> { new("a", 1), new("b", 2) };
+        var actions = RecordActions(target);
+
+        // Act
+        Reconcile(target, []);
+
+        // Assert
+        Assert.IsEmpty(target);
+        CollectionAssert.DoesNotContain(actions, NotifyCollectionChangedAction.Reset, "Clearによるリセットを使ってはならない。");
+    }
+
+    [TestMethod]
+    public void Reconcile_AddedAtEnd_RaisesSingleAdd()
+    {
+        // Arrange
+        var target = new ObservableCollection<Item> { new("a", 1) };
+        var originalA = target[0];
+        var actions = RecordActions(target);
+        var source = new[] { new Item("a", 1), new Item("b", 2) };
+
+        // Act
+        Reconcile(target, source);
+
+        // Assert
+        CollectionAssert.AreEqual(new[] { "a", "b" }, target.Select(i => i.Key).ToArray());
+        Assert.AreSame(originalA, target[0]);
+        Assert.AreEqual(1, actions.Count(a => a == NotifyCollectionChangedAction.Add));
+    }
+
+    [TestMethod]
+    public void Reconcile_NullUpdate_MatchingKeysNotMutated()
+    {
+        // Arrange
+        var target = new ObservableCollection<Item> { new("a", 1) };
+        var original = target[0];
+        var source = new[] { new Item("a", 99) };
+
+        // Act
+        Reconcile(target, source, applyUpdate: false);
+
+        // Assert
+        Assert.AreSame(original, target[0]);
+        Assert.AreEqual(1, target[0].Value);
+    }
+
+    [TestMethod]
+    public void Reconcile_RemoveInsertAndReorderCombined_ProducesSourceStateAndPreservesSurvivors()
+    {
+        // Arrange
+        var target = new ObservableCollection<Item> { new("a", 1), new("b", 2), new("c", 3), new("d", 4) };
+        var originalB = target[1];
+        var originalD = target[3];
+        var source = new[] { new Item("d", 4), new Item("b", 2), new Item("e", 5) };
+
+        // Act
+        Reconcile(target, source);
+
+        // Assert
+        CollectionAssert.AreEqual(new[] { "d", "b", "e" }, target.Select(i => i.Key).ToArray());
+        Assert.AreSame(originalD, target[0]);
+        Assert.AreSame(originalB, target[1]);
+    }
+
+    [TestMethod]
+    public void Reconcile_DuplicateSourceKeys_ThrowsArgumentException()
+    {
+        // Arrange
+        var target = new ObservableCollection<Item>();
+        var source = new[] { new Item("a", 1), new Item("a", 2) };
+
+        // Act & Assert
+        Assert.ThrowsExactly<ArgumentException>(() => Reconcile(target, source));
+    }
+}

--- a/tests/WslContainersDesktop.App.Tests/Pages/ContainersPageSourceTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/Pages/ContainersPageSourceTests.cs
@@ -1,0 +1,49 @@
+namespace WslContainersDesktop_App_Tests.Pages;
+
+[TestClass]
+public sealed class ContainersPageSourceTests
+{
+    [TestMethod]
+    public void ContainersPage_StateColumnBindsDisplayStateOneWay()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Pages\ContainersPage.xaml");
+
+        // Act
+        // No-op: the test validates the source binding required by the intermediate-state display feature.
+
+        // Assert
+        StringAssert.Contains(
+            sourceText,
+            "Text=\"{x:Bind DisplayState, Mode=OneWay, Converter={StaticResource StateToDisplayTextConverter}}\"",
+            "State列は途中状態（Stopping等）を反映するため DisplayState を Mode=OneWay でバインドする必要がある。");
+    }
+
+    private static string ReadRepositorySourceFile(string relativePath)
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var normalizedRelativePath = relativePath.Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar);
+        var fullPath = Path.Combine(repositoryRoot, normalizedRelativePath);
+
+        Assert.IsTrue(File.Exists(fullPath), $"Expected source file '{relativePath}' to exist at '{fullPath}'.");
+        return File.ReadAllText(fullPath);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var currentDirectory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (currentDirectory is not null)
+        {
+            var appProjectFilePath = Path.Combine(currentDirectory.FullName, "src", "WslContainersDesktop.App", "WslContainersDesktop.App.csproj");
+            if (File.Exists(appProjectFilePath))
+            {
+                return currentDirectory.FullName;
+            }
+
+            currentDirectory = currentDirectory.Parent;
+        }
+
+        Assert.Fail($"Could not locate repository root from '{AppContext.BaseDirectory}'.");
+        return string.Empty;
+    }
+}

--- a/tests/WslContainersDesktop.App.Tests/ViewModels/ContainersViewModelTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/ViewModels/ContainersViewModelTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Specialized;
 using System.Threading.Channels;
 using WslContainersDesktop.Application.Exceptions;
 using WslContainersDesktop.Application.Ports;
@@ -82,6 +83,8 @@ public sealed class ContainersViewModelTests
         await sut.RefreshCommand.ExecuteAsync(null);
         var row = sut.Containers[0];
         service.StartResult = CreateContainer("c1", ContainerState.Running);
+        // 操作成功後のベストエフォート再同期では、サーバーが更新後の状態（Running）を返す。
+        service.GetContainersResults.Enqueue(() => Task.FromResult<IReadOnlyList<Container>>([CreateContainer("c1", ContainerState.Running)]));
 
         // Act
         await sut.StartCommand.ExecuteAsync(row);
@@ -170,7 +173,7 @@ public sealed class ContainersViewModelTests
         var operationTask = sut.StartCommand.ExecuteAsync(row1);
         await sut.RefreshCommand.ExecuteAsync(null);
         var liveRow = sut.Containers.Single(c => c.Id == "c1");
-        Assert.AreNotSame(row1, liveRow);
+        Assert.AreSame(row1, liveRow);
         gate.SetResult(service.StartResult!);
         await operationTask;
 
@@ -201,7 +204,7 @@ public sealed class ContainersViewModelTests
         var operationTask = sut.StartCommand.ExecuteAsync(row1);
         await sut.RefreshCommand.ExecuteAsync(null);
         var liveRow = sut.Containers.Single(c => c.Id == "c1");
-        Assert.AreNotSame(row1, liveRow);
+        Assert.AreSame(row1, liveRow);
         gate.SetException(exception);
         await operationTask;
 
@@ -356,9 +359,10 @@ public sealed class ContainersViewModelTests
         await sut.RefreshCommand.ExecuteAsync(null);
         var rebuiltRow = sut.Containers.Single(c => c.Id == "c1");
 
-        // Assert: in-flight中は再構築後の行にも保留中操作が復元される。
-        Assert.AreNotSame(row, rebuiltRow);
+        // Assert: in-flight中は差分更新で行インスタンスが維持され、保留中操作も保持される。
+        Assert.AreSame(row, rebuiltRow);
         Assert.AreEqual(ContainerRowOperation.Stopping, rebuiltRow.PendingOperation);
+        Assert.AreEqual(ContainerRowOperation.Stopping, rebuiltRow.DisplayState.PendingOperation);
 
         // 操作完了後のベストエフォート再同期で最新状態（Stopped）を返すようにする。
         service.GetContainersResults.Enqueue(() => Task.FromResult<IReadOnlyList<Container>>([CreateContainer("c1", ContainerState.Stopped)]));
@@ -536,6 +540,8 @@ public sealed class ContainersViewModelTests
         await sut.RefreshCommand.ExecuteAsync(null);
         var row = sut.Containers[0];
         service.StopResult = CreateContainer("c1", ContainerState.Stopped);
+        // 操作成功後のベストエフォート再同期では、サーバーが更新後の状態（Stopped）を返す。
+        service.GetContainersResults.Enqueue(() => Task.FromResult<IReadOnlyList<Container>>([CreateContainer("c1", ContainerState.Stopped)]));
 
         // Act
         await sut.StopCommand.ExecuteAsync(row);
@@ -594,18 +600,19 @@ public sealed class ContainersViewModelTests
         var sut = new ContainersViewModel(service);
         await sut.RefreshCommand.ExecuteAsync(null);
         var row1 = sut.Containers.Single(c => c.Id == "c1");
+        var row2 = sut.Containers.Single(c => c.Id == "c2");
 
         // Act
         var operationTask = sut.DeleteCommand.ExecuteAsync(row1);
         await sut.RefreshCommand.ExecuteAsync(null);
         var liveRow = sut.Containers.SingleOrDefault(c => c.Id == "c1");
-        Assert.AreNotSame(row1, liveRow);
         gate.SetResult(true);
         await operationTask;
 
         // Assert
         Assert.IsNull(liveRow);
         Assert.IsFalse(sut.Containers.Any(c => c.Id == "c1"));
+        Assert.AreSame(row2, sut.Containers.Single(c => c.Id == "c2"));
     }
 
     [TestMethod]
@@ -1306,6 +1313,167 @@ public sealed class ContainersViewModelTests
         Assert.IsFalse(sut.IsShellPanelVisible);
         Assert.IsFalse(sut.IsShellConnected);
         Assert.IsFalse(sut.IsSidePanelVisible);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_RefetchesSameContainers_PreservesRowInstances()
+    {
+        // Arrange
+        var service = new FakeContainerManagementService
+        {
+            DefaultContainers = [CreateContainer("c1", ContainerState.Running), CreateContainer("c2", ContainerState.Stopped)],
+        };
+        var sut = new ContainersViewModel(service);
+        await sut.RefreshCommand.ExecuteAsync(null);
+        var row1 = sut.Containers.Single(c => c.Id == "c1");
+        var row2 = sut.Containers.Single(c => c.Id == "c2");
+
+        // Act
+        await sut.RefreshCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.AreSame(row1, sut.Containers.Single(c => c.Id == "c1"));
+        Assert.AreSame(row2, sut.Containers.Single(c => c.Id == "c2"));
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_RefetchesIdenticalContainers_RaisesNoCollectionChanged()
+    {
+        // Arrange
+        var service = new FakeContainerManagementService
+        {
+            DefaultContainers = [CreateContainer("c1", ContainerState.Running), CreateContainer("c2", ContainerState.Stopped)],
+        };
+        var sut = new ContainersViewModel(service);
+        await sut.RefreshCommand.ExecuteAsync(null);
+        var actions = new List<NotifyCollectionChangedAction>();
+        sut.Containers.CollectionChanged += (_, e) => actions.Add(e.Action);
+
+        // Act
+        await sut.RefreshCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.IsEmpty(actions);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_ContainerStateChangedOnServer_SameInstanceReflectsNewState()
+    {
+        // Arrange
+        var service = new FakeContainerManagementService
+        {
+            DefaultContainers = [CreateContainer("c1", ContainerState.Running)],
+        };
+        var sut = new ContainersViewModel(service);
+        await sut.RefreshCommand.ExecuteAsync(null);
+        var row1 = sut.Containers.Single(c => c.Id == "c1");
+        service.GetContainersResults.Enqueue(() => Task.FromResult<IReadOnlyList<Container>>([CreateContainer("c1", ContainerState.Stopped)]));
+
+        // Act
+        await sut.RefreshCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.AreSame(row1, sut.Containers.Single(c => c.Id == "c1"));
+        Assert.AreEqual(ContainerState.Stopped, row1.State);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_ContainerRenamedOnServerSameId_RowReflectsNewNameAndInstanceIsRecreated()
+    {
+        // Arrange
+        var service = new FakeContainerManagementService
+        {
+            DefaultContainers = [new Container("c1", "old-name", "nginx:latest", ContainerState.Running, new DateTimeOffset(2026, 7, 2, 9, 0, 0, TimeSpan.Zero))],
+        };
+        var sut = new ContainersViewModel(service);
+        await sut.RefreshCommand.ExecuteAsync(null);
+        var originalRow = sut.Containers.Single(c => c.Id == "c1");
+        service.GetContainersResults.Enqueue(() => Task.FromResult<IReadOnlyList<Container>>(
+            [new Container("c1", "new-name", "nginx:latest", ContainerState.Running, new DateTimeOffset(2026, 7, 2, 9, 0, 0, TimeSpan.Zero))]));
+
+        // Act
+        await sut.RefreshCommand.ExecuteAsync(null);
+
+        // Assert
+        var currentRow = sut.Containers.Single(c => c.Id == "c1");
+        Assert.AreEqual("new-name", currentRow.Name);
+        Assert.AreNotSame(originalRow, currentRow);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_ContainerRemovedOnServer_RowRemovedAndOthersPreserved()
+    {
+        // Arrange
+        var service = new FakeContainerManagementService
+        {
+            DefaultContainers = [CreateContainer("c1", ContainerState.Running), CreateContainer("c2", ContainerState.Stopped)],
+        };
+        var sut = new ContainersViewModel(service);
+        await sut.RefreshCommand.ExecuteAsync(null);
+        var row2 = sut.Containers.Single(c => c.Id == "c2");
+        service.GetContainersResults.Enqueue(() => Task.FromResult<IReadOnlyList<Container>>([CreateContainer("c2", ContainerState.Stopped)]));
+
+        // Act
+        await sut.RefreshCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.IsFalse(sut.Containers.Any(c => c.Id == "c1"));
+        Assert.AreSame(row2, sut.Containers.Single(c => c.Id == "c2"));
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_NewContainerOnServer_RowAddedAndExistingPreserved()
+    {
+        // Arrange
+        var service = new FakeContainerManagementService
+        {
+            DefaultContainers = [CreateContainer("c1", ContainerState.Running)],
+        };
+        var sut = new ContainersViewModel(service);
+        await sut.RefreshCommand.ExecuteAsync(null);
+        var row1 = sut.Containers.Single(c => c.Id == "c1");
+        service.GetContainersResults.Enqueue(() => Task.FromResult<IReadOnlyList<Container>>([CreateContainer("c1", ContainerState.Running), CreateContainer("c2", ContainerState.Stopped)]));
+
+        // Act
+        await sut.RefreshCommand.ExecuteAsync(null);
+
+        // Assert
+        Assert.AreSame(row1, sut.Containers.Single(c => c.Id == "c1"));
+        Assert.IsTrue(sut.Containers.Any(c => c.Id == "c2"));
+    }
+
+    [TestMethod]
+    public async Task StopAsync_ContainerDisappearsThenReappearsWhileInFlight_RecreatedRowShowsStopping()
+    {
+        // Arrange
+        var service = new FakeContainerManagementService { DefaultContainers = [CreateContainer("c1", ContainerState.Running)] };
+        var gate = new TaskCompletionSource<Container>(TaskCreationOptions.RunContinuationsAsynchronously);
+        service.StopAsyncGate = gate;
+        service.StopResult = CreateContainer("c1", ContainerState.Stopped);
+        var sut = new ContainersViewModel(service);
+        await sut.RefreshCommand.ExecuteAsync(null);
+        var row = sut.Containers[0];
+
+        // 停止操作の実行中に、サーバー一覧から c1 が一旦消え、その後まだ完了前に再出現するシナリオ。
+        service.GetContainersResults.Enqueue(() => Task.FromResult<IReadOnlyList<Container>>([]));
+        service.GetContainersResults.Enqueue(() => Task.FromResult<IReadOnlyList<Container>>([CreateContainer("c1", ContainerState.Running)]));
+
+        // Act
+        var operationTask = sut.StopCommand.ExecuteAsync(row);
+        await sut.RefreshCommand.ExecuteAsync(null); // c1 が消える → 行が削除される
+        Assert.IsFalse(sut.Containers.Any(c => c.Id == "c1"));
+        await sut.RefreshCommand.ExecuteAsync(null); // c1 が再出現 → 新しい行が作られる
+
+        // Assert: 再生成された行にも進行中の Stopping が復元される。
+        var recreatedRow = sut.Containers.Single(c => c.Id == "c1");
+        Assert.IsTrue(recreatedRow.IsBusy);
+        Assert.AreEqual(ContainerRowOperation.Stopping, recreatedRow.PendingOperation);
+        Assert.AreEqual(ContainerRowOperation.Stopping, recreatedRow.DisplayState.PendingOperation);
+
+        // クリーンアップ: 操作を完了させる。
+        service.GetContainersResults.Enqueue(() => Task.FromResult<IReadOnlyList<Container>>([CreateContainer("c1", ContainerState.Stopped)]));
+        gate.SetResult(service.StopResult!);
+        await operationTask;
     }
 
     private static async Task WaitForConditionAsync(Func<bool> condition, TimeSpan timeout)

--- a/tests/WslContainersDesktop.App.Tests/ViewModels/ImagesViewModelTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/ViewModels/ImagesViewModelTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Specialized;
 using WslContainersDesktop.Application.Exceptions;
 using WslContainersDesktop.Domain;
 using WslContainersDesktop_App.ViewModels;
@@ -8,12 +9,14 @@ namespace WslContainersDesktop_App_Tests.ViewModels;
 [TestClass]
 public sealed class ImagesViewModelTests
 {
+    private static DateTimeOffset CreatedAt => new(2026, 7, 2, 9, 0, 0, TimeSpan.Zero);
+
     private static ContainerImage CreateImage(string id) => new(
         Id: id,
         Repository: "ubuntu",
         Tag: "latest",
         SizeBytes: 120L,
-        CreatedAt: new DateTimeOffset(2026, 7, 2, 9, 0, 0, TimeSpan.Zero));
+        CreatedAt: CreatedAt);
 
     [TestMethod]
     public async Task RefreshAsync_ServiceReturnsImages_PopulatesRowsAndClearsErrorAndIsEmptyIsFalse()
@@ -248,5 +251,117 @@ public sealed class ImagesViewModelTests
         Assert.AreEqual("delete failed", sut.ErrorMessage);
         Assert.HasCount(1, sut.Images);
         Assert.AreSame(row, sut.Images[0]);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_RefetchesIdenticalImages_PreservesRowInstances()
+    {
+        // Arrange
+        var service = new FakeImageManagementService { DefaultImages = [CreateImage("img-1"), CreateImage("img-2")] };
+        var sut = new ImagesViewModel(service);
+        await sut.RefreshAsync();
+        var row1 = sut.Images[0];
+        var row2 = sut.Images[1];
+
+        // Act
+        await sut.RefreshAsync();
+
+        // Assert
+        Assert.HasCount(2, sut.Images);
+        Assert.AreSame(row1, sut.Images[0]);
+        Assert.AreSame(row2, sut.Images[1]);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_RefetchesIdenticalImages_RaisesNoCollectionChanged()
+    {
+        // Arrange
+        var service = new FakeImageManagementService { DefaultImages = [CreateImage("img-1"), CreateImage("img-2")] };
+        var sut = new ImagesViewModel(service);
+        await sut.RefreshAsync();
+        var actions = new List<NotifyCollectionChangedAction>();
+        sut.Images.CollectionChanged += (_, e) => actions.Add(e.Action);
+
+        // Act
+        await sut.RefreshAsync();
+
+        // Assert
+        Assert.IsEmpty(actions);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_ImageRemovedOnServer_RowRemovedAndOthersPreserved()
+    {
+        // Arrange
+        var service = new FakeImageManagementService { DefaultImages = [CreateImage("img-1"), CreateImage("img-2")] };
+        var sut = new ImagesViewModel(service);
+        await sut.RefreshAsync();
+        var row1 = sut.Images[0];
+        service.DefaultImages = [CreateImage("img-1")];
+
+        // Act
+        await sut.RefreshAsync();
+
+        // Assert
+        Assert.HasCount(1, sut.Images);
+        Assert.AreSame(row1, sut.Images[0]);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_NewImageOnServer_RowAddedAndExistingPreserved()
+    {
+        // Arrange
+        var service = new FakeImageManagementService { DefaultImages = [CreateImage("img-1")] };
+        var sut = new ImagesViewModel(service);
+        await sut.RefreshAsync();
+        var row1 = sut.Images[0];
+        service.DefaultImages = [CreateImage("img-1"), CreateImage("img-2")];
+
+        // Act
+        await sut.RefreshAsync();
+
+        // Assert
+        Assert.HasCount(2, sut.Images);
+        Assert.AreSame(row1, sut.Images[0]);
+        Assert.AreEqual("img-2", sut.Images[1].Id);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_ImageTagChangedForSameId_RowReplacedWithNewDisplayName()
+    {
+        // Arrange
+        var service = new FakeImageManagementService
+        {
+            DefaultImages = [new ContainerImage("img-1", "ubuntu", "20.04", 120L, CreatedAt)],
+        };
+        var sut = new ImagesViewModel(service);
+        await sut.RefreshAsync();
+        var originalRow = sut.Images[0];
+        service.DefaultImages = [new ContainerImage("img-1", "ubuntu", "22.04", 120L, CreatedAt)];
+
+        // Act
+        await sut.RefreshAsync();
+
+        // Assert
+        Assert.HasCount(1, sut.Images);
+        Assert.AreNotSame(originalRow, sut.Images[0]);
+        Assert.AreEqual("ubuntu:22.04", sut.Images[0].DisplayName);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_RefetchesEquivalentImagesFromFreshRecordInstances_PreservesRowInstances()
+    {
+        // Arrange
+        var service = new FakeImageManagementService { DefaultImages = [CreateImage("img-1")] };
+        var sut = new ImagesViewModel(service);
+        await sut.RefreshAsync();
+        var row1 = sut.Images[0];
+        service.DefaultImages = [CreateImage("img-1")];
+
+        // Act
+        await sut.RefreshAsync();
+
+        // Assert
+        Assert.AreSame(row1, sut.Images[0]);
     }
 }

--- a/tests/WslContainersDesktop.App.Tests/ViewModels/NetworksViewModelTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/ViewModels/NetworksViewModelTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Specialized;
 using WslContainersDesktop.Application.Exceptions;
 using WslContainersDesktop.Domain;
 using WslContainersDesktop_App.ViewModels;
@@ -274,5 +275,116 @@ public sealed class NetworksViewModelTests
         // Assert
         Assert.AreEqual("Network 'bridge' is a system network and cannot be deleted.", sut.ErrorMessage);
         Assert.HasCount(1, sut.Networks);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_RefetchesIdenticalNetworks_PreservesRowInstances()
+    {
+        // Arrange
+        var service = new FakeNetworkManagementService { DefaultNetworks = [CreateNetwork("app-net"), CreateNetwork("db-net")] };
+        var sut = new NetworksViewModel(service);
+        await sut.RefreshAsync();
+        var row1 = sut.Networks[0];
+        var row2 = sut.Networks[1];
+
+        // Act
+        await sut.RefreshAsync();
+
+        // Assert
+        Assert.HasCount(2, sut.Networks);
+        Assert.AreSame(row1, sut.Networks[0]);
+        Assert.AreSame(row2, sut.Networks[1]);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_RefetchesIdenticalNetworks_RaisesNoCollectionChanged()
+    {
+        // Arrange
+        var service = new FakeNetworkManagementService { DefaultNetworks = [CreateNetwork("app-net"), CreateNetwork("db-net")] };
+        var sut = new NetworksViewModel(service);
+        await sut.RefreshAsync();
+        var actions = new List<NotifyCollectionChangedAction>();
+        sut.Networks.CollectionChanged += (_, e) => actions.Add(e.Action);
+
+        // Act
+        await sut.RefreshAsync();
+
+        // Assert
+        Assert.IsEmpty(actions);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_NetworkRemovedOnServer_RowRemovedAndOthersPreserved()
+    {
+        // Arrange
+        var service = new FakeNetworkManagementService { DefaultNetworks = [CreateNetwork("app-net"), CreateNetwork("db-net")] };
+        var sut = new NetworksViewModel(service);
+        await sut.RefreshAsync();
+        var row1 = sut.Networks[0];
+        service.DefaultNetworks = [CreateNetwork("app-net")];
+
+        // Act
+        await sut.RefreshAsync();
+
+        // Assert
+        Assert.HasCount(1, sut.Networks);
+        Assert.AreSame(row1, sut.Networks[0]);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_NewNetworkOnServer_RowAddedAndExistingPreserved()
+    {
+        // Arrange
+        var service = new FakeNetworkManagementService { DefaultNetworks = [CreateNetwork("app-net")] };
+        var sut = new NetworksViewModel(service);
+        await sut.RefreshAsync();
+        var row1 = sut.Networks[0];
+        service.DefaultNetworks = [CreateNetwork("app-net"), CreateNetwork("db-net")];
+
+        // Act
+        await sut.RefreshAsync();
+
+        // Assert
+        Assert.HasCount(2, sut.Networks);
+        Assert.AreSame(row1, sut.Networks[0]);
+        Assert.AreEqual("db-net", sut.Networks[1].Name);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_NetworkConnectionsChanged_ChangedRowReplacedWithNewUsageTextAndOthersPreserved()
+    {
+        // Arrange
+        var service = new FakeNetworkManagementService { DefaultNetworks = [CreateNetwork("app-net"), CreateNetwork("db-net", false, "web")] };
+        var sut = new NetworksViewModel(service);
+        await sut.RefreshAsync();
+        var appRow = sut.Networks[0];
+        var dbRow = sut.Networks[1];
+        service.DefaultNetworks = [CreateNetwork("app-net"), CreateNetwork("db-net", false, "web", "api")];
+
+        // Act
+        await sut.RefreshAsync();
+
+        // Assert
+        Assert.HasCount(2, sut.Networks);
+        Assert.AreSame(appRow, sut.Networks[0]);
+        Assert.AreNotSame(dbRow, sut.Networks[1]);
+        Assert.AreEqual("web, api", sut.Networks[1].UsageText);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_RefetchesEquivalentNetworksFromFreshRecordInstances_PreservesRowInstances()
+    {
+        // Arrange
+        var service = new FakeNetworkManagementService { DefaultNetworks = [CreateNetwork("app-net", false, "web")] };
+        var sut = new NetworksViewModel(service);
+        await sut.RefreshAsync();
+        var row1 = sut.Networks[0];
+        service.DefaultNetworks = [CreateNetwork("app-net", false, "web")];
+
+        // Act
+        await sut.RefreshAsync();
+
+        // Assert
+        Assert.AreSame(row1, sut.Networks[0]);
     }
 }

--- a/tests/WslContainersDesktop.App.Tests/ViewModels/VolumesViewModelTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/ViewModels/VolumesViewModelTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Specialized;
 using WslContainersDesktop.Application.Exceptions;
 using WslContainersDesktop.Domain;
 using WslContainersDesktop_App.ViewModels;
@@ -260,5 +261,116 @@ public sealed class VolumesViewModelTests
         // Assert
         Assert.AreEqual("Volume 'vol-1' is in use by: web, db", sut.ErrorMessage);
         Assert.HasCount(1, sut.Volumes);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_RefetchesIdenticalVolumes_PreservesRowInstances()
+    {
+        // Arrange
+        var service = new FakeVolumeManagementService { DefaultVolumes = [CreateVolume("vol-1"), CreateVolume("vol-2")] };
+        var sut = new VolumesViewModel(service);
+        await sut.RefreshAsync();
+        var row1 = sut.Volumes[0];
+        var row2 = sut.Volumes[1];
+
+        // Act
+        await sut.RefreshAsync();
+
+        // Assert
+        Assert.HasCount(2, sut.Volumes);
+        Assert.AreSame(row1, sut.Volumes[0]);
+        Assert.AreSame(row2, sut.Volumes[1]);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_RefetchesIdenticalVolumes_RaisesNoCollectionChanged()
+    {
+        // Arrange
+        var service = new FakeVolumeManagementService { DefaultVolumes = [CreateVolume("vol-1"), CreateVolume("vol-2")] };
+        var sut = new VolumesViewModel(service);
+        await sut.RefreshAsync();
+        var actions = new List<NotifyCollectionChangedAction>();
+        sut.Volumes.CollectionChanged += (_, e) => actions.Add(e.Action);
+
+        // Act
+        await sut.RefreshAsync();
+
+        // Assert
+        Assert.IsEmpty(actions);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_VolumeRemovedOnServer_RowRemovedAndOthersPreserved()
+    {
+        // Arrange
+        var service = new FakeVolumeManagementService { DefaultVolumes = [CreateVolume("vol-1"), CreateVolume("vol-2")] };
+        var sut = new VolumesViewModel(service);
+        await sut.RefreshAsync();
+        var row1 = sut.Volumes[0];
+        service.DefaultVolumes = [CreateVolume("vol-1")];
+
+        // Act
+        await sut.RefreshAsync();
+
+        // Assert
+        Assert.HasCount(1, sut.Volumes);
+        Assert.AreSame(row1, sut.Volumes[0]);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_NewVolumeOnServer_RowAddedAndExistingPreserved()
+    {
+        // Arrange
+        var service = new FakeVolumeManagementService { DefaultVolumes = [CreateVolume("vol-1")] };
+        var sut = new VolumesViewModel(service);
+        await sut.RefreshAsync();
+        var row1 = sut.Volumes[0];
+        service.DefaultVolumes = [CreateVolume("vol-1"), CreateVolume("vol-2")];
+
+        // Act
+        await sut.RefreshAsync();
+
+        // Assert
+        Assert.HasCount(2, sut.Volumes);
+        Assert.AreSame(row1, sut.Volumes[0]);
+        Assert.AreEqual("vol-2", sut.Volumes[1].Name);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_VolumeReferencesChanged_ChangedRowReplacedWithNewUsageTextAndOthersPreserved()
+    {
+        // Arrange
+        var service = new FakeVolumeManagementService { DefaultVolumes = [CreateVolume("vol-1"), CreateVolume("vol-2", "web")] };
+        var sut = new VolumesViewModel(service);
+        await sut.RefreshAsync();
+        var row1 = sut.Volumes[0];
+        var row2 = sut.Volumes[1];
+        service.DefaultVolumes = [CreateVolume("vol-1"), CreateVolume("vol-2", "web", "db")];
+
+        // Act
+        await sut.RefreshAsync();
+
+        // Assert
+        Assert.HasCount(2, sut.Volumes);
+        Assert.AreSame(row1, sut.Volumes[0]);
+        Assert.AreNotSame(row2, sut.Volumes[1]);
+        Assert.AreEqual("web, db", sut.Volumes[1].UsageText);
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_RefetchesEquivalentVolumesFromFreshRecordInstances_PreservesRowInstances()
+    {
+        // Arrange
+        var service = new FakeVolumeManagementService { DefaultVolumes = [CreateVolume("vol-1", "web")] };
+        var sut = new VolumesViewModel(service);
+        await sut.RefreshAsync();
+        var row1 = sut.Volumes[0];
+        service.DefaultVolumes = [CreateVolume("vol-1", "web")];
+
+        // Act
+        await sut.RefreshAsync();
+
+        // Assert
+        Assert.AreSame(row1, sut.Volumes[0]);
     }
 }


### PR DESCRIPTION
## 概要

Issue #28（UIブラッシュアップ part2）に対応。

### スコープ1: 一覧の差分更新
Containers / Images / Networks / Volumes の各一覧が更新のたびに `ObservableCollection.Clear()` + 全件 `Add()` で全体リフレッシュされ、`ListView` の Reset（ちらつき・選択喪失）を招いていた問題を解消。

- Presentation層に汎用ヘルパー `ObservableCollectionReconciler.Reconcile(...)` を追加。キー一致で既存行インスタンスを維持し、追加・削除・並び替え・（任意の）インプレース更新のみを適用（`Clear()` 不使用 → Reset なし。同一内容の再取得では `CollectionChanged` を発生させない）。
- キー選択:
  - **Container**: `Id ∣ Name ∣ Image ∣ CreatedAt`（`State` はキーに含めず `ApplyFrom` でインプレース更新）。
  - **Image / Network / Volume**: 表示・使用フィールドを連結した構造的な文字列キー（`record` 直接キーは `IReadOnlyList<string>` 参照比較の罠があるため回避）。

### スコープ2: コンテナ操作の途中状態表示
Stop 実行時に Stopping が表示されず Stopped まで変わらなかった問題を解消。

- 行インスタンスが維持されるようになったため、`ContainersPage.xaml` の状態列を `x:Bind ... Mode=OneWay` に変更（`x:Bind` 既定の `OneTime` では途中状態が反映されない）。
- `_pendingOperations` を単一の情報源として、差分更新の新規・更新いずれの経路でも busy/途中状態を復元。

## テスト
- `ObservableCollectionReconcilerTests`（12件・新規）
- Containers/Images/Networks/Volumes VMテストに差分更新の検証を追加（インスタンス維持・no-op時 0イベント・追加/削除/並び替え・構造キーによる再生成・record参照等価の回帰）
- `ContainersPageSourceTests`（DisplayState の OneWay バインドを検査・新規）
- 全 **233 tests green**（baseline 195 → 233）

## ドキュメント
- ADR-0013 を追加、`docs/design/{containers,images,networks,volumes}-view.md` を差分更新方針へ更新。

Closes #28