### PR TITLE
Brand app as Hakonexa

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# WSL Containers Desktop
+# Hakonexa - WSL Containers Manager
 
-WSL Containers Desktop は、WSL (Windows Subsystem for Linux) 上のコンテナを管理するための
+Hakonexa - WSL Containers Manager は、WSL (Windows Subsystem for Linux) 上のコンテナを管理するための
 WinUI 3 / .NET デスクトップアプリケーションです。Docker Desktop と同等の機能セット
 （コンテナ/イメージ/ボリューム/ネットワークの管理、ログ表示等）を目標としています。
 

--- a/docs/design/design-policy.md
+++ b/docs/design/design-policy.md
@@ -4,7 +4,7 @@
 
 ## 目的
 
-WSL Containers Desktop は、WSL Containers を管理する Windows ネイティブの開発者向けデスクトップアプリである。
+Hakonexa - WSL Containers Manager は、WSL Containers を管理する Windows ネイティブの開発者向けデスクトップアプリである。
 UIは、コンテナの状態・操作・ログを短時間で把握できるよう、Fluent Design に沿った明確な視覚階層を持つ。
 
 ## 基本原則

--- a/docs/design/settings-view.md
+++ b/docs/design/settings-view.md
@@ -6,7 +6,7 @@
 
 ## 概要
 
-設定画面は初期版として2カテゴリを扱う（[`docs/specs/0007-settings.md`](../specs/0007-settings.md)）。
+設定画面は初期版として、アプリ情報表示に加えて2カテゴリを扱う（[`docs/specs/0007-settings.md`](../specs/0007-settings.md)）。
 
 1. **WSL連携状態の確認**（読み取りのみ）: WSLバージョン検出と、WSL Containersの動作要件充足判定。
 2. **リソース制限**（読み取り/変更/保存/リセット）: メモリ量(MB)と論理プロセッサ数を
@@ -104,8 +104,8 @@
 
 ## SettingsPage（View）
 
-- ヘッダー（4pxアクセントバー付きカード）、連携状態カード（WSLバージョン表示、wslc利用可否、要件未達時の
-  警告`InfoBar`）、リソース制限カード（メモリ/プロセッサ入力、Save/Resetボタン、
+- ヘッダー（4pxアクセントバー付きカード）、アプリ情報カード（アプリ表示名、目的文、アプリバージョン）、連携状態カード
+  （WSLバージョン表示、wslc利用可否、要件未達時の警告`InfoBar`）、リソース制限カード（メモリ/プロセッサ入力、Save/Resetボタン、
   `CanEditResourceLimits`で有効化）、エラー`InfoBar`と成功`InfoBar`で構成する。
 - 入力欄は`Mode=TwoWay, UpdateSourceTrigger=PropertyChanged`でバインドし、空欄=WSL既定であることを
   ヒントで示す。

--- a/docs/reference/wsl-containers-platform.md
+++ b/docs/reference/wsl-containers-platform.md
@@ -3,7 +3,7 @@
 > **最終確認日: 2026-07-03**（Microsoft Build 2026 発表直後の情報。**Public Preview** のため
 > 仕様は変わりやすい。実装前に必ず一次情報源または Microsoft Learn MCP で最新情報を確認すること）
 
-本アプリ（WSL Containers Desktop）は、この「WSL Containers」機能をGUIで管理するための
+本アプリ（Hakonexa - WSL Containers Manager）は、この「WSL Containers」機能をGUIで管理するための
 Docker Desktop相当のアプリである。つまり本アプリの Infrastructure層（[ADR-0005](../adr/0005-adopt-clean-architecture-layering.md)）は、
 ここに書かれている `wslc` CLI または WSL Container API のいずれか（両方）をラップして実装することになる。
 

--- a/src/WslContainersDesktop.App/Pages/SettingsPage.xaml
+++ b/src/WslContainersDesktop.App/Pages/SettingsPage.xaml
@@ -73,7 +73,7 @@
                         <TextBlock
                             x:Name="TxtAppVersionValue"
                             VerticalAlignment="Center"
-                            Text="{x:Bind AppVersionText, Mode=OneWay}" />
+                            Text="{x:Bind AppVersionText, Mode=OneTime}" />
                     </StackPanel>
                 </StackPanel>
             </Border>

