### PR TITLE
Add Logs/Shell pop-out windows with consistent title bars

### DIFF
--- a/docs/design/containers-view.md
+++ b/docs/design/containers-view.md
@@ -169,3 +169,37 @@
   `double.MaxValue`）が常にクランプされる保証はない。また、新規追加行のレイアウトが
   `ExtentHeight`に反映されるタイミングとの競合により、自前実装では追従が途中で解除される
   不具合が発生していた。
+
+## ログ/シェルパネルの個別ウィンドウ表示（ポップアウト）
+
+- 右側の補助ペインは小さいため、ログ・シェルパネルのヘッダーに「Open in window」ボタン
+  （`BtnOpenLogsWindow`/`BtnOpenShellWindow`）を追加し、同じ内容を大きな個別ウィンドウ
+  （`Windows/LogsWindow.xaml`・`Windows/ShellWindow.xaml`）としても表示できる。小さい補助ペイン自体は
+  引き続き表示されたままで、どちらからでも同じ状態（`ContainersViewModel`の`LogLines`/`ShellOutput`
+  や各種コマンド）を操作できる。詳細パネルはこの導線の対象外。
+- 各ウィンドウは対象ごとに1つだけ開く。ボタンを押したとき既に開いていれば新規に開かず、既存の
+  ウィンドウを`Activate()`するだけにとどめる。この生成/再利用/Closed後の再生成ロジックは
+  `Windows/SingleInstanceWindowOpener.cs`（`SingleInstanceWindowOpener<TWindow>`）に切り出されている。
+  `TWindow`を実際のWinUI `Window`型に固定せず、生成・Activate・Closed購読をすべてデリゲート経由で
+  受け取ることで、実ウィンドウを介さずにMSTestで検証できるようにしている。
+- `ContainersPage`は`Frame.Navigate`のたびに作り直されるため、ウィンドウ参照をページのフィールドで
+  保持することはできない。そこで`Windows/ContainerAuxiliaryWindowManager.cs`をDIの
+  Singleton（`App.xaml.cs`の`ConfigureServices`で登録）として用意し、`SingleInstanceWindowOpener<LogsWindow>`と
+  `SingleInstanceWindowOpener<ShellWindow>`を1組ずつ合成して保持する。`ContainersPage`のClickハンドラは
+  `_windowManager.ShowLogsWindow()`/`ShowShellWindow()`を呼ぶだけで、ウィンドウの生成・再利用判断には
+  関与しない。
+- `LogsWindow`/`ShellWindow`は小さい補助ペインと同じ`ContainersViewModel`インスタンスを共有する
+  （コンストラクタで受け取り、`ViewModel`プロパティとして公開）。そのため以下は既存の設計制約に
+  起因する既知の挙動であり、今回のスコープでは対応しない:
+  - `ContainersViewModel`は単一コンテナの状態のみを保持するため、ポップアウトを開いたまま
+    別コンテナのログ/シェルを開くと、ポップアウト側の表示内容も暗黙に切り替わる。
+  - `ShellCommandText`は小さいシェルパネルとポップアウト`ShellWindow`の間でTwoWay共有されるため、
+    両方を同時に表示して入力すると干渉し得る。
+  - ウィンドウサイズは`Activated`イベント時に取得した`XamlRoot.RasterizationScale`を用いた近似的な
+    DPI考慮のみ（1000x700 DIPs相当）で、モニター間移動時のDPI変化への追従までは行わない。
+- ポップアウト側にもログ用のPause/Resume/Clear/Close、シェル用のコマンド入力・Send・Closeを
+  再配置しており、ユーザーが`ContainersPage`から離れてポップアウトだけが残っている状態でも
+  セッションを操作・終了できる。ただし、ウィンドウのタイトルバーの閉じるボタン（×）はウィンドウを
+  閉じるだけで、ログ追跡やシェル接続そのものは停止しない（停止するには各ウィンドウ内の
+  `CloseLogsCommand`/`CloseShellCommand`を使う）。ウィンドウを閉じる操作とセッションを終了する操作は
+  意図的に分離している。

--- a/docs/design/containers-view.md
+++ b/docs/design/containers-view.md
@@ -197,9 +197,15 @@
     両方を同時に表示して入力すると干渉し得る。
   - ウィンドウサイズは`Activated`イベント時に取得した`XamlRoot.RasterizationScale`を用いた近似的な
     DPI考慮のみ（1000x700 DIPs相当）で、モニター間移動時のDPI変化への追従までは行わない。
-- ポップアウト側にもログ用のPause/Resume/Clear/Close、シェル用のコマンド入力・Send・Closeを
-  再配置しており、ユーザーが`ContainersPage`から離れてポップアウトだけが残っている状態でも
-  セッションを操作・終了できる。ただし、ウィンドウのタイトルバーの閉じるボタン（×）はウィンドウを
-  閉じるだけで、ログ追跡やシェル接続そのものは停止しない（停止するには各ウィンドウ内の
-  `CloseLogsCommand`/`CloseShellCommand`を使う）。ウィンドウを閉じる操作とセッションを終了する操作は
-  意図的に分離している。
+- ポップアウト側にもログ用のPause/Resume/Clear、シェル用のコマンド入力・Sendを再配置しており、
+  ユーザーが`ContainersPage`から離れてポップアウトだけが残っている状態でもセッションを操作できる。
+  各ウィンドウ内の`Close`ボタン（`BtnCloseLogs`/`BtnCloseShell`）およびタイトルバーの閉じるボタン
+  （×）は、どちらも**このウィンドウを閉じるだけ**で、ログ追跡やシェル接続そのものは停止しない。
+  ログ追跡・シェル接続を終了するには、小さい補助ペイン側の`CloseLogsCommand`/`CloseShellCommand`
+  に配線されたCloseボタンを使う。ウィンドウを閉じる操作とセッションを終了する操作は意図的に
+  分離している（ポップアウトを閉じても小さい補助ペインは影響を受けず動作し続ける）。
+- `LogsWindow`/`ShellWindow`のタイトルバーは`MainWindow`と同じルック＆フィールにしている。
+  `ExtendsContentIntoTitleBar = true`とアプリアイコン付きの`TitleBar`コントロール
+  （`IsPaneToggleButtonVisible="False"`、`TitleBarHeightOption.Tall`）を各ウィンドウに配置し、
+  `MainWindow`のカスタムタイトルバーと視覚的に統一している（ナビゲーションペインを持たないため
+  ペイントグルボタンのみ非表示にしている）。

--- a/src/WslContainersDesktop.App/App.xaml.cs
+++ b/src/WslContainersDesktop.App/App.xaml.cs
@@ -13,6 +13,7 @@ using WslContainersDesktop.Infrastructure.Clients;
 using WslContainersDesktop.Infrastructure.Settings;
 using WslContainersDesktop.Infrastructure.Wsl;
 using WslContainersDesktop_App.ViewModels;
+using WslContainersDesktop_App.Windows;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -74,6 +75,10 @@ public partial class App : Application
         services.AddSingleton<VolumesViewModel>();
         services.AddSingleton<NetworksViewModel>();
         services.AddSingleton<SettingsViewModel>();
+
+        // Logs/Shellパネルのポップアウトウィンドウは、ContainersPageがNavigateのたびに
+        // 作り直されても状態を維持できるよう、アプリケーションライフタイムのSingletonとする。
+        services.AddSingleton<ContainerAuxiliaryWindowManager>();
 
         return services.BuildServiceProvider();
     }

--- a/src/WslContainersDesktop.App/Pages/ContainersPage.xaml
+++ b/src/WslContainersDesktop.App/Pages/ContainersPage.xaml
@@ -264,7 +264,17 @@
                 </Grid.RowDefinitions>
 
                 <Grid Grid.Row="0" ColumnSpacing="8">
-                    <TextBlock x:Name="TxtShellPanelTitle" x:Uid="TxtShellPanelTitle" Style="{StaticResource SubtitleTextBlockStyle}" />
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock x:Name="TxtShellPanelTitle" Grid.Column="0" x:Uid="TxtShellPanelTitle" Style="{StaticResource SubtitleTextBlockStyle}" />
+                    <Button
+                        x:Name="BtnOpenShellWindow"
+                        Grid.Column="1"
+                        x:Uid="BtnOpenShellWindow"
+                        AutomationProperties.AutomationId="BtnOpenShellWindow"
+                        Click="BtnOpenShellWindow_Click" />
                 </Grid>
 
                 <InfoBar
@@ -339,31 +349,38 @@
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
                     <TextBlock x:Name="TxtLogPanelTitle" x:Uid="TxtLogPanelTitle" Grid.Column="0" Style="{StaticResource SubtitleTextBlockStyle}" />
                     <Button
-                        x:Name="BtnPauseLogs"
+                        x:Name="BtnOpenLogsWindow"
                         Grid.Column="1"
+                        x:Uid="BtnOpenLogsWindow"
+                        AutomationProperties.AutomationId="BtnOpenLogsWindow"
+                        Click="BtnOpenLogsWindow_Click" />
+                    <Button
+                        x:Name="BtnPauseLogs"
+                        Grid.Column="2"
                         x:Uid="BtnPauseLogs"
                         AutomationProperties.AutomationId="BtnPauseLogs"
                         Command="{x:Bind ViewModel.PauseLogsCommand}"
                         Visibility="{x:Bind ToVisibleWhenFalse(ViewModel.IsLogsPaused), Mode=OneWay}" />
                     <Button
                         x:Name="BtnResumeLogs"
