### PR TITLE
Update Store package identity

### DIFF
--- a/src/WslContainersDesktop.App/Package.appxmanifest
+++ b/src/WslContainersDesktop.App/Package.appxmanifest
@@ -8,15 +8,15 @@
   IgnorableNamespaces="uap rescap">
 
   <Identity
-    Name="4F24CC3B-CE1C-4B87-92A5-48C0A3EB5A98"
-    Publisher="CN=AppPublisher"
+    Name="45014okazuki.Hakonexa-WSLContainersManager"
+    Publisher="CN=57A8C5FA-395A-4109-91A0-CF1B93556B5D"
     Version="1.0.0.0" />
 
   <mp:PhoneIdentity PhoneProductId="4F24CC3B-CE1C-4B87-92A5-48C0A3EB5A98" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 
   <Properties>
     <DisplayName>ms-resource:AppDisplayName</DisplayName>
-    <PublisherDisplayName>AppPublisher</PublisherDisplayName>
+    <PublisherDisplayName>okazuki</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>
 

--- a/tests/WslContainersDesktop.App.Tests/Branding/AppBrandingSourceTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/Branding/AppBrandingSourceTests.cs
@@ -8,6 +8,9 @@ namespace WslContainersDesktop_App_Tests.Branding;
 public sealed class AppBrandingSourceTests
 {
     private const string ExpectedAppName = "Hakonexa - WSL Containers Manager";
+    private const string ExpectedPackageIdentityName = "45014okazuki.Hakonexa-WSLContainersManager";
+    private const string ExpectedPackageIdentityPublisher = "CN=57A8C5FA-395A-4109-91A0-CF1B93556B5D";
+    private const string ExpectedPublisherDisplayName = "okazuki";
     private const string ExpectedSettingsPurpose = "Manage WSL Containers from a native Windows desktop app.";
 
     [TestMethod]
@@ -58,6 +61,27 @@ public sealed class AppBrandingSourceTests
         StringAssert.Contains(manifestText, "<DisplayName>ms-resource:AppDisplayName</DisplayName>");
         StringAssert.Contains(manifestText, "DisplayName=\"ms-resource:AppDisplayName\"");
         StringAssert.Contains(manifestText, "Description=\"ms-resource:AppDescription\"");
+    }
+
+    [TestMethod]
+    public void AppBranding_Manifest_UsesStorePackageIdentityValues()
+    {
+        // Arrange
+        var manifestDocument = XDocument.Parse(ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Package.appxmanifest"));
+        XNamespace manifestNamespace = "http://schemas.microsoft.com/appx/manifest/foundation/windows10";
+
+        // Act
+        var identityElement = manifestDocument.Root?.Element(manifestNamespace + "Identity");
+        var publisherDisplayNameElement = manifestDocument.Root?
+            .Element(manifestNamespace + "Properties")?
+            .Element(manifestNamespace + "PublisherDisplayName");
+
+        // Assert
+        Assert.IsNotNull(identityElement, "Expected the app package manifest to contain an Identity element.");
+        Assert.AreEqual(ExpectedPackageIdentityName, (string?)identityElement!.Attribute("Name"));
+        Assert.AreEqual(ExpectedPackageIdentityPublisher, (string?)identityElement.Attribute("Publisher"));
+        Assert.IsNotNull(publisherDisplayNameElement, "Expected the app package manifest to contain a PublisherDisplayName element.");
+        Assert.AreEqual(ExpectedPublisherDisplayName, publisherDisplayNameElement!.Value);
     }
 
     [TestMethod]


### PR DESCRIPTION
The app name has been reserved in Microsoft Partner Center, so the packaged app manifest needs to use the Store-assigned identity before generating release MSIX packages.

This updates the WinUI app package manifest with the reserved Store package identity, publisher, and publisher display name. It also adds a branding source test that locks these manifest values so future packaging changes do not accidentally revert to placeholder identity values.