### PR TITLE
Add privacy policy for Microsoft Store submission

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -51,6 +51,7 @@ WinUI / .NET デスクトップアプリケーションです。新しい **WSL 
 | [`docs/design/`](docs/design/README.md) | 現在の設計の最新スナップショット |
 | [`docs/adr/`](docs/adr/README.md) | 設計判断・プロセス決定の記録 (Architecture Decision Record) |
 | [`docs/reference/`](docs/reference/README.md) | WSL Containers等、外部プラットフォームの仕様参照資料 |
+| [`docs/privacy-policy.md`](docs/privacy-policy.md) | Microsoft Store提出用のプライバシーポリシー |
 
 ## AIコーディングエージェントでの開発
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ for the layering decision.
 | [`docs/design/`](docs/design/README.md) | Current design snapshots |
 | [`docs/adr/`](docs/adr/README.md) | Architecture Decision Records |
 | [`docs/reference/`](docs/reference/README.md) | External platform references, including WSL Containers |
+| [`docs/privacy-policy.md`](docs/privacy-policy.md) | Privacy policy for Microsoft Store submission |
 
 ## Development with AI coding agents
 

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,0 +1,49 @@
+# Privacy Policy
+
+Effective date: 2026-07-08
+
+This Privacy Policy applies to Hakonexa - WSL Containers Manager (the "App"), distributed through Microsoft Store.
+
+## Information we collect
+
+The App does not collect, store, or transmit personal information to our servers.
+
+The App runs locally on your Windows device and uses the installed WSL / WSL Containers tools (`wsl`, `wslc`) and local WSL configuration files (such as `.wslconfig`) to manage containers, images, volumes, networks, and related settings. The data used for these operations remains on your device unless you explicitly choose to use a separate external service or command.
+
+## Local data processed by the App
+
+To provide its features, the App may read and display information that is already available locally on your machine, such as:
+
+- container, image, volume, and network names and status
+- WSL integration status
+- WSL resource limit settings
+
+This information is used only to present and manage your local WSL containers and related settings.
+
+## Information sharing
+
+We do not sell, rent, or share personal information with third parties.
+
+The App does not include third-party analytics, advertising, or tracking SDKs.
+
+## Data storage and security
+
+Because the App does not transmit personal data to our servers, no personal data is stored by us. Local data is stored on your device and handled according to your operating system and device security settings.
+
+## Microsoft Store and platform data
+
+Microsoft Store may process standard transaction and diagnostic data in accordance with Microsoft’s privacy policies. This App itself does not collect personal data directly.
+
+## Children’s privacy
+
+The App is not intended for children under 13 and does not knowingly collect personal information from them.
+
+## Changes to this Privacy Policy
+
+We may update this Privacy Policy from time to time. Any changes will be reflected in this document.
+
+## Contact
+
+If you have questions about this Privacy Policy, please contact us through the GitHub repository issues page:
+
+https://github.com/runceel/wsl-containers-desktop/issues


### PR DESCRIPTION
## Summary
- Added a repository privacy policy document tailored for Microsoft Store submission.
- Linked the new policy from the English and Japanese READMEs so it is easy to find.

## Why
The app is being prepared for Microsoft Store distribution, and a privacy policy is needed to describe how the app handles local WSL and container data.

## Notes
- This change is documentation-only.
- No code paths or runtime behavior were changed.