-                        Grid.Column="1"
+                        Grid.Column="2"
                         x:Uid="BtnResumeLogs"
                         AutomationProperties.AutomationId="BtnResumeLogs"
                         Command="{x:Bind ViewModel.ResumeLogsCommand}"
                         Visibility="{x:Bind ToVisibleWhenTrue(ViewModel.IsLogsPaused), Mode=OneWay}" />
                     <Button
                         x:Name="BtnClearLogs"
-                        Grid.Column="2"
+                        Grid.Column="3"
                         x:Uid="BtnClearLogs"
                         AutomationProperties.AutomationId="BtnClearLogs"
                         Command="{x:Bind ViewModel.ClearLogsCommand}" />
                     <Button
                         x:Name="BtnCloseLogs"
-                        Grid.Column="3"
+                        Grid.Column="4"
                         x:Uid="BtnCloseLogs"
                         AutomationProperties.AutomationId="BtnCloseLogs"
                         Command="{x:Bind ViewModel.CloseLogsCommand}" />

--- a/src/WslContainersDesktop.App/Pages/ContainersPage.xaml.cs
+++ b/src/WslContainersDesktop.App/Pages/ContainersPage.xaml.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using WslContainersDesktop_App.ViewModels;
+using WslContainersDesktop_App.Windows;
 using Windows.ApplicationModel.Resources;
 
 namespace WslContainersDesktop_App.Pages;
