### PR TITLE
Containers画面のボタン見切れとヘッダー/行のずれを修正

### DIFF
--- a/src/WslContainersDesktop.App/Pages/ContainersPage.xaml
+++ b/src/WslContainersDesktop.App/Pages/ContainersPage.xaml
@@ -87,11 +87,11 @@
 
                     <Grid Grid.Row="0" Padding="12,8" ColumnSpacing="12">
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="260" />
-                            <ColumnDefinition Width="100" />
-                            <ColumnDefinition Width="90" />
-                            <ColumnDefinition Width="140" />
-                            <ColumnDefinition Width="220" />
+                            <ColumnDefinition Width="*" MinWidth="120" />
+                            <ColumnDefinition Width="130" />
+                            <ColumnDefinition Width="120" />
+                            <ColumnDefinition Width="150" />
+                            <ColumnDefinition Width="190" />
                         </Grid.ColumnDefinitions>
                         <TextBlock Grid.Column="0" Text="Name" FontWeight="SemiBold" />
                         <TextBlock Grid.Column="1" Text="Image" FontWeight="SemiBold" />
@@ -110,16 +110,16 @@
                             <DataTemplate x:DataType="vm:ContainerRowViewModel">
                                 <Grid Padding="12,8" ColumnSpacing="12" HorizontalAlignment="Stretch">
                                     <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="260" />
-                                        <ColumnDefinition Width="100" />
-                                        <ColumnDefinition Width="90" />
-                                        <ColumnDefinition Width="140" />
-                                        <ColumnDefinition Width="220" />
+                                        <ColumnDefinition Width="*" MinWidth="120" />
+                                        <ColumnDefinition Width="130" />
+                                        <ColumnDefinition Width="120" />
+                                        <ColumnDefinition Width="150" />
+                                        <ColumnDefinition Width="190" />
                                     </Grid.ColumnDefinitions>
-                                    <TextBlock Grid.Column="0" VerticalAlignment="Center" Text="{x:Bind Name}" />
-                                    <TextBlock Grid.Column="1" VerticalAlignment="Center" Text="{x:Bind Image}" />
-                                    <TextBlock Grid.Column="2" VerticalAlignment="Center" Text="{x:Bind DisplayState, Mode=OneWay, Converter={StaticResource StateToDisplayTextConverter}}" />
-                                    <TextBlock Grid.Column="3" VerticalAlignment="Center" Text="{x:Bind CreatedAt, Converter={StaticResource CreatedAtConverter}}" />
+                                    <TextBlock Grid.Column="0" VerticalAlignment="Center" Text="{x:Bind Name}" TextTrimming="CharacterEllipsis" />
+                                    <TextBlock Grid.Column="1" VerticalAlignment="Center" Text="{x:Bind Image}" TextTrimming="CharacterEllipsis" />
+                                    <TextBlock Grid.Column="2" VerticalAlignment="Center" Text="{x:Bind DisplayState, Mode=OneWay, Converter={StaticResource StateToDisplayTextConverter}}" TextTrimming="CharacterEllipsis" />
+                                    <TextBlock Grid.Column="3" VerticalAlignment="Center" Text="{x:Bind CreatedAt, Converter={StaticResource CreatedAtConverter}}" TextTrimming="CharacterEllipsis" />
                                     <StackPanel Grid.Column="4" HorizontalAlignment="Right" Orientation="Horizontal" Spacing="4">
                                         <!-- Start/Stopはよく使う操作のため、"..."メニューの中に隠さずトップレベルに表示する。
                                              状態に応じてどちらか一方(または操作進行中はどちらも非表示)のみ表示する。 -->


### PR DESCRIPTION
## 背景

Containers画面のテーブルで2つの表示不具合があった。

1. デフォルトのウィンドウサイズだと、右端のStart/Stop/...操作ボタンが列幅の合計(固定幅810px超)により見切れて表示されない。
2. 上記の応急修正としてActions列を`Width="Auto"`にしたところ、行ごとにStart/Stopボタンの有無で列幅が変わり、隣のStar列(Name)の幅も連動して変化。結果としてヘッダーと各行、および行同士で列の開始位置がずれてしまった。State列(90px)も"Restarting…"等の長い文言で隣列にはみ出していた。

## 対応内容

- Actions列を`Auto`幅から**固定幅190px**に変更し、Start/Stopボタンの有無に関わらず常に同じ幅を確保。これによりName列(Star)の幅が行ごとにぶれる問題を解消。
- State列を90px→120pxに拡大し、"Restarting…"等の最長文言でも収まるように調整。
- Image列(100→130px)、Created列(140→150px)も併せて調整。
- ヘッダー行と各行テンプレートの列定義を完全に一致させ、Image/State/Created各列に`TextTrimming="CharacterEllipsis"`を追加してテキストが隣列にはみ出さないようにした。

## 確認

`dotnet build`でビルドが成功することを確認済み。単純なレイアウト調整（設計判断を伴わない）のため、機能開発フローの6フェーズは適用せず直接修正した。