### PR TITLE
Multi-arch MSIX Store packaging + fix missing image assets

### DIFF
--- a/scripts/Build-StoreMsixUpload.ps1
+++ b/scripts/Build-StoreMsixUpload.ps1
@@ -1,44 +1,42 @@
 [CmdletBinding()]
 param(
     [string]$ProjectPath = ".\src\WslContainersDesktop.App\WslContainersDesktop.App.csproj",
+
+    # Store baseline is x64 + arm64. x86 is opt-in via -IncludeX86 or -Architectures.
+    [ValidateSet('x64', 'arm64', 'x86', IgnoreCase = $true)]
+    [string[]]$Architectures = @('x64', 'arm64'),
+
+    [switch]$IncludeX86,
+
     [string]$Configuration = "Release",
-    [string]$RuntimeIdentifier = "win-x64",
-    [string]$Platform = "x64",
     [string]$OutputDirectory,
+
+    # -Sign additionally produces a separately-named, locally signed sideload
+    # bundle ('<name>_<version>_sideload.msix[bundle]') plus its public
+    # certificate ('devcert.cer'). These never affect the Store .msixupload,
+    # which Microsoft Store re-signs during ingestion and must stay unsigned.
+    [switch]$Sign,
     [string]$CertificatePath,
     [string]$CertificatePassword,
     [string]$CertificateThumbprint,
     [switch]$GenerateTemporaryStoreCertificate,
-    [switch]$NoRestore
+
+    [switch]$NoRestore,
+    [switch]$SkipClean
 )
 
 $ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
 
