### PR TITLE
Stabilize ARM64 app test builds

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -63,6 +63,20 @@ WinUI / .NET デスクトップアプリケーションです。新しい **WSL 
 [`AGENTS.md`](AGENTS.md) にまとめています。人間のコントリビューターが同じ開発フローに従う場合も、
 そちらを参照してください。
 
+## ビルドとテスト
+
+対象アーキテクチャと同じネイティブWindowsホストでビルドとテストを実行します。追加のMSBuildプロパティは不要です。
+
+```powershell
+# ARM64
+dotnet build WslContainersDesktop.slnx -p:Platform=ARM64
+dotnet test tests\WslContainersDesktop.App.Tests\WslContainersDesktop.App.Tests.csproj -p:Platform=ARM64
+
+# x64
+dotnet build WslContainersDesktop.slnx -p:Platform=x64
+dotnet test tests\WslContainersDesktop.App.Tests\WslContainersDesktop.App.Tests.csproj -p:Platform=x64
+```
+
 ## セットアップ（Copilot CLIでの開発に必要なplugin）
 
 このリポジトリのCopilot運用には、以下のplugin/marketplaceが必要です。未導入の環境では以下を

--- a/README.md
+++ b/README.md
@@ -64,6 +64,21 @@ This repository is designed to be developed with GitHub Copilot CLI and other AI
 agents. Agent operating rules, including the required feature workflow, TDD policy, ADR
 handling, and model routing, are documented in [`AGENTS.md`](AGENTS.md).
 
+## Building and testing
+
+Build and test on a Windows host that natively matches the target architecture. No additional
+MSBuild properties are required.
+
+```powershell
+# ARM64
+dotnet build WslContainersDesktop.slnx -p:Platform=ARM64
+dotnet test tests\WslContainersDesktop.App.Tests\WslContainersDesktop.App.Tests.csproj -p:Platform=ARM64
+
+# x64
+dotnet build WslContainersDesktop.slnx -p:Platform=x64
+dotnet test tests\WslContainersDesktop.App.Tests\WslContainersDesktop.App.Tests.csproj -p:Platform=x64
+```
+
 ## Copilot CLI plugin setup
 
 The repository workflow expects the following Copilot CLI plugins/marketplaces. These are

--- a/src/WslContainersDesktop.App/WslContainersDesktop.App.csproj
+++ b/src/WslContainersDesktop.App/WslContainersDesktop.App.csproj
@@ -6,6 +6,9 @@
     <RootNamespace>WslContainersDesktop_App</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' and '$(Platform)' == 'x86'">win-x86</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' and '$(Platform)' == 'x64'">win-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' and '$(Platform)' == 'ARM64'">win-arm64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">win-$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</RuntimeIdentifier>
     <PublishProfile Condition="Exists('Properties\PublishProfiles\win-$(Platform).pubxml')">win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>

--- a/tests/WslContainersDesktop.App.Tests/WslContainersDesktop.App.Tests.csproj
+++ b/tests/WslContainersDesktop.App.Tests/WslContainersDesktop.App.Tests.csproj
@@ -6,6 +6,9 @@
     <RootNamespace>WslContainersDesktop_App_Tests</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x86;x64;ARM64</Platforms>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' and '$(Platform)' == 'x86'">win-x86</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' and '$(Platform)' == 'x64'">win-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' and '$(Platform)' == 'ARM64'">win-arm64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">win-$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant())</RuntimeIdentifier>
     <PublishProfile Condition="Exists('Properties\PublishProfiles\win-$(Platform).pubxml')">win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
@@ -20,6 +23,8 @@
       引き起こすため無効化する。
     -->
     <WindowsAppSdkDeploymentManagerInitialize>false</WindowsAppSdkDeploymentManagerInitialize>
+    <!-- The test host is unpackaged, so it must not run the MSIX payload pipeline. -->
+    <WindowsPackageType>None</WindowsPackageType>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
ARM64 Windows can invoke an x86 MSBuild host, causing the App and App.Tests runtime identifiers to diverge from the selected platform. App.Tests also needs to run unpackaged so normal test builds do not enter the MSIX payload pipeline.

- Resolve the default RID from `Platform` for ARM64, x64, and x86 while preserving explicit RID overrides and the AnyCPU host fallback.
- Configure App.Tests as unpackaged, leaving App MSIX packaging unchanged.
- Document native ARM64 and x64 build/test commands in both READMEs.

Validated with the full ARM64 test suite (573 passed) and an x64 solution build.

Fixes: #50