@@ -12,12 +13,17 @@ namespace WslContainersDesktop_App.Pages;
 public sealed partial class ContainersPage : Page
 {
     private readonly ResourceLoader _resourceLoader = new();
+    private readonly ContainerAuxiliaryWindowManager _windowManager;
 
     public ContainersPage()
     {
         // Frame.Navigate(Type)によるページ遷移はパラメーターレスコンストラクタを要求するため、
         // ADR-0010に基づきCompositionRoot(App)のServiceProvider経由でViewModelを解決する。
         ViewModel = ((App)Application.Current).Services.GetRequiredService<ContainersViewModel>();
+
+        // ページはNavigateのたびに作り直されるため、ポップアウトウィンドウの参照はページの
+        // フィールドではなくDIのSingletonである_windowManagerが保持し続ける。
+        _windowManager = ((App)Application.Current).Services.GetRequiredService<ContainerAuxiliaryWindowManager>();
 
         InitializeComponent();
 
@@ -105,6 +111,16 @@ public sealed partial class ContainersPage : Page
         {
             await ViewModel.RestartCommand.ExecuteAsync(row);
         }
+    }
+
+    private void BtnOpenLogsWindow_Click(object sender, RoutedEventArgs e)
+    {
+        _windowManager.ShowLogsWindow();
+    }
+
+    private void BtnOpenShellWindow_Click(object sender, RoutedEventArgs e)
+    {
+        _windowManager.ShowShellWindow();
     }
 
     private static ContainerRowViewModel? GetContainerRow(object sender)

--- a/src/WslContainersDesktop.App/Strings/en-US/Resources.resw
+++ b/src/WslContainersDesktop.App/Strings/en-US/Resources.resw
@@ -303,6 +303,12 @@
   <data name="ShellWindow.Title" xml:space="preserve">
     <value>Container shell</value>
   </data>
+  <data name="LogsWindowTitleBar.Title" xml:space="preserve">
+    <value>Container logs</value>
+  </data>
+  <data name="ShellWindowTitleBar.Title" xml:space="preserve">
+    <value>Container shell</value>
+  </data>
   <data name="ImagesPageTitle.Text" xml:space="preserve">
     <value>Images</value>
   </data>

--- a/src/WslContainersDesktop.App/Strings/en-US/Resources.resw
+++ b/src/WslContainersDesktop.App/Strings/en-US/Resources.resw
@@ -276,6 +276,9 @@
   <data name="BtnCloseLogs.Content" xml:space="preserve">
     <value>Close</value>
   </data>
+  <data name="BtnOpenLogsWindow.Content" xml:space="preserve">
+    <value>Open in window</value>
+  </data>
   <data name="TxtLogEmptyState.Text" xml:space="preserve">
     <value>No logs to display.</value>
   </data>
@@ -288,6 +291,9 @@
   <data name="TxtShellPanelTitle.Text" xml:space="preserve">
     <value>Container shell</value>
   </data>
+  <data name="BtnOpenShellWindow.Content" xml:space="preserve">
+    <value>Open in window</value>
+  </data>
   <data name="BtnCloseShell.Content" xml:space="preserve">
     <value>Close shell</value>
   </data>
@@ -296,6 +302,12 @@
   </data>
   <data name="BtnSendShellCommand.Content" xml:space="preserve">
     <value>Send</value>
+  </data>
+  <data name="LogsWindow.Title" xml:space="preserve">
+    <value>Container logs</value>
+  </data>
+  <data name="ShellWindow.Title" xml:space="preserve">
+    <value>Container shell</value>
   </data>
   <data name="ImagesPageTitle.Text" xml:space="preserve">
     <value>Images</value>

--- a/src/WslContainersDesktop.App/Windows/ContainerAuxiliaryWindowManager.cs
+++ b/src/WslContainersDesktop.App/Windows/ContainerAuxiliaryWindowManager.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using WslContainersDesktop_App.ViewModels;
+
+namespace WslContainersDesktop_App.Windows;
+
+/// <summary>
+/// LogsWindow/ShellWindowの単一インスタンス生成・再利用を担うDIのSingletonサービス。
+/// </summary>
+/// <remarks>
+/// ContainersPageはFrame.Navigateのたびに作り直されるため、ウィンドウ参照をページの
+/// フィールドとして保持すると、ページを離れて戻ってきた際に追跡が切れてしまう。
+/// このクラスをDIのSingletonとして登録し、アプリ全体で寿命を共有することで、
+/// どのタイミングでContainersPageに遷移してもポップアウトウィンドウの状態を維持できる。
+/// 生成/再利用/Closed後の再生成ロジック本体は<see cref="SingleInstanceWindowOpener{TWindow}"/>に
+/// 委譲しており、そちらは独立してMSTestで検証済みのため、本クラス自体は薄い合成のみを行う。
+/// </remarks>
+public sealed class ContainerAuxiliaryWindowManager
+{
+    private readonly SingleInstanceWindowOpener<LogsWindow> _logsWindowOpener;
+    private readonly SingleInstanceWindowOpener<ShellWindow> _shellWindowOpener;
+
+    public ContainerAuxiliaryWindowManager(ContainersViewModel viewModel)
+    {
+        _logsWindowOpener = new SingleInstanceWindowOpener<LogsWindow>(
+            createWindow: () => new LogsWindow(viewModel),
+            activateWindow: window => window.Activate(),
+            registerClosedHandler: (window, onClosed) => window.Closed += (_, _) => onClosed());
+
+        _shellWindowOpener = new SingleInstanceWindowOpener<ShellWindow>(
+            createWindow: () => new ShellWindow(viewModel),
+            activateWindow: window => window.Activate(),
+            registerClosedHandler: (window, onClosed) => window.Closed += (_, _) => onClosed());
+    }
+
+    /// <summary>
+    /// ログのポップアウトウィンドウを開く。既に開いていれば新規に開かず、既存ウィンドウを
+    /// Activateするだけにとどめる。
+    /// </summary>
+    public void ShowLogsWindow() => _logsWindowOpener.ShowOrActivate();
+
+    /// <summary>
+    /// シェルのポップアウトウィンドウを開く。既に開いていれば新規に開かず、既存ウィンドウを
+    /// Activateするだけにとどめる。
+    /// </summary>
+    public void ShowShellWindow() => _shellWindowOpener.ShowOrActivate();
+}

--- a/src/WslContainersDesktop.App/Windows/LogsWindow.xaml
+++ b/src/WslContainersDesktop.App/Windows/LogsWindow.xaml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Window
+    x:Class="WslContainersDesktop_App.Windows.LogsWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:WslContainersDesktop_App.Windows"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+    <Window.SystemBackdrop>
+        <MicaBackdrop />
+    </Window.SystemBackdrop>
+
+    <Grid Padding="24,16,24,16" RowSpacing="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <Grid Grid.Row="0" ColumnSpacing="8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <TextBlock x:Name="TxtLogPanelTitle" x:Uid="TxtLogPanelTitle" Grid.Column="0" Style="{StaticResource SubtitleTextBlockStyle}" />
+            <Button
+                x:Name="BtnPauseLogs"
+                Grid.Column="1"
+                x:Uid="BtnPauseLogs"
+                AutomationProperties.AutomationId="LogsWindow_BtnPauseLogs"
+                Command="{x:Bind ViewModel.PauseLogsCommand}"
+                Visibility="{x:Bind ToVisibleWhenFalse(ViewModel.IsLogsPaused), Mode=OneWay}" />
+            <Button
+                x:Name="BtnResumeLogs"
+                Grid.Column="1"
+                x:Uid="BtnResumeLogs"
+                AutomationProperties.AutomationId="LogsWindow_BtnResumeLogs"
+                Command="{x:Bind ViewModel.ResumeLogsCommand}"
+                Visibility="{x:Bind ToVisibleWhenTrue(ViewModel.IsLogsPaused), Mode=OneWay}" />
+            <Button
+                x:Name="BtnClearLogs"
+                Grid.Column="2"
+                x:Uid="BtnClearLogs"
+                AutomationProperties.AutomationId="LogsWindow_BtnClearLogs"
+                Command="{x:Bind ViewModel.ClearLogsCommand}" />
+            <Button
+                x:Name="BtnCloseLogs"
+                Grid.Column="3"
+                x:Uid="BtnCloseLogs"
+                AutomationProperties.AutomationId="LogsWindow_BtnCloseLogs"
+                Command="{x:Bind ViewModel.CloseLogsCommand}" />
+        </Grid>
+
+        <InfoBar
+            x:Name="InfoBarLogError"
+            Grid.Row="1"
+            Severity="Error"
+            IsClosable="False"
+            IsOpen="{x:Bind ViewModel.IsLogError, Mode=OneWay}"
+            Message="{x:Bind ViewModel.LogStatusMessage, Mode=OneWay}" />
+
+        <TextBlock
+            x:Name="TxtLogStatus"
+            Grid.Row="2"
+            Text="{x:Bind ViewModel.LogStatusMessage, Mode=OneWay}"
+            Visibility="{x:Bind ToVisibleWhenTrue(ViewModel.IsLogStatusVisible), Mode=OneWay}" />
+
+        <ListView
+            x:Name="LstLogs"
+            Grid.Row="3"
+            AutomationProperties.AutomationId="LogsWindow_LstLogs"
+            ItemsSource="{x:Bind ViewModel.LogLines, Mode=OneWay}"
+            SelectionMode="None"
+            Visibility="{x:Bind ToVisibleWhenFalse(ViewModel.IsLogEmpty), Mode=OneWay}">
+            <!--
+                小さいログパネル(ContainersPage.xaml)と同じく、WinUI公式の「Inverted lists」パターン
+                (https://learn.microsoft.com/en-us/windows/apps/design/controls/inverted-lists)に従い、
+                末尾を表示している間だけ新着行に自動追従させる。
+            -->
+            <ListView.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <ItemsStackPanel ItemsUpdatingScrollMode="KeepLastItemInView" />
+                </ItemsPanelTemplate>
+            </ListView.ItemsPanel>
+        </ListView>
+
+        <TextBlock
+            x:Name="TxtLogEmptyState"
+            Grid.Row="3"
+            x:Uid="TxtLogEmptyState"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            Visibility="{x:Bind ToVisibleWhenTrue(ViewModel.IsLogEmpty), Mode=OneWay}" />
+    </Grid>
+</Window>

--- a/src/WslContainersDesktop.App/Windows/LogsWindow.xaml
+++ b/src/WslContainersDesktop.App/Windows/LogsWindow.xaml
@@ -11,7 +11,7 @@
         <MicaBackdrop />
     </Window.SystemBackdrop>
 
-    <Grid>
+    <Grid x:Name="RootGrid">
         <Grid.RowDefinitions>
             <RowDefinition Height="48" />
             <RowDefinition Height="*" />

--- a/src/WslContainersDesktop.App/Windows/LogsWindow.xaml
+++ b/src/WslContainersDesktop.App/Windows/LogsWindow.xaml
@@ -11,7 +11,23 @@
         <MicaBackdrop />
     </Window.SystemBackdrop>
 
-    <Grid Padding="24,16,24,16" RowSpacing="12">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="48" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <TitleBar
+            x:Name="LogsWindowTitleBar"
+            x:Uid="LogsWindowTitleBar"
+            IsBackButtonVisible="False"
+            IsPaneToggleButtonVisible="False">
+            <TitleBar.IconSource>
+                <ImageIconSource ImageSource="Assets/AppIcon.ico" />
+            </TitleBar.IconSource>
+        </TitleBar>
+
+        <Grid Grid.Row="1" Padding="24,16,24,16" RowSpacing="12">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
@@ -52,7 +68,7 @@
                 Grid.Column="3"
                 x:Uid="BtnCloseLogs"
                 AutomationProperties.AutomationId="LogsWindow_BtnCloseLogs"
-                Command="{x:Bind ViewModel.CloseLogsCommand}" />
+                Click="BtnCloseLogs_Click" />
         </Grid>
 
         <InfoBar
@@ -95,5 +111,6 @@
             HorizontalAlignment="Center"
             VerticalAlignment="Center"
             Visibility="{x:Bind ToVisibleWhenTrue(ViewModel.IsLogEmpty), Mode=OneWay}" />
+        </Grid>
     </Grid>
 </Window>

--- a/src/WslContainersDesktop.App/Windows/LogsWindow.xaml.cs
+++ b/src/WslContainersDesktop.App/Windows/LogsWindow.xaml.cs
@@ -37,17 +37,21 @@ public sealed partial class LogsWindow : Window
         AppWindow.TitleBar.PreferredHeightOption = TitleBarHeightOption.Tall;
         AppWindow.SetIcon("Assets/AppIcon.ico");
 
-        // DPIスケールはXamlRootが確定するActivated後でないと取得できないため、初回のみここでリサイズする。
-        Activated += LogsWindow_Activated;
+        // DPIスケールはXamlRootが確定してからでないと取得できない。Activatedイベントは
+        // ウィンドウ再生成時(閉じて再度開いたとき)にXamlRoot確立前に発火することがあり、
+        // Content.XamlRootへの直接アクセスがNullReferenceExceptionでクラッシュする不具合が
+        // 実機で確認された。RootGridのLoadedイベントはXamlRoot確立後にのみ発火するため、
+        // こちらを使う。
+        RootGrid.Loaded += LogsWindow_RootGrid_Loaded;
     }
 
     public ContainersViewModel ViewModel { get; }
 
-    private void LogsWindow_Activated(object sender, WindowActivatedEventArgs args)
+    private void LogsWindow_RootGrid_Loaded(object sender, RoutedEventArgs e)
     {
-        Activated -= LogsWindow_Activated;
+        RootGrid.Loaded -= LogsWindow_RootGrid_Loaded;
 
-        var scale = Content.XamlRoot.RasterizationScale;
+        var scale = RootGrid.XamlRoot.RasterizationScale;
         AppWindow.Resize(new global::Windows.Graphics.SizeInt32(
             (int)(DefaultWidthInDips * scale),
             (int)(DefaultHeightInDips * scale)));

--- a/src/WslContainersDesktop.App/Windows/LogsWindow.xaml.cs
+++ b/src/WslContainersDesktop.App/Windows/LogsWindow.xaml.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.UI.Xaml;
+using WslContainersDesktop_App.ViewModels;
+
+namespace WslContainersDesktop_App.Windows;
+
+/// <summary>
+/// ログパネルの内容を大きな個別ウィンドウとして表示する。<see cref="ContainersViewModel"/>の
+/// <see cref="ContainersViewModel.LogLines"/>等を小さいログパネルと共有するため、常に同じ状態が
+/// 同期して表示される(状態を複製しない)。
+/// </summary>
+/// <remarks>
+/// タイトルバーの閉じるボタンでこのウィンドウを閉じても、ログ追跡自体は停止しない
+/// (ログ追跡の停止は本ウィンドウ・小さいログパネルどちらからでも<see cref="ContainersViewModel.CloseLogsCommand"/>
+/// で行う。ウィンドウを閉じる操作とセッションを閉じる操作は意図的に分離している)。
+/// </remarks>
+public sealed partial class LogsWindow : Window
+{
+    private const int DefaultWidthInDips = 1000;
+    private const int DefaultHeightInDips = 700;
+
+    public LogsWindow(ContainersViewModel viewModel)
+    {
+        ViewModel = viewModel;
+
+        InitializeComponent();
+
+        Title = new global::Windows.ApplicationModel.Resources.ResourceLoader().GetString("LogsWindow.Title");
+
+        // DPIスケールはXamlRootが確定するActivated後でないと取得できないため、初回のみここでリサイズする。
+        Activated += LogsWindow_Activated;
+    }
+
+    public ContainersViewModel ViewModel { get; }
+
+    private void LogsWindow_Activated(object sender, WindowActivatedEventArgs args)
+    {
+        Activated -= LogsWindow_Activated;
+
+        var scale = Content.XamlRoot.RasterizationScale;
+        AppWindow.Resize(new global::Windows.Graphics.SizeInt32(
+            (int)(DefaultWidthInDips * scale),
+            (int)(DefaultHeightInDips * scale)));
+    }
+
+    /// <summary>
+    /// x:Bind用のbool→Visibility変換関数。値がtrueのとき表示する。
+    /// </summary>
+    public Visibility ToVisibleWhenTrue(bool value) => value ? Visibility.Visible : Visibility.Collapsed;
+
+    /// <summary>
+    /// x:Bind用のbool→Visibility変換関数。値がfalseのとき表示する。
+    /// </summary>
+    public Visibility ToVisibleWhenFalse(bool value) => value ? Visibility.Collapsed : Visibility.Visible;
+}

--- a/src/WslContainersDesktop.App/Windows/LogsWindow.xaml.cs
+++ b/src/WslContainersDesktop.App/Windows/LogsWindow.xaml.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using WslContainersDesktop_App.ViewModels;
 
@@ -12,9 +13,10 @@ namespace WslContainersDesktop_App.Windows;
 /// 同期して表示される(状態を複製しない)。
 /// </summary>
 /// <remarks>
-/// タイトルバーの閉じるボタンでこのウィンドウを閉じても、ログ追跡自体は停止しない
-/// (ログ追跡の停止は本ウィンドウ・小さいログパネルどちらからでも<see cref="ContainersViewModel.CloseLogsCommand"/>
-/// で行う。ウィンドウを閉じる操作とセッションを閉じる操作は意図的に分離している)。
+/// タイトルバーの閉じるボタン・ウィンドウ内のCloseボタンのどちらでこのウィンドウを閉じても、
+/// ログ追跡自体は停止しない(このウィンドウを閉じる操作は「このウィンドウを閉じるだけ」であり、
+/// ログ追跡の停止とは意図的に分離している)。ログ追跡を停止するには、小さいログパネル側の
+/// <see cref="ContainersViewModel.CloseLogsCommand"/>に配線されたCloseボタンを使う。
 /// </remarks>
 public sealed partial class LogsWindow : Window
 {
@@ -28,6 +30,12 @@ public sealed partial class LogsWindow : Window
         InitializeComponent();
 
         Title = new global::Windows.ApplicationModel.Resources.ResourceLoader().GetString("LogsWindow.Title");
+
+        // MainWindowと同じ、アプリアイコン付きのカスタムTitleBarをTall高さで表示する。
+        ExtendsContentIntoTitleBar = true;
+        SetTitleBar(LogsWindowTitleBar);
+        AppWindow.TitleBar.PreferredHeightOption = TitleBarHeightOption.Tall;
+        AppWindow.SetIcon("Assets/AppIcon.ico");
 
         // DPIスケールはXamlRootが確定するActivated後でないと取得できないため、初回のみここでリサイズする。
         Activated += LogsWindow_Activated;
@@ -43,6 +51,14 @@ public sealed partial class LogsWindow : Window
         AppWindow.Resize(new global::Windows.Graphics.SizeInt32(
             (int)(DefaultWidthInDips * scale),
             (int)(DefaultHeightInDips * scale)));
+    }
+
+    /// <summary>
+    /// Closeボタン押下時のハンドラ。ログ追跡は停止せず、このウィンドウを閉じるだけにする。
+    /// </summary>
+    private void BtnCloseLogs_Click(object sender, RoutedEventArgs e)
+    {
+        Close();
     }
 
     /// <summary>

--- a/src/WslContainersDesktop.App/Windows/ShellWindow.xaml
+++ b/src/WslContainersDesktop.App/Windows/ShellWindow.xaml
@@ -11,7 +11,23 @@
         <MicaBackdrop />
     </Window.SystemBackdrop>
 
-    <Grid Padding="24,16,24,16" RowSpacing="12">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="48" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <TitleBar
+            x:Name="ShellWindowTitleBar"
+            x:Uid="ShellWindowTitleBar"
+            IsBackButtonVisible="False"
+            IsPaneToggleButtonVisible="False">
+            <TitleBar.IconSource>
+                <ImageIconSource ImageSource="Assets/AppIcon.ico" />
+            </TitleBar.IconSource>
+        </TitleBar>
+
+        <Grid Grid.Row="1" Padding="24,16,24,16" RowSpacing="12">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
@@ -68,7 +84,8 @@
                 x:Uid="BtnCloseShell"
                 VerticalAlignment="Bottom"
                 AutomationProperties.AutomationId="ShellWindow_BtnCloseShell"
-                Command="{x:Bind ViewModel.CloseShellCommand}" />
+                Click="BtnCloseShell_Click" />
+        </Grid>
         </Grid>
     </Grid>
 </Window>

--- a/src/WslContainersDesktop.App/Windows/ShellWindow.xaml
+++ b/src/WslContainersDesktop.App/Windows/ShellWindow.xaml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Window
+    x:Class="WslContainersDesktop_App.Windows.ShellWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:WslContainersDesktop_App.Windows"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+    <Window.SystemBackdrop>
+        <MicaBackdrop />
+    </Window.SystemBackdrop>
+
+    <Grid Padding="24,16,24,16" RowSpacing="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBlock x:Name="TxtShellPanelTitle" Grid.Row="0" x:Uid="TxtShellPanelTitle" Style="{StaticResource SubtitleTextBlockStyle}" />
+
+        <InfoBar
+            x:Name="InfoBarShellError"
+            Grid.Row="1"
+            Severity="Error"
+            IsClosable="False"
+            IsOpen="{x:Bind ViewModel.IsShellError, Mode=OneWay}"
+            Message="{x:Bind ViewModel.ShellStatusMessage, Mode=OneWay}" />
+
+        <TextBlock
+            x:Name="TxtShellStatus"
+            Grid.Row="2"
+            Text="{x:Bind ViewModel.ShellStatusMessage, Mode=OneWay}"
+            Visibility="{x:Bind ToVisibleWhenTrue(ViewModel.IsShellStatusVisible), Mode=OneWay}" />
+
+        <ListView
+            x:Name="LstShellOutput"
+            Grid.Row="3"
+            AutomationProperties.AutomationId="ShellWindow_LstShellOutput"
+            ItemsSource="{x:Bind ViewModel.ShellOutput, Mode=OneWay}"
+            SelectionMode="None" />
+
+        <Grid Grid.Row="4" ColumnSpacing="8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <TextBox
+                x:Name="TxtShellCommand"
+                Grid.Column="0"
+                x:Uid="TxtShellCommand"
+                AutomationProperties.AutomationId="ShellWindow_TxtShellCommand"
+                Text="{x:Bind ViewModel.ShellCommandText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+            <Button
+                x:Name="BtnSendShellCommand"
+                Grid.Column="1"
+                x:Uid="BtnSendShellCommand"
+                VerticalAlignment="Bottom"
+                AutomationProperties.AutomationId="ShellWindow_BtnSendShellCommand"
+                Command="{x:Bind ViewModel.SendShellCommandCommand}" />
+            <Button
+                x:Name="BtnCloseShell"
+                Grid.Column="2"
+                x:Uid="BtnCloseShell"
+                VerticalAlignment="Bottom"
+                AutomationProperties.AutomationId="ShellWindow_BtnCloseShell"
+                Command="{x:Bind ViewModel.CloseShellCommand}" />
+        </Grid>
+    </Grid>
+</Window>

--- a/src/WslContainersDesktop.App/Windows/ShellWindow.xaml
+++ b/src/WslContainersDesktop.App/Windows/ShellWindow.xaml
@@ -11,7 +11,7 @@
         <MicaBackdrop />
     </Window.SystemBackdrop>
 
-    <Grid>
+    <Grid x:Name="RootGrid">
         <Grid.RowDefinitions>
             <RowDefinition Height="48" />
             <RowDefinition Height="*" />

--- a/src/WslContainersDesktop.App/Windows/ShellWindow.xaml.cs
+++ b/src/WslContainersDesktop.App/Windows/ShellWindow.xaml.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using WslContainersDesktop_App.ViewModels;
 
@@ -12,10 +13,10 @@ namespace WslContainersDesktop_App.Windows;
 /// 同期して表示される(状態を複製しない)。
 /// </summary>
 /// <remarks>
-/// タイトルバーの閉じるボタンでこのウィンドウを閉じても、シェルセッション自体は切断されない
-/// (シェルセッションの終了は本ウィンドウ・小さいシェルパネルどちらからでも
-/// <see cref="ContainersViewModel.CloseShellCommand"/>で行う。ウィンドウを閉じる操作とセッションを
-/// 閉じる操作は意図的に分離している)。
+/// タイトルバーの閉じるボタン・ウィンドウ内のCloseボタンのどちらでこのウィンドウを閉じても、
+/// シェルセッション自体は切断されない(このウィンドウを閉じる操作は「このウィンドウを閉じるだけ」
+/// であり、シェルセッションの終了とは意図的に分離している)。シェルセッションを終了するには、
+/// 小さいシェルパネル側の<see cref="ContainersViewModel.CloseShellCommand"/>に配線されたCloseボタンを使う。
 /// </remarks>
 public sealed partial class ShellWindow : Window
 {
@@ -29,6 +30,12 @@ public sealed partial class ShellWindow : Window
         InitializeComponent();
 
         Title = new global::Windows.ApplicationModel.Resources.ResourceLoader().GetString("ShellWindow.Title");
+
+        // MainWindowと同じ、アプリアイコン付きのカスタムTitleBarをTall高さで表示する。
+        ExtendsContentIntoTitleBar = true;
+        SetTitleBar(ShellWindowTitleBar);
+        AppWindow.TitleBar.PreferredHeightOption = TitleBarHeightOption.Tall;
+        AppWindow.SetIcon("Assets/AppIcon.ico");
 
         // DPIスケールはXamlRootが確定するActivated後でないと取得できないため、初回のみここでリサイズする。
         Activated += ShellWindow_Activated;
@@ -44,6 +51,14 @@ public sealed partial class ShellWindow : Window
         AppWindow.Resize(new global::Windows.Graphics.SizeInt32(
             (int)(DefaultWidthInDips * scale),
             (int)(DefaultHeightInDips * scale)));
+    }
+
+    /// <summary>
+    /// Closeボタン押下時のハンドラ。シェルセッションは切断せず、このウィンドウを閉じるだけにする。
+    /// </summary>
+    private void BtnCloseShell_Click(object sender, RoutedEventArgs e)
+    {
+        Close();
     }
 
     /// <summary>

--- a/src/WslContainersDesktop.App/Windows/ShellWindow.xaml.cs
+++ b/src/WslContainersDesktop.App/Windows/ShellWindow.xaml.cs
@@ -37,17 +37,21 @@ public sealed partial class ShellWindow : Window
         AppWindow.TitleBar.PreferredHeightOption = TitleBarHeightOption.Tall;
         AppWindow.SetIcon("Assets/AppIcon.ico");
 
-        // DPIスケールはXamlRootが確定するActivated後でないと取得できないため、初回のみここでリサイズする。
-        Activated += ShellWindow_Activated;
+        // DPIスケールはXamlRootが確定してからでないと取得できない。Activatedイベントは
+        // ウィンドウ再生成時(閉じて再度開いたとき)にXamlRoot確立前に発火することがあり、
+        // Content.XamlRootへの直接アクセスがNullReferenceExceptionでクラッシュする不具合が
+        // 実機で確認された。RootGridのLoadedイベントはXamlRoot確立後にのみ発火するため、
+        // こちらを使う。
+        RootGrid.Loaded += ShellWindow_RootGrid_Loaded;
     }
 
     public ContainersViewModel ViewModel { get; }
 
-    private void ShellWindow_Activated(object sender, WindowActivatedEventArgs args)
+    private void ShellWindow_RootGrid_Loaded(object sender, RoutedEventArgs e)
     {
-        Activated -= ShellWindow_Activated;
+        RootGrid.Loaded -= ShellWindow_RootGrid_Loaded;
 
-        var scale = Content.XamlRoot.RasterizationScale;
+        var scale = RootGrid.XamlRoot.RasterizationScale;
         AppWindow.Resize(new global::Windows.Graphics.SizeInt32(
             (int)(DefaultWidthInDips * scale),
             (int)(DefaultHeightInDips * scale)));

--- a/src/WslContainersDesktop.App/Windows/ShellWindow.xaml.cs
+++ b/src/WslContainersDesktop.App/Windows/ShellWindow.xaml.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.UI.Xaml;
+using WslContainersDesktop_App.ViewModels;
+
+namespace WslContainersDesktop_App.Windows;
+
+/// <summary>
+/// シェルパネルの内容を大きな個別ウィンドウとして表示する。<see cref="ContainersViewModel"/>の
+/// <see cref="ContainersViewModel.ShellOutput"/>等を小さいシェルパネルと共有するため、常に同じ状態が
+/// 同期して表示される(状態を複製しない)。
+/// </summary>
+/// <remarks>
+/// タイトルバーの閉じるボタンでこのウィンドウを閉じても、シェルセッション自体は切断されない
+/// (シェルセッションの終了は本ウィンドウ・小さいシェルパネルどちらからでも
+/// <see cref="ContainersViewModel.CloseShellCommand"/>で行う。ウィンドウを閉じる操作とセッションを
+/// 閉じる操作は意図的に分離している)。
+/// </remarks>
+public sealed partial class ShellWindow : Window
+{
+    private const int DefaultWidthInDips = 1000;
+    private const int DefaultHeightInDips = 700;
+
+    public ShellWindow(ContainersViewModel viewModel)
+    {
+        ViewModel = viewModel;
+
+        InitializeComponent();
+
+        Title = new global::Windows.ApplicationModel.Resources.ResourceLoader().GetString("ShellWindow.Title");
+
+        // DPIスケールはXamlRootが確定するActivated後でないと取得できないため、初回のみここでリサイズする。
+        Activated += ShellWindow_Activated;
+    }
+
+    public ContainersViewModel ViewModel { get; }
+
+    private void ShellWindow_Activated(object sender, WindowActivatedEventArgs args)
+    {
+        Activated -= ShellWindow_Activated;
+
+        var scale = Content.XamlRoot.RasterizationScale;
+        AppWindow.Resize(new global::Windows.Graphics.SizeInt32(
+            (int)(DefaultWidthInDips * scale),
+            (int)(DefaultHeightInDips * scale)));
+    }
+
+    /// <summary>
+    /// x:Bind用のbool→Visibility変換関数。値がtrueのとき表示する。
+    /// </summary>
+    public Visibility ToVisibleWhenTrue(bool value) => value ? Visibility.Visible : Visibility.Collapsed;
+}

--- a/src/WslContainersDesktop.App/Windows/SingleInstanceWindowOpener.cs
+++ b/src/WslContainersDesktop.App/Windows/SingleInstanceWindowOpener.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace WslContainersDesktop_App.Windows;
+
+/// <summary>
+/// 「同種のウィンドウは常に1つだけ」を保証しつつ開くためのヘルパー。
+/// </summary>
+/// <remarks>
+/// <typeparamref name="TWindow"/>を実際のWinUI <c>Window</c>型に固定せず、生成・Activate・
+/// Closed購読をすべてデリゲート経由で受け取ることで、実ウィンドウを生成せずにMSTestで
+/// 「初回生成」「既存ウィンドウの再利用」「Closed後の再生成」を検証できるようにしている。
+/// </remarks>
+/// <typeparam name="TWindow">開閉対象のウィンドウの型。</typeparam>
+public sealed class SingleInstanceWindowOpener<TWindow>
+    where TWindow : class
+{
+    private readonly Func<TWindow> _createWindow;
+    private readonly Action<TWindow> _activateWindow;
+    private readonly Action<TWindow, Action> _registerClosedHandler;
+
+    private TWindow? _window;
+
+    public SingleInstanceWindowOpener(
+        Func<TWindow> createWindow,
+        Action<TWindow> activateWindow,
+        Action<TWindow, Action> registerClosedHandler)
+    {
+        _createWindow = createWindow;
+        _activateWindow = activateWindow;
+        _registerClosedHandler = registerClosedHandler;
+    }
+
+    /// <summary>
+    /// ウィンドウが開いていなければ生成してActivateし、既に開いていれば既存のウィンドウを
+    /// Activateするだけにとどめる(新規に複数開かない)。
+    /// </summary>
+    public void ShowOrActivate()
+    {
+        if (_window is null)
+        {
+            var window = _createWindow();
+            _window = window;
+            _registerClosedHandler(window, () => _window = null);
+        }
+
+        _activateWindow(_window);
+    }
+}

--- a/tests/WslContainersDesktop.App.Tests/Pages/ContainersPageSourceTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/Pages/ContainersPageSourceTests.cs
@@ -30,6 +30,55 @@ public sealed class ContainersPageSourceTests
         StringAssert.Contains(sourceText, "<Grid Padding=\"12,8\" ColumnSpacing=\"12\" HorizontalAlignment=\"Stretch\">");
     }
 
+    [TestMethod]
+    public void ContainersPage_LogPanelHeader_HasOpenLogsWindowButton()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Pages\ContainersPage.xaml");
+
+        // Assert: ログパネルを大きな個別ウィンドウで開くボタンが存在し、コードビハインドの
+        // Clickハンドラに配線されていること。
+        StringAssert.Contains(sourceText, "x:Name=\"BtnOpenLogsWindow\"");
+        StringAssert.Contains(sourceText, "Click=\"BtnOpenLogsWindow_Click\"");
+    }
+
+    [TestMethod]
+    public void ContainersPage_ShellPanelHeader_HasOpenShellWindowButton()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Pages\ContainersPage.xaml");
+
+        // Assert: シェルパネルを大きな個別ウィンドウで開くボタンが存在し、コードビハインドの
+        // Clickハンドラに配線されていること。
+        StringAssert.Contains(sourceText, "x:Name=\"BtnOpenShellWindow\"");
+        StringAssert.Contains(sourceText, "Click=\"BtnOpenShellWindow_Click\"");
+    }
+
+    [TestMethod]
+    public void ContainersPageCodeBehind_OpenLogsWindowClickHandler_DelegatesToAuxiliaryWindowManager()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Pages\ContainersPage.xaml.cs");
+
+        // Assert: ボタンが存在するだけでなく、実際にContainerAuxiliaryWindowManager経由で
+        // ログウィンドウを開く呼び出しへ配線されていること(rubber-duckレビュー指摘:
+        // ボタンの存在確認だけでは押下時に何もしない実装や誤配線を見逃す)。
+        StringAssert.Contains(sourceText, "BtnOpenLogsWindow_Click");
+        StringAssert.Contains(sourceText, "_windowManager.ShowLogsWindow()");
+    }
+
+    [TestMethod]
+    public void ContainersPageCodeBehind_OpenShellWindowClickHandler_DelegatesToAuxiliaryWindowManager()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Pages\ContainersPage.xaml.cs");
+
+        // Assert: ボタンが存在するだけでなく、実際にContainerAuxiliaryWindowManager経由で
+        // シェルウィンドウを開く呼び出しへ配線されていること。
+        StringAssert.Contains(sourceText, "BtnOpenShellWindow_Click");
+        StringAssert.Contains(sourceText, "_windowManager.ShowShellWindow()");
+    }
+
     private static string ReadRepositorySourceFile(string relativePath)
     {
         var repositoryRoot = FindRepositoryRoot();

--- a/tests/WslContainersDesktop.App.Tests/Windows/ContainerAuxiliaryWindowManagerSourceTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/Windows/ContainerAuxiliaryWindowManagerSourceTests.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace WslContainersDesktop_App_Tests.Windows;
+
+[TestClass]
+public sealed class ContainerAuxiliaryWindowManagerSourceTests
+{
+    [TestMethod]
+    public void App_ConfigureServices_RegistersContainerAuxiliaryWindowManagerAsSingleton()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\App.xaml.cs");
+
+        // Assert: LogsWindow/ShellWindowはContainersPageのNavigateのたびに参照が切れないよう、
+        // アプリケーションライフタイムのSingletonとして登録されている必要がある
+        // (rubber-duckレビュー指摘: ウィンドウ参照をページのフィールドで持つと追跡が切れる)。
+        StringAssert.Contains(sourceText, "services.AddSingleton<ContainerAuxiliaryWindowManager>();");
+    }
+
+    [TestMethod]
+    public void ContainerAuxiliaryWindowManager_ComposesSingleInstanceWindowOpenersForLogsAndShellWindows()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Windows\ContainerAuxiliaryWindowManager.cs");
+
+        // Assert: 生成/再利用/Closed後再生成のロジック本体は独立してテスト済みの
+        // SingleInstanceWindowOpener<TWindow>に委譲しており、本クラスはLogsWindow/ShellWindow
+        // それぞれのopenerを合成するだけであること。
+        StringAssert.Contains(sourceText, "new SingleInstanceWindowOpener<LogsWindow>(");
+        StringAssert.Contains(sourceText, "new SingleInstanceWindowOpener<ShellWindow>(");
+        StringAssert.Contains(sourceText, "public void ShowLogsWindow() => _logsWindowOpener.ShowOrActivate();");
+        StringAssert.Contains(sourceText, "public void ShowShellWindow() => _shellWindowOpener.ShowOrActivate();");
+    }
+
+    private static string ReadRepositorySourceFile(string relativePath)
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var normalizedRelativePath = relativePath.Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar);
+        var fullPath = Path.Combine(repositoryRoot, normalizedRelativePath);
+
+        Assert.IsTrue(File.Exists(fullPath), $"Expected source file '{relativePath}' to exist at '{fullPath}'.");
+        return File.ReadAllText(fullPath);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var currentDirectory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (currentDirectory is not null)
+        {
+            var appProjectFilePath = Path.Combine(currentDirectory.FullName, "src", "WslContainersDesktop.App", "WslContainersDesktop.App.csproj");
+            if (File.Exists(appProjectFilePath))
+            {
+                return currentDirectory.FullName;
+            }
+
+            currentDirectory = currentDirectory.Parent;
+        }
+
+        Assert.Fail($"Could not locate repository root from '{AppContext.BaseDirectory}'.");
+        return string.Empty;
+    }
+}

