### PR TITLE
Fix WMC1506 warning in DashboardPage.xaml

### DIFF
--- a/src/WslContainersDesktop.App/Pages/DashboardPage.xaml
+++ b/src/WslContainersDesktop.App/Pages/DashboardPage.xaml
@@ -240,13 +240,13 @@
                                         <Button
                                             x:Uid="BtnDashboardStatsDetails"
                                             VerticalAlignment="Center"
-                                            AutomationProperties.AutomationId="{x:Bind ContainerId, Mode=OneWay, Converter={StaticResource AutomationIdConverter}, ConverterParameter=BtnDashboardStatsDetails}"
+                                            AutomationProperties.AutomationId="{x:Bind ContainerId, Mode=OneTime, Converter={StaticResource AutomationIdConverter}, ConverterParameter=BtnDashboardStatsDetails}"
                                             Click="BtnStatsDetails_Click"
                                             CommandParameter="{x:Bind}" />
                                         <Button
                                             x:Uid="BtnDashboardStatsLogs"
                                             VerticalAlignment="Center"
-                                            AutomationProperties.AutomationId="{x:Bind ContainerId, Mode=OneWay, Converter={StaticResource AutomationIdConverter}, ConverterParameter=BtnDashboardStatsLogs}"
+                                            AutomationProperties.AutomationId="{x:Bind ContainerId, Mode=OneTime, Converter={StaticResource AutomationIdConverter}, ConverterParameter=BtnDashboardStatsLogs}"
                                             Click="BtnStatsLogs_Click"
                                             CommandParameter="{x:Bind}" />
                                     </StackPanel>


### PR DESCRIPTION
## Why

The dashboard's stats row buttons bind `AutomationProperties.AutomationId` to `ContainerId` using `x:Bind Mode=OneWay`. `ContainerId` on `DashboardContainerStatsRowViewModel` is a get-only property backed by an immutable `ContainerResourceUsage` value and never changes after the row view model is created, and the view model does not implement `INotifyPropertyChanged`. Because no step in the binding path can raise a change notification, the compiler emitted:

```
XamlCompiler warning WMC1506: OneWay bindings require at least one of their steps to support raising notifications when their value changes
```

## What changed

Switched the two affected bindings in `DashboardPage.xaml` from `Mode=OneWay` to `Mode=OneTime`, since the bound value is fixed for the lifetime of the row.

## Verification

- Reviewed the fix approach with a rubber-duck pass: `OneTime` is correct here; no need to add `INotifyPropertyChanged` to the view model since the value is genuinely static.
- `dotnet build src\WslContainersDesktop.App\WslContainersDesktop.App.csproj` succeeds with 0 warnings for WMC1506.