--- a/src/WslContainersDesktop.App/Pages/SettingsPage.xaml
+++ b/src/WslContainersDesktop.App/Pages/SettingsPage.xaml
@@ -16,6 +16,7 @@
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
             <!-- ヘッダー -->
@@ -52,9 +53,34 @@
                 </Grid>
             </Border>
 
-            <!-- WSL連携状態 -->
+            <!-- アプリ情報 -->
             <Border
                 Grid.Row="1"
+                Padding="16"
+                Background="{ThemeResource LayerFillColorDefaultBrush}"
+                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                BorderThickness="{ThemeResource WslContainersSurfaceBorderThickness}"
+                CornerRadius="{StaticResource OverlayCornerRadius}">
+                <StackPanel Spacing="4">
+                    <TextBlock x:Uid="SettingsAppName" Style="{StaticResource SubtitleTextBlockStyle}" />
+                    <TextBlock x:Uid="SettingsAppPurpose" TextWrapping="Wrap" />
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <TextBlock
+                            x:Name="TxtAppVersionLabel"
+                            x:Uid="TxtAppVersionLabel"
+                            VerticalAlignment="Center"
+                            FontWeight="SemiBold" />
+                        <TextBlock
+                            x:Name="TxtAppVersionValue"
+                            VerticalAlignment="Center"
+                            Text="{x:Bind AppVersionText, Mode=OneWay}" />
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+
+            <!-- WSL連携状態 -->
+            <Border
+                Grid.Row="2"
                 Padding="16"
                 Background="{ThemeResource LayerFillColorDefaultBrush}"
                 BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
@@ -94,7 +120,7 @@
 
             <!-- リソース制限 -->
             <Border
-                Grid.Row="2"
+                Grid.Row="3"
                 Padding="16"
                 Background="{ThemeResource LayerFillColorDefaultBrush}"
                 BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
@@ -145,7 +171,7 @@
             </Border>
 
             <!-- エラー / ステータスメッセージ -->
-            <StackPanel Grid.Row="3" Spacing="8">
+            <StackPanel Grid.Row="4" Spacing="8">
                 <InfoBar
                     x:Name="InfoBarSettingsError"
                     Severity="Error"

--- a/src/WslContainersDesktop.App/Pages/SettingsPage.xaml.cs
+++ b/src/WslContainersDesktop.App/Pages/SettingsPage.xaml.cs
@@ -1,10 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Globalization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using WslContainersDesktop_App.ViewModels;
+using Windows.ApplicationModel;
 using Windows.ApplicationModel.Resources;
 
 namespace WslContainersDesktop_App.Pages;
@@ -32,6 +34,15 @@ public sealed partial class SettingsPage : Page
     /// ページのViewModel。
     /// </summary>
     public SettingsViewModel ViewModel { get; }
+
+    /// <summary>
+    /// 表示用のアプリパッケージバージョン文字列。
+    /// </summary>
+    public string AppVersionText { get; } = FormatPackageVersion(
+        Package.Current.Id.Version.Major,
+        Package.Current.Id.Version.Minor,
+        Package.Current.Id.Version.Build,
+        Package.Current.Id.Version.Revision);
 
     private async void SettingsPage_Loaded(object sender, RoutedEventArgs e)
     {
@@ -70,4 +81,17 @@ public sealed partial class SettingsPage : Page
     /// <param name="value">変換元の値。</param>
     /// <returns>対応する <see cref="Visibility"/>。</returns>
     public Visibility ToVisibleWhenFalse(bool value) => value ? Visibility.Collapsed : Visibility.Visible;
+
+    /// <summary>
+    /// パッケージバージョンの4要素を表示用文字列に変換する。
+    /// </summary>
+    /// <param name="major">メジャーバージョン。</param>
+    /// <param name="minor">マイナーバージョン。</param>
+    /// <param name="build">ビルド番号。</param>
+    /// <param name="revision">リビジョン番号。</param>
+    /// <returns>表示用の4要素バージョン文字列。</returns>
+    public static string FormatPackageVersion(int major, int minor, int build, int revision)
+    {
+        return string.Format(CultureInfo.InvariantCulture, "{0}.{1}.{2}.{3}", major, minor, build, revision);
+    }
 }