--- a/tests/WslContainersDesktop.App.Tests/Windows/LogsWindowSourceTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/Windows/LogsWindowSourceTests.cs
@@ -76,6 +76,50 @@ public sealed class LogsWindowSourceTests
         StringAssert.Contains(codeBehindSourceText, "AppWindow.SetIcon(\"Assets/AppIcon.ico\");");
     }
 
+    [TestMethod]
+    public void LogsWindow_RootGrid_HasNameForLoadedEventSubscription()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Windows\LogsWindow.xaml");
+
+        // Assert: DPIリサイズはRootGridのLoadedイベントで行う(Activatedはウィンドウ再生成時に
+        // XamlRoot確立前に発火しNullReferenceExceptionを起こすため使わない。再現・詳細は
+        // LogsWindowCodeBehind_DoesNotResizeOnActivated_ToAvoidXamlRootRaceConditionテスト参照)。
+        StringAssert.Contains(sourceText, "x:Name=\"RootGrid\"");
+    }
+
+    [TestMethod]
+    public void LogsWindowCodeBehind_DoesNotResizeOnActivated_ToAvoidXamlRootRaceConditionBug()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Windows\LogsWindow.xaml.cs");
+
+        // Assert: 「Logsウィンドウを閉じて再度開くとアプリがクラッシュする」バグの再発防止。
+        // SingleInstanceWindowOpenerで2回目以降に生成されるLogsWindowはActivate()呼び出しから
+        // Activatedイベント発火までの間にXamlRootが未確立のことがあり、
+        // Content.XamlRoot.RasterizationScaleへの直接アクセスがNullReferenceExceptionで
+        // クラッシュしていた(実機で再現確認済み)。ActivatedではなくLoadedイベントを使い、
+        // XamlRoot確立後にのみリサイズすることでこれを防ぐ。
+        Assert.IsFalse(
+            sourceText.Contains("Activated += LogsWindow_Activated;"),
+            "ActivatedイベントでのDPIリサイズはXamlRoot未確立によるクラッシュを再発させるため使用禁止。");
+        StringAssert.Contains(sourceText, "RootGrid.Loaded +=");
+    }
+
+    [TestMethod]
+    public void LogsWindowCodeBehind_LoadedHandler_ReadsXamlRootFromRootGridNotContent()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Windows\LogsWindow.xaml.cs");
+
+        // Assert: Loadedイベントの時点ではRootGrid.XamlRootが確立済みであることを保証された
+        // 状態で読み取る(Content.XamlRootへの無条件アクセスを再導入しない)。
+        StringAssert.Contains(sourceText, "RootGrid.XamlRoot.RasterizationScale");
+        Assert.IsFalse(
+            sourceText.Contains("Content.XamlRoot.RasterizationScale"),
+            "Content.XamlRootへの無条件アクセスはXamlRoot未確立時にクラッシュするため使用禁止。");
+    }
+
     private static string ReadRepositorySourceFile(string relativePath)
     {
         var repositoryRoot = FindRepositoryRoot();

--- a/tests/WslContainersDesktop.App.Tests/Windows/LogsWindowSourceTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/Windows/LogsWindowSourceTests.cs
@@ -19,17 +19,61 @@ public sealed class LogsWindowSourceTests
     }
 
     [TestMethod]
