### PR TITLE
Bump package version to 1.1.0.0

### DIFF
--- a/src/WslContainersDesktop.App/Package.appxmanifest
+++ b/src/WslContainersDesktop.App/Package.appxmanifest
@@ -10,7 +10,7 @@
   <Identity
     Name="45014okazuki.Hakonexa-WSLContainersManager"
     Publisher="CN=57A8C5FA-395A-4109-91A0-CF1B93556B5D"
-    Version="1.0.0.0" />
+    Version="1.1.0.0" />
 
   <mp:PhoneIdentity PhoneProductId="4F24CC3B-CE1C-4B87-92A5-48C0A3EB5A98" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 


### PR DESCRIPTION
## Summary
- Update the Microsoft Store package identity version from `1.0.0.0` to `1.1.0.0`.

## Package validation
- Built the Release Store upload for x64 and arm64 with `scripts\Build-StoreMsixUpload.ps1`.
- Validated all manifest image assets in both architecture packages.
- Produced `45014okazuki.Hakonexa-WSLContainersManager_1.1.0.0.msixupload`.