-function New-TemporarySigningCertificate {
-    param(
-        [Parameter(Mandatory)]
-        [string]$Subject,
-        [Parameter(Mandatory)]
-        [string]$OutputPath,
-        [Parameter(Mandatory)]
-        [string]$Password
-    )
-
-    $tempDir = Split-Path -Parent $OutputPath
-    if (-not (Test-Path $tempDir)) {
-        New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
-    }
-
-    $certificate = New-SelfSignedCertificate -Type CodeSigning -Subject $Subject -CertStoreLocation "Cert:\CurrentUser\My" -KeyAlgorithm RSA -KeyLength 2048 -HashAlgorithm SHA256 -KeyExportPolicy Exportable -NotAfter (Get-Date).AddYears(1)
-    $securePassword = ConvertTo-SecureString -String $Password -Force -AsPlainText
-    Export-PfxCertificate -Cert $certificate -FilePath $OutputPath -Password $securePassword | Out-Null
-
-    return [pscustomobject]@{
-        Path = $OutputPath
-        Password = $Password
-        Thumbprint = $certificate.Thumbprint
+function Assert-Command {
+    param([Parameter(Mandatory)][string]$Name, [Parameter(Mandatory)][string]$InstallHint)
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        throw "Required command '$Name' was not found on PATH. $InstallHint"
     }
 }
+
+Assert-Command -Name "dotnet" -InstallHint "Install the .NET SDK."
+Assert-Command -Name "winapp" -InstallHint "Install via 'winget install Microsoft.WinAppCLI'."
 
 function New-RandomPassword {
     param([int]$Length = 24)
@@ -57,114 +55,293 @@ function New-RandomPassword {
     return $builder.ToString()
 }
 
+# ---------------------------------------------------------------------------
+# Resolve paths
+# ---------------------------------------------------------------------------
 $scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
 $repoRoot = Resolve-Path (Join-Path $scriptRoot "..")
 $projectFile = (Resolve-Path (Join-Path $repoRoot $ProjectPath) -ErrorAction Stop).Path
 $projectDir = Split-Path -Parent $projectFile
 $manifestFile = Join-Path $projectDir "Package.appxmanifest"
-$manifestContent = Get-Content -Path $manifestFile -Raw
-$manifestPublisherMatch = [regex]::Match($manifestContent, '<Identity\b[^>]*Publisher="([^"]+)"')
-if (-not $manifestPublisherMatch.Success) {
-    throw "Could not locate the package publisher in $manifestFile"
-}
-$publisher = $manifestPublisherMatch.Groups[1].Value
-
-$resolvedCertificatePath = $null
-$resolvedCertificatePassword = $null
-$resolvedCertificateThumbprint = $null
-
-if ($CertificatePath) {
-    $resolvedCertificatePath = (Resolve-Path -Path $CertificatePath -ErrorAction Stop).Path
+if (-not (Test-Path $manifestFile)) {
+    throw "Manifest not found: $manifestFile"
 }
 
-if ($CertificatePassword) {
-    $resolvedCertificatePassword = $CertificatePassword
+# ---------------------------------------------------------------------------
+# Architecture normalisation (dedup, preserve first-seen order)
+# ---------------------------------------------------------------------------
+$archTable = @{
+    'x64'   = [pscustomobject]@{ Key = 'x64';   Platform = 'x64';   Rid = 'win-x64'   }
+    'arm64' = [pscustomobject]@{ Key = 'arm64'; Platform = 'ARM64'; Rid = 'win-arm64' }
+    'x86'   = [pscustomobject]@{ Key = 'x86';   Platform = 'x86';   Rid = 'win-x86'   }
 }
 
-if ($CertificateThumbprint) {
-    $resolvedCertificateThumbprint = $CertificateThumbprint
-}
-
-$generateTemporaryCertificate = $GenerateTemporaryStoreCertificate -or (-not $resolvedCertificatePath -and -not $resolvedCertificateThumbprint)
-if ($generateTemporaryCertificate) {
-    $tempCertDir = Join-Path ([System.IO.Path]::GetTempPath()) "wsl-containers-desktop-store-cert"
-    $tempCertPath = Join-Path $tempCertDir "store-signing.pfx"
-    $tempCertPassword = New-RandomPassword
-
-    Write-Host "Generating temporary signing certificate for publisher '$publisher'"
-    $tempCertificate = New-TemporarySigningCertificate -Subject $publisher -OutputPath $tempCertPath -Password $tempCertPassword
-    $resolvedCertificatePath = $tempCertificate.Path
-    $resolvedCertificatePassword = $tempCertificate.Password
-    $resolvedCertificateThumbprint = $tempCertificate.Thumbprint
-}
-
-if ($OutputDirectory) {
-    $resolvedOutputDirectory = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($OutputDirectory)
-    if (-not (Test-Path $resolvedOutputDirectory)) {
-        New-Item -ItemType Directory -Path $resolvedOutputDirectory -Force | Out-Null
+$resolvedArchs = [System.Collections.Generic.List[object]]::new()
+$seenArchs = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+foreach ($a in $Architectures) {
+    $key = $a.ToLowerInvariant()
+    if ($seenArchs.Add($key)) {
+        [void]$resolvedArchs.Add($archTable[$key])
     }
-} else {
-    $resolvedOutputDirectory = Join-Path $projectDir "AppPackages"
+}
+if ($IncludeX86 -and $seenArchs.Add('x86')) {
+    [void]$resolvedArchs.Add($archTable['x86'])
+}
+if ($resolvedArchs.Count -eq 0) {
+    throw "No target architectures resolved."
 }
 
-$buildArgs = @(
-    $projectFile
-)
-
-if (-not $NoRestore) {
-    $buildArgs += "/restore"
+# ---------------------------------------------------------------------------
+# Manifest identity (Name / Version / Publisher) for output naming and
+# per-architecture sanity checks
+# ---------------------------------------------------------------------------
+[xml]$manifestXml = Get-Content -LiteralPath $manifestFile -Raw
+$identity = $manifestXml.Package.Identity
+if (-not $identity) {
+    throw "Manifest at $manifestFile is missing <Identity>."
 }
 
-$buildArgs += @(
-    "/t:Publish",
-    "/p:Configuration=$Configuration",
-    "/p:RuntimeIdentifier=$RuntimeIdentifier",
-    "/p:Platform=$Platform",
-    "/p:GenerateAppxPackageOnBuild=true",
-    "/p:AppxPackageIsForStore=true",
-    "/p:BuildAppxUploadPackageForUap=true",
-    "/p:AppxPackageSigningEnabled=true",
-    "/p:UapAppxPackageBuildMode=StoreUpload",
-    "/p:AppxBundle=Always",
-    "/p:AppxBundlePlatforms=$Platform",
-    "/p:PublishTrimmed=false",
-    "/p:AppxPackageDir=$resolvedOutputDirectory"
-)
-
-if ($resolvedCertificatePath) {
-    $buildArgs += "/p:PackageCertificateKeyFile=$resolvedCertificatePath"
+$packageName = $identity.Name
+$packageVersion = $identity.Version
+$packagePublisher = $identity.Publisher
+if (-not $packageName -or -not $packageVersion -or -not $packagePublisher) {
+    throw "Manifest Identity is missing Name/Version/Publisher."
 }
 
-if ($resolvedCertificatePassword) {
-    $buildArgs += "/p:PackageCertificatePassword=$resolvedCertificatePassword"
+if (-not $OutputDirectory) {
+    $OutputDirectory = Join-Path $projectDir "AppPackages"
+}
+$OutputDirectory = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($OutputDirectory)
+
+Write-Host "==> WSL Containers Desktop Store package build" -ForegroundColor Cyan
+Write-Host "    Identity Name      : $packageName"
+Write-Host "    Identity Publisher : $packagePublisher"
+Write-Host "    Version            : $packageVersion"
+Write-Host "    Architectures      : $((($resolvedArchs | ForEach-Object Key) -join ', '))"
+Write-Host "    Output directory   : $OutputDirectory"
+
+# ---------------------------------------------------------------------------
+# Clean output (preserve dev signing certificate across incremental -Sign runs)
+# ---------------------------------------------------------------------------
+$layoutRoot = Join-Path $OutputDirectory "layout"
+
+if (-not $SkipClean -and (Test-Path $OutputDirectory)) {
+    Write-Host "==> Cleaning $OutputDirectory (preserving devcert.pfx / devcert.cer)" -ForegroundColor Cyan
+    Get-ChildItem -LiteralPath $OutputDirectory -Force |
+        Where-Object { $_.Name -ne 'devcert.pfx' -and $_.Name -ne 'devcert.cer' } |
+        Remove-Item -Recurse -Force
+}
+New-Item -ItemType Directory -Force -Path $OutputDirectory, $layoutRoot | Out-Null
+
+# ---------------------------------------------------------------------------
+# Per-architecture: self-contained dotnet publish
+# ---------------------------------------------------------------------------
+$publishDirs = [System.Collections.Generic.List[string]]::new()
+foreach ($arch in $resolvedArchs) {
+    Write-Host ""
+    Write-Host "==> [$($arch.Key)] dotnet publish ($Configuration, $($arch.Rid))" -ForegroundColor Cyan
+
+    $publishDir = Join-Path $layoutRoot $arch.Key
+    New-Item -ItemType Directory -Force -Path $publishDir | Out-Null
+
+    # `dotnet publish` produces the self-contained layout (with AppxManifest.xml
+    # token-replaced) under -o. Trimming is forcibly disabled: WinUI 3 /
+    # CommunityToolkit.Mvvm reflection-heavy code paths are not fully
+    # trim-safe. GenerateAppxPackageOnBuild=false ensures MSBuild does not try
+    # to invoke MakeAppx itself -- `winapp package` below owns that step.
+    $dotnetArgs = @(
+        'publish', $projectFile
+        '-c', $Configuration
+        '-p:Platform=' + $arch.Platform
+        '-p:RuntimeIdentifier=' + $arch.Rid
+        '-p:SelfContained=true'
+        '-p:PublishTrimmed=false'
+        '-p:GenerateAppxPackageOnBuild=false'
+        '-p:AppxPackageSigningEnabled=false'
+        '-o', $publishDir
+        '--nologo'
+        '-v', 'minimal'
+    )
+    if ($NoRestore) {
+        $dotnetArgs += '--no-restore'
+    }
+    & dotnet @dotnetArgs
+    if ($LASTEXITCODE -ne 0) {
+        throw "dotnet publish failed for $($arch.Key) (exit $LASTEXITCODE)"
+    }
+
+    # WslContainersDesktop.App.csproj marks Assets\*.png / Assets\AppIcon.ico
+    # with CopyToPublishDirectory="PreserveNewest", so `dotnet publish` copies
+    # them into the publish output even with GenerateAppxPackageOnBuild=false
+    # (that flag only disables the MSIX single-project packaging targets, not
+    # the normal Content-copy mechanism, once the metadata is set). This is a
+    # fail-fast safety net: if the csproj setting ever regresses, the manifest's
+    # image references (StoreLogo.png, Square44x44Logo.png, etc.) would resolve
+    # to nothing and Partner Center would reject the package with
+    # "Package acceptance validation error: ... were not found".
+    $assetsDestDir = Join-Path $publishDir 'Assets'
+    if (-not (Get-ChildItem -LiteralPath $assetsDestDir -Filter '*.png' -ErrorAction SilentlyContinue)) {
+        throw "Published output for $($arch.Key) has no Assets\*.png files. Check that Content items in WslContainersDesktop.App.csproj have CopyToPublishDirectory set; manifest image references will fail Store validation otherwise."
+    }
+
+    # Verify the published layout has the token-replaced manifest. If the
+    # publish target dropped it, fall back to the canonical
+    # bin\<Platform>\<Configuration>\<TFM>\<RID>\AppxManifest.xml.
+    $publishedManifest = Join-Path $publishDir 'AppxManifest.xml'
+    if (-not (Test-Path $publishedManifest)) {
+        $tfmRoots = Get-ChildItem -LiteralPath (Join-Path $projectDir "bin\$($arch.Platform)\$Configuration") -Directory -ErrorAction SilentlyContinue
+        $fallback = $null
+        foreach ($tfm in $tfmRoots) {
+            $candidate = Join-Path $tfm.FullName "$($arch.Rid)\AppxManifest.xml"
+            if (Test-Path $candidate) { $fallback = $candidate; break }
+        }
+        if (-not $fallback) {
+            throw "Published layout for $($arch.Key) is missing AppxManifest.xml and no build-output fallback was found under bin\$($arch.Platform)\$Configuration."
+        }
+        Write-Host "    AppxManifest.xml missing from publish dir; copying from $fallback" -ForegroundColor Yellow
+        Copy-Item -LiteralPath $fallback -Destination $publishedManifest
+    }
+
+    # Sanity check: token replacement and arch tagging
+    $manifestText = Get-Content -LiteralPath $publishedManifest -Raw
+    if ($manifestText -match '\$targetnametoken\$|\$targetentrypoint\$') {
+        throw "Published AppxManifest.xml still contains MSBuild tokens for $($arch.Key)."
+    }
+    if ($manifestText -notmatch 'ProcessorArchitecture\s*=\s*"' + [regex]::Escape($arch.Rid.Substring(4)) + '"') {
+        throw "Published AppxManifest.xml for $($arch.Key) does not declare ProcessorArchitecture=`"$($arch.Rid.Substring(4))`"."
+    }
+
+    Write-Host "    Published layout: $publishDir"
+    $publishDirs.Add($publishDir)
 }
 
-if ($resolvedCertificateThumbprint) {
-    $buildArgs += "/p:PackageCertificateThumbprint=$resolvedCertificateThumbprint"
-}
+# ---------------------------------------------------------------------------
+# Package / bundle: `winapp package` accepts multiple input folders and
+# produces a multi-architecture .msixbundle directly (a single folder yields
+# a plain .msix). No --cert here: the Store artifact must stay unsigned
+# because Microsoft Store re-signs every package during ingestion.
+# ---------------------------------------------------------------------------
+Write-Host ""
+$packageExtension = if ($publishDirs.Count -gt 1) { ".msixbundle" } else { ".msix" }
+$packageFileName = "${packageName}_${packageVersion}${packageExtension}"
+$packageOut = Join-Path $OutputDirectory $packageFileName
+Write-Host "==> Packaging $($publishDirs.Count) architecture(s) into $packageFileName" -ForegroundColor Cyan
 
-if ($NoRestore) {
-    $buildArgs += "/p:Restore=false"
-}
-
-$packageSearchRoot = if ($OutputDirectory) { $resolvedOutputDirectory } else { $projectDir }
-Get-ChildItem -Path $packageSearchRoot -Filter "*.msixupload" -Recurse -File -ErrorAction SilentlyContinue | Remove-Item -Force
-
-Write-Host "Running: dotnet msbuild $($buildArgs -join ' ')"
-& dotnet msbuild @buildArgs
-$packageFiles = Get-ChildItem -Path $packageSearchRoot -Filter "*.msixupload" -Recurse -File | Sort-Object LastWriteTime -Descending
-if ($LASTEXITCODE -ne 0 -and -not $packageFiles) {
-    throw "MSIX Store upload build failed with exit code $LASTEXITCODE and no .msixupload package was produced."
-}
-
+$winappPackageArgs = @($publishDirs) + @('--output', $packageOut, '--quiet')
+& winapp package @winappPackageArgs
 if ($LASTEXITCODE -ne 0) {
-    Write-Warning "The build exited with code $LASTEXITCODE, but an .msixupload package was produced. Review the packaging warnings before submission."
+    throw "winapp package failed (exit $LASTEXITCODE)"
+}
+if (-not (Test-Path $packageOut)) {
+    throw "Expected package not found: $packageOut"
 }
 
-if (-not $packageFiles) {
-    throw "No .msixupload package was produced under $packageSearchRoot."
+$packageSizeMB = [math]::Round((Get-Item $packageOut).Length / 1MB, 2)
+Write-Host "    Produced $packageFileName ($packageSizeMB MB)"
+
+# ---------------------------------------------------------------------------
+# Wrap into .msixupload (a zip containing the bundle/package at the root)
+#
+# IMPORTANT: This must happen BEFORE optional signing, because the Store
+# .msixupload must contain the UNSIGNED package, not the locally-signed
+# sideload copy produced below.
+# ---------------------------------------------------------------------------
+Write-Host ""
+Write-Host "==> Wrapping unsigned package into .msixupload (Store submission artifact)" -ForegroundColor Cyan
+$uploadName = "${packageName}_${packageVersion}.msixupload"
+$uploadOut = Join-Path $OutputDirectory $uploadName
+if (Test-Path $uploadOut) { Remove-Item -LiteralPath $uploadOut -Force }
+
+Add-Type -AssemblyName System.IO.Compression
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+$zip = [System.IO.Compression.ZipFile]::Open($uploadOut, [System.IO.Compression.ZipArchiveMode]::Create)
+try {
+    [void][System.IO.Compression.ZipFileExtensions]::CreateEntryFromFile(
+        $zip,
+        $packageOut,
+        $packageFileName,
+        [System.IO.Compression.CompressionLevel]::Optimal)
+} finally {
+    $zip.Dispose()
 }
 
-$packageFile = $packageFiles[0]
-Write-Host "Created: $($packageFile.FullName)"
-$packageFile.FullName
+$uploadSizeMB = [math]::Round((Get-Item $uploadOut).Length / 1MB, 2)
+Write-Host "    Produced $uploadName ($uploadSizeMB MB)"
+
+try {
+    $zip = [System.IO.Compression.ZipFile]::OpenRead($uploadOut)
+    try {
+        $entries = $zip.Entries.FullName
+        if ($entries -notcontains $packageFileName) {
+            throw "The .msixupload does not contain $packageFileName at its root. Entries: $($entries -join ', ')"
+        }
+    } finally {
+        $zip.Dispose()
+    }
+} catch {
+    throw "Verification of $uploadOut failed: $_"
+}
+
+# ---------------------------------------------------------------------------
+# Optional: produce a signed sideload copy (GitHub Releases / local
+# Add-AppxPackage testing only). This never touches the Store .msixupload.
+# ---------------------------------------------------------------------------
+$sideloadOut = $null
+$cerOut = $null
+if ($Sign) {
+    Write-Host ""
+    Write-Host "==> Producing signed sideload package" -ForegroundColor Cyan
+
+    $sideloadName = "${packageName}_${packageVersion}_sideload${packageExtension}"
+    $sideloadOut = Join-Path $OutputDirectory $sideloadName
+    Copy-Item -LiteralPath $packageOut -Destination $sideloadOut -Force
+
+    if ($CertificateThumbprint) {
+        Write-Host "    Signing with certificate thumbprint $CertificateThumbprint from the local certificate store"
+        & winapp tool signtool sign /sha1 $CertificateThumbprint /fd SHA256 /a $sideloadOut
+        if ($LASTEXITCODE -ne 0) { throw "signtool sign failed (exit $LASTEXITCODE)" }
+    } else {
+        if (-not $CertificatePath) {
+            $CertificatePath = Join-Path $OutputDirectory "devcert.pfx"
+            $cerOut = Join-Path $OutputDirectory "devcert.cer"
+            if (-not $CertificatePassword) {
+                $CertificatePassword = New-RandomPassword
+            }
+            if ($GenerateTemporaryStoreCertificate -or -not (Test-Path $CertificatePath)) {
+                Write-Host "    Generating dev certificate at $CertificatePath (matches manifest Publisher '$packagePublisher')"
+                & winapp cert generate --manifest $manifestFile --output $CertificatePath --password $CertificatePassword --export-cer --if-exists Overwrite --quiet
+                if ($LASTEXITCODE -ne 0) { throw "winapp cert generate failed (exit $LASTEXITCODE)" }
+            }
+        } else {
+            $CertificatePath = (Resolve-Path -Path $CertificatePath -ErrorAction Stop).Path
+        }
+        if (-not $CertificatePassword) {
+            $CertificatePassword = 'password'
+        }
+
+        & winapp sign $sideloadOut $CertificatePath --password $CertificatePassword
+        if ($LASTEXITCODE -ne 0) { throw "winapp sign failed (exit $LASTEXITCODE)" }
+    }
+
+    Write-Host "    Signed sideload package: $sideloadOut"
+    if ($cerOut -and (Test-Path $cerOut)) {
+        Write-Host "    Public certificate      : $cerOut"
+        Write-Host "    NEVER publish the .pfx -- only the .cer (public key) is safe to distribute." -ForegroundColor Yellow
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+Write-Host ""
+Write-Host "==> Done." -ForegroundColor Green
+Write-Host "    Package (unsigned, intermediate) : $packageOut"
+Write-Host "    Upload (Store submission)        : $uploadOut"
+if ($Sign) {
+    Write-Host "    Sideload package (signed)        : $sideloadOut"
+    if ($cerOut -and (Test-Path $cerOut)) {
+        Write-Host "    Public cert (.cer)               : $cerOut"
+    }
+}
+
+$uploadOut

--- a/src/WslContainersDesktop.App/WslContainersDesktop.App.csproj
+++ b/src/WslContainersDesktop.App/WslContainersDesktop.App.csproj
@@ -26,9 +26,17 @@
     <WindowsAppSdkDeploymentManagerInitialize>false</WindowsAppSdkDeploymentManagerInitialize>
   </PropertyGroup>
 
+  <!--
+    dotnet publish -p:GenerateAppxPackageOnBuild=false (winapp CLIによる
+    パッケージング用にMSIXの単一プロジェクトパッケージングを無効化して
+    publishする場合)では、Content項目のペイロードコピーはMSIXパッケージング
+    専用ターゲット経由でしか行われず、通常のpublish出力コピーは発生しない。
+    CopyToPublishDirectoryを明示することで、GenerateAppxPackageOnBuildの
+    値に関わらずAssetsがpublish出力へ確実にコピーされるようにする。
+  -->
   <ItemGroup>
-    <Content Include="Assets\*.png" />
-    <Content Include="Assets\AppIcon.ico" />
+    <Content Include="Assets\*.png" CopyToPublishDirectory="PreserveNewest" />
+    <Content Include="Assets\AppIcon.ico" CopyToPublishDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Why

The existing `Build-StoreMsixUpload.ps1` only ever produced a single-architecture (x64) package via one MSBuild `AppxBundle` invocation, even though the app project declares `<Platforms>x86;x64;ARM64</Platforms>`. Separately, a real Partner Center submission failed with:

```
Package acceptance validation error: The following image(s) specified in the appxManifest.xml
... were not found: Assets\StoreLogo.png, Assets\Square44x44Logo.png, Assets\Square150x150Logo.png,
Assets\Wide310x150Logo.png, Assets\SplashScreen.png
```

## What changed

**Multi-architecture packaging** (`scripts/Build-StoreMsixUpload.ps1`)
- Replaced the single `dotnet msbuild /t:Publish` + `AppxBundlePlatforms` call (which always resolved to one platform) with a per-architecture `dotnet publish` (self-contained, trimming disabled, `GenerateAppxPackageOnBuild=false`) followed by a single `winapp package` call across all published layouts, which bundles them into one `.msixbundle`.
- Defaults to `x64` + `arm64`; `x86` is available via `-IncludeX86`.
- Reference: adapted the pattern from a sibling project's `Build-StorePackage.ps1` / release skill.

**Signing policy fix**
- The `.msixupload` submitted to the Store is no longer signed by default. The Store re-signs every package on ingestion, so shipping a pre-signed upload was unnecessary (and was the old script's behavior).
- Added an optional `-Sign` switch that produces a *separate* signed `_sideload` package plus a `devcert.cer`, useful for GitHub Releases or local `Add-AppxPackage` testing. This never touches the Store artifact.

**Root-cause fix for the missing-assets validation error**
- Diagnosed: `dotnet publish -p:GenerateAppxPackageOnBuild=false` does not copy `Content` items like `Assets\*.png` into the publish output, because that copy is normally performed only by the MSIX single-project packaging targets (which this flag disables). The manifest's image references then pointed to nothing.
- Fix: added `CopyToPublishDirectory="PreserveNewest"` to the `Assets\*.png` / `Assets\AppIcon.ico` `Content` items in `WslContainersDesktop.App.csproj`, so `dotnet publish` copies them regardless of the packaging-target flag. This is the actual root-cause fix (verified independently before touching the script).
- The script's earlier ad-hoc `Copy-Item -Recurse` workaround was removed and replaced with a fail-fast guard that verifies `Assets\*.png` exists in the publish output, so a future regression of the csproj setting is caught immediately instead of surfacing days later as a Partner Center rejection.

## Verification

Ran the script end-to-end multiple times:
- Default `x64` + `arm64` build: produced a 160.5 MB `.msixbundle` / 158.33 MB `.msixupload`; confirmed both `x64.msix` and `arm64.msix` entries are present.
- Extracted the `x64.msix` from the bundle and confirmed all 47 `Assets/*` files (including scale/targetsize variants such as `Square44x44Logo.targetsize-*.png`) and `resources.pri` are present.
- `x64 -Sign`: confirmed a separate signed sideload `.msix` + `devcert.cer` are produced, and that `winapp tool signtool verify` reports the expected (harmless) untrusted-root error since the dev cert isn't installed to the trust store.
- Test build artifacts (`AppPackages`, `bin`, `obj`) were cleaned up after each verification run; they are gitignored and not part of this diff.