--- a/src/WslContainersDesktop.App/Strings/en-US/Resources.resw
+++ b/src/WslContainersDesktop.App/Strings/en-US/Resources.resw
@@ -118,10 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MainWindow.Title" xml:space="preserve">
-    <value>WSL Containers Desktop</value>
+    <value>Hakonexa - WSL Containers Manager</value>
   </data>
   <data name="AppTitleBar.Title" xml:space="preserve">
-    <value>WSL Containers Desktop</value>
+    <value>Hakonexa - WSL Containers Manager</value>
   </data>
   <data name="NavItemDashboard.Content" xml:space="preserve">
     <value>Dashboard</value>
@@ -516,6 +516,15 @@
   <data name="SettingsPageDescription.Text" xml:space="preserve">
     <value>Review WSL integration status and configure WSL resource limits.</value>
   </data>
+  <data name="SettingsAppName.Text" xml:space="preserve">
+    <value>Hakonexa - WSL Containers Manager</value>
+  </data>
+  <data name="SettingsAppPurpose.Text" xml:space="preserve">
+    <value>Manage WSL Containers from a native Windows desktop app.</value>
+  </data>
+  <data name="TxtAppVersionLabel.Text" xml:space="preserve">
+    <value>App version:</value>
+  </data>
   <data name="TxtWslIntegrationHeader.Text" xml:space="preserve">
     <value>WSL integration status</value>
   </data>
@@ -568,9 +577,9 @@
     <value>Cancel</value>
   </data>
   <data name="AppDisplayName" xml:space="preserve">
-    <value>WSL Containers Desktop</value>
+    <value>Hakonexa - WSL Containers Manager</value>
   </data>
   <data name="AppDescription" xml:space="preserve">
-    <value>WSL Containers Desktop</value>
+    <value>Hakonexa - WSL Containers Manager</value>
   </data>
 </root>