-    public void LogsWindow_Header_HasPauseResumeClearAndCloseCommands()
+    public void LogsWindow_Header_HasPauseResumeAndClearCommands()
     {
         // Arrange
         var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Windows\LogsWindow.xaml");
 
-        // Assert: ポップアウト側からもPause/Resume/Clear/Closeを操作できること
+        // Assert: ポップアウト側からもPause/Resume/Clearを操作できること
         // (rubber-duckレビュー指摘: ポップアウト側にセッション停止手段が必要)。
         StringAssert.Contains(sourceText, "Command=\"{x:Bind ViewModel.PauseLogsCommand}\"");
         StringAssert.Contains(sourceText, "Command=\"{x:Bind ViewModel.ResumeLogsCommand}\"");
         StringAssert.Contains(sourceText, "Command=\"{x:Bind ViewModel.ClearLogsCommand}\"");
-        StringAssert.Contains(sourceText, "Command=\"{x:Bind ViewModel.CloseLogsCommand}\"");
+    }
+
+    [TestMethod]
+    public void LogsWindow_CloseButton_UsesClickHandlerInsteadOfCloseLogsCommand()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Windows\LogsWindow.xaml");
+
+        // Assert: Closeボタンはウィンドウを閉じるだけの操作にする(ログ追跡自体は継続する)ため、
+        // セッション停止用のCloseLogsCommandではなくコードビハインドのClickハンドラに配線する。
+        StringAssert.Contains(sourceText, "x:Name=\"BtnCloseLogs\"");
+        StringAssert.Contains(sourceText, "Click=\"BtnCloseLogs_Click\"");
+        Assert.IsFalse(
+            sourceText.Contains("Command=\"{x:Bind ViewModel.CloseLogsCommand}\""),
+            "BtnCloseLogsはウィンドウを閉じるだけにするため、CloseLogsCommandへのバインドを持ってはいけない。");
+    }
+
+    [TestMethod]
+    public void LogsWindowCodeBehind_CloseButtonClickHandler_ClosesWindow()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Windows\LogsWindow.xaml.cs");
+
+        // Assert: Clickハンドラが実際にWindow.Close()を呼び出していること
+        // (ボタンの存在確認だけでは押下時に何もしない実装を見逃すため)。
+        StringAssert.Contains(sourceText, "BtnCloseLogs_Click");
+        StringAssert.Contains(sourceText, "Close();");
+    }
+
+    [TestMethod]
+    public void LogsWindow_TitleBar_MatchesMainWindowLookAndFeel()
+    {
+        // Arrange
+        var xamlSourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Windows\LogsWindow.xaml");
+        var codeBehindSourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Windows\LogsWindow.xaml.cs");
+
+        // Assert: MainWindowと同じ、アプリアイコン付きのカスタムTitleBarを
+        // ExtendsContentIntoTitleBar + Tall高さで表示する。
+        StringAssert.Contains(xamlSourceText, "<TitleBar");
+        StringAssert.Contains(xamlSourceText, "IsPaneToggleButtonVisible=\"False\"");
+        StringAssert.Contains(xamlSourceText, "ImageSource=\"Assets/AppIcon.ico\"");
+        StringAssert.Contains(codeBehindSourceText, "ExtendsContentIntoTitleBar = true;");
+        StringAssert.Contains(codeBehindSourceText, "TitleBarHeightOption.Tall");
+        StringAssert.Contains(codeBehindSourceText, "SetTitleBar(");
+        StringAssert.Contains(codeBehindSourceText, "AppWindow.SetIcon(\"Assets/AppIcon.ico\");");
     }
 
     private static string ReadRepositorySourceFile(string relativePath)

