### PR TITLE
Add horizontal scroll for Logs/Shell output, wrap status text

### DIFF
--- a/scripts/Run-App.ps1
+++ b/scripts/Run-App.ps1
@@ -1,0 +1,63 @@
+<#
+.SYNOPSIS
+WslContainersDesktop.App をビルドして起動するだけのスクリプト。
+
+.DESCRIPTION
+ローカルで動作確認したいときに使う、単純なbuild+runラッパー。
+実行中マシンのアーキテクチャ(ARM64/x64)を自動判定し、対応する RuntimeIdentifier を
+明示的に指定してビルドしたのち、winapp run で起動する(.exe を直接実行しない)。
+
+高度なビルドオプション(アナライザー注入、MSBuild自動検出等)が必要な場合は、
+winui-dev-workflow skill の BuildAndRun.ps1 を利用すること(本スクリプトでは重複させない)。
+
+.EXAMPLE
+.\scripts\Run-App.ps1
+.\scripts\Run-App.ps1 -Configuration Release
+#>
+
+[CmdletBinding()]
+param(
+    [string]$ProjectPath = "$PSScriptRoot\..\src\WslContainersDesktop.App\WslContainersDesktop.App.csproj",
+    [string]$Configuration = "Debug"
+)
+
+$ErrorActionPreference = "Stop"
+
+$platform = if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") { "ARM64" } else { "x64" }
+$rid = "win-$($platform.ToLowerInvariant())"
+$resolvedProject = (Resolve-Path $ProjectPath).Path
+$projectDir = Split-Path $resolvedProject -Parent
+
+Write-Host "--> Building $resolvedProject (Platform: $platform, Configuration: $Configuration, RID: $rid)" -ForegroundColor Cyan
+
+& dotnet build $resolvedProject -c $Configuration -p:Platform=$platform -p:RuntimeIdentifier=$rid
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "BUILD FAILED (exit code $LASTEXITCODE)" -ForegroundColor Red
+    exit $LASTEXITCODE
+}
+
+Write-Host ""
+Write-Host "BUILD SUCCEEDED" -ForegroundColor Green
+
+$winapp = Get-Command winapp -ErrorAction SilentlyContinue
+if (-not $winapp) {
+    Write-Host "WARNING: winapp CLI が見つかりません。起動をスキップします。" -ForegroundColor Yellow
+    exit 0
+}
+
+$binDir = Join-Path $projectDir "bin\$platform\$Configuration"
+$tfmDir = Get-ChildItem $binDir -Directory -ErrorAction Stop |
+    Where-Object { $_.Name -match "^net\d" } |
+    Sort-Object Name -Descending |
+    Select-Object -First 1
+if (-not $tfmDir) {
+    throw "ビルド出力フォルダが見つかりません: $binDir"
+}
+
+$outputDir = Join-Path $tfmDir.FullName $rid
+if (-not (Test-Path $outputDir)) {
+    $outputDir = $tfmDir.FullName
+}
+
+Write-Host "--> Launching app: winapp run $outputDir --debug-output" -ForegroundColor Cyan
+& winapp run $outputDir --debug-output

--- a/src/WslContainersDesktop.App/Pages/ContainersPage.xaml
+++ b/src/WslContainersDesktop.App/Pages/ContainersPage.xaml
@@ -279,6 +279,7 @@
                     x:Name="TxtShellStatus"
                     Grid.Row="2"
                     Text="{x:Bind ViewModel.ShellStatusMessage, Mode=OneWay}"
+                    TextWrapping="WrapWholeWords"
                     Visibility="{x:Bind ToVisibleWhenTrue(ViewModel.IsShellStatusVisible), Mode=OneWay}" />
 
                 <ListView
@@ -286,7 +287,20 @@
                     Grid.Row="3"
                     AutomationProperties.AutomationId="LstShellOutput"
                     ItemsSource="{x:Bind ViewModel.ShellOutput, Mode=OneWay}"