--- a/tests/WslContainersDesktop.App.Tests/Branding/AppBrandingSourceTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/Branding/AppBrandingSourceTests.cs
@@ -1,0 +1,113 @@
+using System.Linq;
+using System.Xml.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace WslContainersDesktop_App_Tests.Branding;
+
+[TestClass]
+public sealed class AppBrandingSourceTests
+{
+    private const string ExpectedAppName = "Hakonexa - WSL Containers Manager";
+    private const string ExpectedSettingsPurpose = "Manage WSL Containers from a native Windows desktop app.";
+
+    [TestMethod]
+    public void AppBranding_Resources_UseExpectedDisplayNameValues()
+    {
+        // Arrange
+        var resourceDocument = XDocument.Parse(ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Strings\en-US\Resources.resw"));
+
+        // Act
+        var mainWindowTitle = GetResourceValue(resourceDocument, "MainWindow.Title");
+        var appTitleBarTitle = GetResourceValue(resourceDocument, "AppTitleBar.Title");
+        var appDisplayName = GetResourceValue(resourceDocument, "AppDisplayName");
+        var appDescription = GetResourceValue(resourceDocument, "AppDescription");
+
+        // Assert
+        Assert.AreEqual(ExpectedAppName, mainWindowTitle, "Expected MainWindow.Title to use the renamed app display name.");
+        Assert.AreEqual(ExpectedAppName, appTitleBarTitle, "Expected AppTitleBar.Title to use the renamed app display name.");
+        Assert.AreEqual(ExpectedAppName, appDisplayName, "Expected AppDisplayName to use the renamed app display name.");
+        Assert.AreEqual(ExpectedAppName, appDescription, "Expected AppDescription to use the renamed app display name.");
+    }
+
+    [TestMethod]
+    public void AppBranding_SettingsPage_UsesLocalizedAppNameAndPurposeResources()
+    {
+        // Arrange
+        var resourceDocument = XDocument.Parse(ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Strings\en-US\Resources.resw"));
+        var settingsPageXamlText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Pages\SettingsPage.xaml");
+
+        // Act
+        var settingsAppNameText = GetResourceValue(resourceDocument, "SettingsAppName.Text");
+        var settingsAppPurposeText = GetResourceValue(resourceDocument, "SettingsAppPurpose.Text");
+
+        // Assert
+        Assert.AreEqual(ExpectedAppName, settingsAppNameText, "Expected SettingsAppName.Text to use the renamed app display name.");
+        Assert.AreEqual(ExpectedSettingsPurpose, settingsAppPurposeText, "Expected SettingsAppPurpose.Text to use the updated app purpose message.");
+        StringAssert.Contains(settingsPageXamlText, "x:Uid=\"SettingsAppName\"");
+        StringAssert.Contains(settingsPageXamlText, "x:Uid=\"SettingsAppPurpose\"");
+        Assert.IsFalse(settingsPageXamlText.Contains(ExpectedAppName, StringComparison.Ordinal), "Expected SettingsPage.xaml to avoid hardcoding the app name.");
+    }
+
+    [TestMethod]
+    public void AppBranding_Manifest_UsesResourceReferencesForDisplayNameAndDescription()
+    {
+        // Arrange
+        var manifestText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Package.appxmanifest");
+
+        // Assert
+        StringAssert.Contains(manifestText, "<DisplayName>ms-resource:AppDisplayName</DisplayName>");
+        StringAssert.Contains(manifestText, "DisplayName=\"ms-resource:AppDisplayName\"");
+        StringAssert.Contains(manifestText, "Description=\"ms-resource:AppDescription\"");
+    }
+
+    [TestMethod]
+    public void AppBranding_Readme_UsesExpectedAppTitleHeading()
+    {
+        // Arrange
+        var readmeText = ReadRepositorySourceFile("README.md");
+
+        // Assert
+        StringAssert.Contains(readmeText, "# Hakonexa - WSL Containers Manager");
+    }
+
+    private static string GetResourceValue(XDocument resourceDocument, string resourceName)
+    {
+        var dataElement = resourceDocument.Root?
+            .Elements("data")
+            .FirstOrDefault(element => string.Equals((string?)element.Attribute("name"), resourceName, StringComparison.Ordinal));
+
+        Assert.IsNotNull(dataElement, $"Expected resource key '{resourceName}' to exist in the resources file.");
+        var valueElement = dataElement!.Element("value");
+        Assert.IsNotNull(valueElement, $"Expected resource key '{resourceName}' to contain a <value> element.");
+
+        return valueElement!.Value;
+    }
+
+    private static string ReadRepositorySourceFile(string relativePath)
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var normalizedRelativePath = relativePath.Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar);
+        var fullPath = Path.Combine(repositoryRoot, normalizedRelativePath);
+
+        Assert.IsTrue(File.Exists(fullPath), $"Expected source file '{relativePath}' to exist at '{fullPath}'.");
+        return File.ReadAllText(fullPath);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var currentDirectory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (currentDirectory is not null)
+        {
+            var appProjectFilePath = Path.Combine(currentDirectory.FullName, "src", "WslContainersDesktop.App", "WslContainersDesktop.App.csproj");
+            if (File.Exists(appProjectFilePath))
+            {
+                return currentDirectory.FullName;
+            }
+
+            currentDirectory = currentDirectory.Parent;
+        }
+
+        Assert.Fail($"Could not locate repository root from '{AppContext.BaseDirectory}'.");
+        return string.Empty;
+    }
+}

--- a/tests/WslContainersDesktop.App.Tests/Pages/PageSurfaceMaterialTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/Pages/PageSurfaceMaterialTests.cs
@@ -16,7 +16,7 @@ public sealed class PageSurfaceMaterialTests
     [DataRow(@"src\WslContainersDesktop.App\Pages\ImagesPage.xaml", 2)]
     [DataRow(@"src\WslContainersDesktop.App\Pages\NetworksPage.xaml", 3)]
     [DataRow(@"src\WslContainersDesktop.App\Pages\VolumesPage.xaml", 2)]
-    [DataRow(@"src\WslContainersDesktop.App\Pages\SettingsPage.xaml", 3)]
+    [DataRow(@"src\WslContainersDesktop.App\Pages\SettingsPage.xaml", 4)]
     public void Page_ContentSurfaces_UseLayerFillOverMica(string relativePath, int expectedSurfaceCount)
     {
         // Arrange

--- a/tests/WslContainersDesktop.App.Tests/Pages/SettingsPageSourceTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/Pages/SettingsPageSourceTests.cs
@@ -1,4 +1,7 @@
+using System.Linq;
 using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using WslContainersDesktop_App.Pages;
 
 namespace WslContainersDesktop_App_Tests.Pages;
 
@@ -108,6 +111,43 @@ public sealed class SettingsPageSourceTests
     }
 
     [TestMethod]