--- a/tests/WslContainersDesktop.App.Tests/Windows/LogsWindowSourceTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/Windows/LogsWindowSourceTests.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace WslContainersDesktop_App_Tests.Windows;
+
+[TestClass]
+public sealed class LogsWindowSourceTests
+{
+    [TestMethod]
+    public void LogsWindow_ListView_BindsToViewModelLogLinesWithAutoScroll()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Windows\LogsWindow.xaml");
+
+        // Assert: 小さいログパネルと同じViewModel.LogLinesを共有し、末尾自動スクロールの
+        // Inverted listsパターン(ItemsUpdatingScrollMode="KeepLastItemInView")も踏襲する。
+        StringAssert.Contains(sourceText, "ItemsSource=\"{x:Bind ViewModel.LogLines, Mode=OneWay}\"");
+        StringAssert.Contains(sourceText, "ItemsUpdatingScrollMode=\"KeepLastItemInView\"");
+    }
+
+    [TestMethod]
+    public void LogsWindow_Header_HasPauseResumeClearAndCloseCommands()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Windows\LogsWindow.xaml");
+
+        // Assert: ポップアウト側からもPause/Resume/Clear/Closeを操作できること
+        // (rubber-duckレビュー指摘: ポップアウト側にセッション停止手段が必要)。
+        StringAssert.Contains(sourceText, "Command=\"{x:Bind ViewModel.PauseLogsCommand}\"");
+        StringAssert.Contains(sourceText, "Command=\"{x:Bind ViewModel.ResumeLogsCommand}\"");
+        StringAssert.Contains(sourceText, "Command=\"{x:Bind ViewModel.ClearLogsCommand}\"");
+        StringAssert.Contains(sourceText, "Command=\"{x:Bind ViewModel.CloseLogsCommand}\"");
+    }
+
+    private static string ReadRepositorySourceFile(string relativePath)
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var normalizedRelativePath = relativePath.Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar);
+        var fullPath = Path.Combine(repositoryRoot, normalizedRelativePath);
+
+        Assert.IsTrue(File.Exists(fullPath), $"Expected source file '{relativePath}' to exist at '{fullPath}'.");
+        return File.ReadAllText(fullPath);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var currentDirectory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (currentDirectory is not null)
+        {
+            var appProjectFilePath = Path.Combine(currentDirectory.FullName, "src", "WslContainersDesktop.App", "WslContainersDesktop.App.csproj");
+            if (File.Exists(appProjectFilePath))
+            {
+                return currentDirectory.FullName;
+            }
+
+            currentDirectory = currentDirectory.Parent;
+        }
+
+        Assert.Fail($"Could not locate repository root from '{AppContext.BaseDirectory}'.");
+        return string.Empty;
+    }
+}