-                    SelectionMode="None" />
+                    ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                    ScrollViewer.HorizontalScrollMode="Enabled"
+                    SelectionMode="None">
+                    <ListView.ItemContainerStyle>
+                        <Style TargetType="ListViewItem">
+                            <Setter Property="HorizontalContentAlignment" Value="Left" />
+                        </Style>
+                    </ListView.ItemContainerStyle>
+                    <ListView.ItemTemplate>
+                        <DataTemplate x:DataType="x:String">
+                            <TextBlock Text="{x:Bind}" TextWrapping="NoWrap" />
+                        </DataTemplate>
+                    </ListView.ItemTemplate>
+                </ListView>
 
                 <Grid Grid.Row="4" ColumnSpacing="8">
                     <Grid.ColumnDefinitions>
@@ -381,6 +395,7 @@
                     x:Name="TxtLogStatus"
                     Grid.Row="2"
                     Text="{x:Bind ViewModel.LogStatusMessage, Mode=OneWay}"
+                    TextWrapping="WrapWholeWords"
                     Visibility="{x:Bind ToVisibleWhenTrue(ViewModel.IsLogStatusVisible), Mode=OneWay}" />
 
                 <Grid Grid.Row="3">
@@ -388,6 +403,8 @@
                         x:Name="LstLogs"
                         AutomationProperties.AutomationId="LstLogs"
                         ItemsSource="{x:Bind ViewModel.LogLines, Mode=OneWay}"
+                        ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                        ScrollViewer.HorizontalScrollMode="Enabled"
                         SelectionMode="None"
                         Visibility="{x:Bind ToVisibleWhenFalse(ViewModel.IsLogEmpty), Mode=OneWay}">
                         <!--
@@ -400,6 +417,16 @@
                             スクロールして読んでいる場合は追従しない」挙動をWinUI自身が保証するため、
                             ScrollViewerを自前で探索・監視するコードは不要になる。
                         -->
+                        <ListView.ItemContainerStyle>
+                            <Style TargetType="ListViewItem">
+                                <Setter Property="HorizontalContentAlignment" Value="Left" />
+                            </Style>
+                        </ListView.ItemContainerStyle>
+                        <ListView.ItemTemplate>
+                            <DataTemplate x:DataType="x:String">
+                                <TextBlock Text="{x:Bind}" TextWrapping="NoWrap" />
+                            </DataTemplate>
+                        </ListView.ItemTemplate>
                         <ListView.ItemsPanel>
                             <ItemsPanelTemplate>
                                 <ItemsStackPanel ItemsUpdatingScrollMode="KeepLastItemInView" />


### PR DESCRIPTION
## Why

The Containers page's Logs and Shell panels showed each line in a fixed-width `ListView`. Long log lines or shell output got visually clipped with no way to see the rest of the text.

## What changed

- `LstLogs` / `LstShellOutput`: enabled `ScrollViewer.HorizontalScrollMode`/`HorizontalScrollBarVisibility` and added an item template with a left-aligned, non-wrapping `TextBlock`, so long lines can be scrolled horizontally instead of being clipped. The existing "keep last item in view" auto-scroll behavior for `LstLogs` is preserved.
- `TxtLogStatus` / `TxtShellStatus`: added `TextWrapping="WrapWholeWords"` so long status messages (e.g. "This container is stopped. Existing logs are displayed...") are fully readable. Since these rows are `Auto`-height and the log/shell list rows below them have a fixed pixel height, wrapping only grows the status area slightly and does not shrink the log/shell viewing area.
- Added `scripts/Run-App.ps1`: a minimal build+run helper for local verification. It detects the machine architecture (ARM64/x64), builds with the matching `RuntimeIdentifier`, and launches the app via `winapp run`. It intentionally stays lightweight (plain `dotnet build`) and defers to the `winui-dev-workflow` skill's `BuildAndRun.ps1` for advanced scenarios (analyzer injection, MSBuild auto-detection), per this repo's convention of not duplicating that skill's functionality.

## Notes for reviewers

- Verified locally: built and ran the app (ARM64), confirmed the panels render and the app launches without new build warnings.
- No production/business logic changed - this is purely a Presentation-layer (XAML) and dev-tooling change.