+    public void SettingsPage_AppInfoDisplaysPackageVersion()
+    {
+        // Arrange
+        var xamlText = ReadRepositorySourceFile(XamlRelativePath);
+        var codeBehindText = ReadRepositorySourceFile(CodeBehindRelativePath);
+
+        // Assert
+        StringAssert.Contains(xamlText, "x:Name=\"TxtAppVersionLabel\"");
+        StringAssert.Contains(xamlText, "x:Uid=\"TxtAppVersionLabel\"");
+        StringAssert.Contains(xamlText, "x:Name=\"TxtAppVersionValue\"");
+        StringAssert.Contains(xamlText, "Text=\"{x:Bind AppVersionText, Mode=OneWay}\"");
+        StringAssert.Contains(codeBehindText, "Package.Current.Id.Version");
+        StringAssert.Contains(codeBehindText, "public string AppVersionText { get; }");
+    }
+
+    [TestMethod]
+    public void SettingsPage_AppVersionLabelResource_UsesLocalizedText()
+    {
+        // Arrange
+        var resourceDocument = XDocument.Parse(ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Strings\en-US\Resources.resw"));
+
+        // Act
+        var appVersionLabelText = GetResourceValue(resourceDocument, "TxtAppVersionLabel.Text");
+
+        // Assert
+        Assert.AreEqual("App version:", appVersionLabelText);
+    }
+
+    [TestMethod]
+    public void FormatPackageVersion_Components_ReturnsFourPartVersion()
+    {
+        // Assert
+        Assert.AreEqual("1.2.3.4", SettingsPage.FormatPackageVersion(1, 2, 3, 4));
+        Assert.AreEqual("10.20.30.40", SettingsPage.FormatPackageVersion(10, 20, 30, 40));
+    }
+
+    [TestMethod]
     public void SettingsPage_ResolvesViewModelFromDependencyInjection()
     {
         // Arrange
@@ -150,6 +190,19 @@ public sealed class SettingsPageSourceTests
         Assert.IsTrue(
             handlerIndex < dialogIndex && dialogIndex < primaryResultIndex && primaryResultIndex < resetCommandIndex,
             "Expected the reset command to execute only inside the primary-confirmation branch of the dialog.");
+    }
+
+    private static string GetResourceValue(XDocument resourceDocument, string resourceName)
+    {
+        var dataElement = resourceDocument.Root?
+            .Elements("data")
+            .FirstOrDefault(element => string.Equals((string?)element.Attribute("name"), resourceName, StringComparison.Ordinal));
+
+        Assert.IsNotNull(dataElement, $"Expected resource key '{resourceName}' to exist in the resources file.");
+        var valueElement = dataElement!.Element("value");
+        Assert.IsNotNull(valueElement, $"Expected resource key '{resourceName}' to contain a <value> element.");
+
+        return valueElement!.Value;
     }
 
     private static string ReadRepositorySourceFile(string relativePath)

--- a/tests/WslContainersDesktop.App.Tests/Pages/SettingsPageSourceTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/Pages/SettingsPageSourceTests.cs
@@ -121,7 +121,7 @@ public sealed class SettingsPageSourceTests
         StringAssert.Contains(xamlText, "x:Name=\"TxtAppVersionLabel\"");
         StringAssert.Contains(xamlText, "x:Uid=\"TxtAppVersionLabel\"");
         StringAssert.Contains(xamlText, "x:Name=\"TxtAppVersionValue\"");
-        StringAssert.Contains(xamlText, "Text=\"{x:Bind AppVersionText, Mode=OneWay}\"");
+        StringAssert.Contains(xamlText, "Text=\"{x:Bind AppVersionText, Mode=OneTime}\"");
         StringAssert.Contains(codeBehindText, "Package.Current.Id.Version");
         StringAssert.Contains(codeBehindText, "public string AppVersionText { get; }");
     }


### PR DESCRIPTION
This updates the user-facing app identity now that the product name is Hakonexa. The title bar, package display resources, settings screen, README, and current design/reference snapshots now use `Hakonexa - WSL Containers Manager`.

The settings app information card now shows the app name, purpose, and package version. The version is read from package metadata at runtime and formatted as a four-part version string, keeping the manifest as the source of truth.

Tests added source-level coverage for branding resources, manifest wiring, settings-screen localization, README heading, and package-version formatting.

Validation:
- `dotnet test WslContainersDesktop.slnx --no-restore --verbosity minimal -p:EnableMsixTooling=false`