--- a/tests/WslContainersDesktop.App.Tests/Windows/ShellWindowSourceTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/Windows/ShellWindowSourceTests.cs
@@ -73,6 +73,45 @@ public sealed class ShellWindowSourceTests
         StringAssert.Contains(codeBehindSourceText, "AppWindow.SetIcon(\"Assets/AppIcon.ico\");");
     }
 
+    [TestMethod]
+    public void ShellWindow_RootGrid_HasNameForLoadedEventSubscription()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Windows\ShellWindow.xaml");
+
+        // Assert: DPIリサイズはRootGridのLoadedイベントで行う(Activatedはウィンドウ再生成時に
+        // XamlRoot確立前に発火しNullReferenceExceptionを起こすため使わない)。
+        StringAssert.Contains(sourceText, "x:Name=\"RootGrid\"");
+    }
+
+    [TestMethod]
+    public void ShellWindowCodeBehind_DoesNotResizeOnActivated_ToAvoidXamlRootRaceConditionBug()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Windows\ShellWindow.xaml.cs");
+
+        // Assert: 「Shellウィンドウを閉じて再度開くとアプリがクラッシュする」バグの再発防止
+        // (LogsWindowと同型のバグ。詳細はLogsWindowCodeBehindの対応するテストのコメント参照)。
+        Assert.IsFalse(
+            sourceText.Contains("Activated += ShellWindow_Activated;"),
+            "ActivatedイベントでのDPIリサイズはXamlRoot未確立によるクラッシュを再発させるため使用禁止。");
+        StringAssert.Contains(sourceText, "RootGrid.Loaded +=");
+    }
+
+    [TestMethod]
+    public void ShellWindowCodeBehind_LoadedHandler_ReadsXamlRootFromRootGridNotContent()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Windows\ShellWindow.xaml.cs");
+
+        // Assert: Loadedイベントの時点ではRootGrid.XamlRootが確立済みであることを保証された
+        // 状態で読み取る(Content.XamlRootへの無条件アクセスを再導入しない)。
+        StringAssert.Contains(sourceText, "RootGrid.XamlRoot.RasterizationScale");
+        Assert.IsFalse(
+            sourceText.Contains("Content.XamlRoot.RasterizationScale"),
+            "Content.XamlRootへの無条件アクセスはXamlRoot未確立時にクラッシュするため使用禁止。");
+    }
+
     private static string ReadRepositorySourceFile(string relativePath)
     {
         var repositoryRoot = FindRepositoryRoot();

--- a/tests/WslContainersDesktop.App.Tests/Windows/ShellWindowSourceTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/Windows/ShellWindowSourceTests.cs
@@ -17,16 +17,60 @@ public sealed class ShellWindowSourceTests
     }
 
     [TestMethod]
-    public void ShellWindow_Footer_HasCommandInputSendAndCloseCommands()
+    public void ShellWindow_Footer_HasCommandInputAndSendCommand()
     {
         // Arrange
         var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Windows\ShellWindow.xaml");
 
-        // Assert: ポップアウト側からもコマンド送信・シェル切断ができること
+        // Assert: ポップアウト側からもコマンド送信ができること
         // (rubber-duckレビュー指摘: ポップアウト側にセッション停止手段が必要)。
         StringAssert.Contains(sourceText, "Text=\"{x:Bind ViewModel.ShellCommandText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}\"");
         StringAssert.Contains(sourceText, "Command=\"{x:Bind ViewModel.SendShellCommandCommand}\"");
-        StringAssert.Contains(sourceText, "Command=\"{x:Bind ViewModel.CloseShellCommand}\"");
+    }
+
+    [TestMethod]
+    public void ShellWindow_CloseButton_UsesClickHandlerInsteadOfCloseShellCommand()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Windows\ShellWindow.xaml");
+
+        // Assert: Closeボタンはウィンドウを閉じるだけの操作にする(シェルセッション自体は継続する)ため、
+        // セッション停止用のCloseShellCommandではなくコードビハインドのClickハンドラに配線する。
+        StringAssert.Contains(sourceText, "x:Name=\"BtnCloseShell\"");
+        StringAssert.Contains(sourceText, "Click=\"BtnCloseShell_Click\"");
+        Assert.IsFalse(
+            sourceText.Contains("Command=\"{x:Bind ViewModel.CloseShellCommand}\""),
+            "BtnCloseShellはウィンドウを閉じるだけにするため、CloseShellCommandへのバインドを持ってはいけない。");
+    }
+
+    [TestMethod]
+    public void ShellWindowCodeBehind_CloseButtonClickHandler_ClosesWindow()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Windows\ShellWindow.xaml.cs");
+
+        // Assert: Clickハンドラが実際にWindow.Close()を呼び出していること
+        // (ボタンの存在確認だけでは押下時に何もしない実装を見逃すため)。
+        StringAssert.Contains(sourceText, "BtnCloseShell_Click");
+        StringAssert.Contains(sourceText, "Close();");
+    }
+
+    [TestMethod]
+    public void ShellWindow_TitleBar_MatchesMainWindowLookAndFeel()
+    {
+        // Arrange
+        var xamlSourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Windows\ShellWindow.xaml");
+        var codeBehindSourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Windows\ShellWindow.xaml.cs");
+
+        // Assert: MainWindowと同じ、アプリアイコン付きのカスタムTitleBarを
+        // ExtendsContentIntoTitleBar + Tall高さで表示する。
+        StringAssert.Contains(xamlSourceText, "<TitleBar");
+        StringAssert.Contains(xamlSourceText, "IsPaneToggleButtonVisible=\"False\"");
+        StringAssert.Contains(xamlSourceText, "ImageSource=\"Assets/AppIcon.ico\"");
+        StringAssert.Contains(codeBehindSourceText, "ExtendsContentIntoTitleBar = true;");
+        StringAssert.Contains(codeBehindSourceText, "TitleBarHeightOption.Tall");
+        StringAssert.Contains(codeBehindSourceText, "SetTitleBar(");
+        StringAssert.Contains(codeBehindSourceText, "AppWindow.SetIcon(\"Assets/AppIcon.ico\");");
     }
 
     private static string ReadRepositorySourceFile(string relativePath)

--- a/tests/WslContainersDesktop.App.Tests/Windows/ShellWindowSourceTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/Windows/ShellWindowSourceTests.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace WslContainersDesktop_App_Tests.Windows;
+
+[TestClass]
+public sealed class ShellWindowSourceTests
+{
+    [TestMethod]
+    public void ShellWindow_ListView_BindsToViewModelShellOutput()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Windows\ShellWindow.xaml");
+
+        // Assert: 小さいシェルパネルと同じViewModel.ShellOutputを共有する。
+        StringAssert.Contains(sourceText, "ItemsSource=\"{x:Bind ViewModel.ShellOutput, Mode=OneWay}\"");
+    }
+
+    [TestMethod]
+    public void ShellWindow_Footer_HasCommandInputSendAndCloseCommands()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Windows\ShellWindow.xaml");
+
+        // Assert: ポップアウト側からもコマンド送信・シェル切断ができること
+        // (rubber-duckレビュー指摘: ポップアウト側にセッション停止手段が必要)。
+        StringAssert.Contains(sourceText, "Text=\"{x:Bind ViewModel.ShellCommandText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}\"");
+        StringAssert.Contains(sourceText, "Command=\"{x:Bind ViewModel.SendShellCommandCommand}\"");
+        StringAssert.Contains(sourceText, "Command=\"{x:Bind ViewModel.CloseShellCommand}\"");
+    }
+
+    private static string ReadRepositorySourceFile(string relativePath)
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var normalizedRelativePath = relativePath.Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar);
+        var fullPath = Path.Combine(repositoryRoot, normalizedRelativePath);
+
+        Assert.IsTrue(File.Exists(fullPath), $"Expected source file '{relativePath}' to exist at '{fullPath}'.");
+        return File.ReadAllText(fullPath);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var currentDirectory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (currentDirectory is not null)
+        {
+            var appProjectFilePath = Path.Combine(currentDirectory.FullName, "src", "WslContainersDesktop.App", "WslContainersDesktop.App.csproj");
+            if (File.Exists(appProjectFilePath))
+            {
+                return currentDirectory.FullName;
+            }
+
+            currentDirectory = currentDirectory.Parent;
+        }
+
+        Assert.Fail($"Could not locate repository root from '{AppContext.BaseDirectory}'.");
+        return string.Empty;
+    }
+}

--- a/tests/WslContainersDesktop.App.Tests/Windows/SingleInstanceWindowOpenerTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/Windows/SingleInstanceWindowOpenerTests.cs
@@ -1,0 +1,120 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using WslContainersDesktop_App.Windows;
+
+namespace WslContainersDesktop_App_Tests.Windows;
+
+[TestClass]
+public sealed class SingleInstanceWindowOpenerTests
+{
+    // テスト対象は実際のWinUI Windowを必要としない、ただのCLRオブジェクト。
+    // ShowOrActivateがWindow型に依存せず「生成/再利用/Closed後の再生成」だけを
+    // 検証できることを示す。
+    private sealed class FakeWindow
+    {
+        public int ActivateCallCount { get; private set; }
+
+        public void Activate() => ActivateCallCount++;
+    }
+
+    [TestMethod]
+    public void ShowOrActivate_FirstCall_CreatesAndActivatesWindow()
+    {
+        // Arrange
+        var createCallCount = 0;
+        FakeWindow? createdWindow = null;
+        var sut = new SingleInstanceWindowOpener<FakeWindow>(
+            createWindow: () =>
+            {
+                createCallCount++;
+                createdWindow = new FakeWindow();
+                return createdWindow;
+            },
+            activateWindow: w => w.Activate(),
+            registerClosedHandler: (_, _) => { });
+
+        // Act
+        sut.ShowOrActivate();
+
+        // Assert
+        Assert.AreEqual(1, createCallCount, "初回呼び出しではウィンドウを1つ生成する必要がある。");
+        Assert.AreEqual(1, createdWindow!.ActivateCallCount, "生成しただけでなく、必ずActivateする必要がある(前面表示されないと導線として機能しない)。");
+    }
+
+    [TestMethod]
+    public void ShowOrActivate_CalledAgainWithoutClosing_ReusesExistingWindowAndActivatesIt()
+    {
+        // Arrange
+        var createCallCount = 0;
+        FakeWindow? createdWindow = null;
+        var sut = new SingleInstanceWindowOpener<FakeWindow>(
+            createWindow: () =>
+            {
+                createCallCount++;
+                createdWindow = new FakeWindow();
+                return createdWindow;
+            },
+            activateWindow: w => w.Activate(),
+            registerClosedHandler: (_, _) => { });
+
+        // Act
+        sut.ShowOrActivate();
+        sut.ShowOrActivate();
+
+        // Assert
+        Assert.AreEqual(1, createCallCount, "既存ウィンドウが開いている間は新規に生成してはいけない。");
+        Assert.AreEqual(2, createdWindow!.ActivateCallCount, "2回目の呼び出しでは既存ウィンドウをActivateする必要がある。");
+    }
+
+    [TestMethod]
+    public void ShowOrActivate_CalledAfterClosedCallbackInvoked_CreatesNewWindow()
+    {
+        // Arrange
+        var createCallCount = 0;
+        Action? closedCallback = null;
+        var sut = new SingleInstanceWindowOpener<FakeWindow>(
+            createWindow: () =>
+            {
+                createCallCount++;
+                return new FakeWindow();
+            },
+            activateWindow: w => w.Activate(),
+            registerClosedHandler: (_, onClosed) => closedCallback = onClosed);
+
+        // Act
+        sut.ShowOrActivate();
+        closedCallback!.Invoke();
+        sut.ShowOrActivate();
+
+        // Assert
+        Assert.AreEqual(2, createCallCount, "Closedコールバック後の呼び出しでは新しいウィンドウを生成し直す必要がある。");
+    }
+
+    [TestMethod]
+    public void ShowOrActivate_ReopenedAfterClose_RegistersClosedHandlerAgainForSecondWindow()
+    {
+        // Arrange: Closed後の再オープン→再クローズという2サイクル目でも、2つ目のウィンドウに対して
+        // ちゃんとClosedハンドラーが登録され、3回目のShowOrActivateで正しく作り直されることを確認する。
+        var createCallCount = 0;
+        Action? closedCallback = null;
+        var sut = new SingleInstanceWindowOpener<FakeWindow>(
+            createWindow: () =>
+            {
+                createCallCount++;
+                return new FakeWindow();
+            },
+            activateWindow: w => w.Activate(),
+            registerClosedHandler: (_, onClosed) => closedCallback = onClosed);
+
+        // Act
+        sut.ShowOrActivate(); // 1つ目生成
+        closedCallback!.Invoke(); // 1つ目クローズ
+        sut.ShowOrActivate(); // 2つ目生成
+        closedCallback!.Invoke(); // 2つ目クローズ(2つ目に対してもハンドラーが登録されている必要がある)
+        sut.ShowOrActivate(); // 3つ目生成
+
+        // Assert
+        Assert.AreEqual(3, createCallCount, "何度クローズ→再オープンを繰り返しても、そのたびに新しいウィンドウを生成し直す必要がある。");
+    }
+}


### PR DESCRIPTION
## Why

The embedded Logs/Shell panels in the container detail view are small and hard to read for long-running output or interactive shell sessions. This adds a way to pop them out into full-size, independent windows while keeping the small embedded panel available.

## What changed

- **Pop-out windows**: Added `LogsWindow`/`ShellWindow`, opened via a button on the embedded Logs/Shell panels (`SingleInstanceWindowOpener` ensures only one pop-out per panel type at a time, reusing the same underlying `ContainersViewModel` state so both views stay in sync).
- **Consistent look and feel**: Pop-out windows now use the same custom `TitleBar` pattern as `MainWindow` (`ExtendsContentIntoTitleBar`, `TitleBarHeightOption.Tall`, app icon), instead of the default title bar.
- **Close button semantics**: The in-window Close button now only closes the pop-out window; it no longer stops the underlying log-follow/shell session. Previously it stopped the session, which made the still-open pop-out window look blank and confusing. The embedded panel keeps working after the pop-out is closed.
- **Crash fix**: Fixed a bug where closing a pop-out window and reopening it crashed the app. The windows resized themselves on the first `Activated` event using `Content.XamlRoot.RasterizationScale`, but `SingleInstanceWindowOpener` creates a new window instance on each reopen, and `Activated` could fire before `XamlRoot` was established on that new instance, throwing an unhandled `NullReferenceException`. Switched to using the root `Grid`'s `Loaded` event instead, which only fires once `XamlRoot` is guaranteed to be set.

## Verification

- Full unit test suite passes (333/333), including new regression tests asserting the title bar setup, Close-button-closes-window-only behavior, and the `Loaded`-based (not `Activated`-based) resize logic.
- Manually reproduced the original crash by building and running the app, then verified the fix at runtime via UI automation (open, close, reopen) for both the Logs and Shell pop-out windows - no crash, correct DPI-scaled size on reopen.