### PR TITLE
Terminate CLI process trees on cancellation

### DIFF
--- a/src/WslContainersDesktop.Infrastructure/Cli/CliProcess.cs
+++ b/src/WslContainersDesktop.Infrastructure/Cli/CliProcess.cs
@@ -1,0 +1,72 @@
+using System.Diagnostics;
+
+namespace WslContainersDesktop.Infrastructure.Cli;
+
+internal sealed class CliProcess : ICliProcess
+{
+    private readonly ProcessJob _job = new();
+    private readonly Process _process;
+
+    public CliProcess(ProcessStartInfo startInfo)
+    {
+        _process = new Process { StartInfo = startInfo };
+    }
+
+    public int ExitCode => _process.ExitCode;
+
+    public bool HasExited => _process.HasExited;
+
+    public void Start()
+    {
+        _process.Start();
+        try
+        {
+            _job.Add(_process);
+        }
+        catch
+        {
+            if (!_process.HasExited)
+            {
+                _process.Kill(entireProcessTree: true);
+            }
+
+            throw;
+        }
+    }
+
+    public Task<string> ReadStandardOutputAsync(CancellationToken cancellationToken)
+    {
+        return _process.StandardOutput.ReadToEndAsync(cancellationToken);
+    }
+
+    public Task<string> ReadStandardErrorAsync(CancellationToken cancellationToken)
+    {
+        return _process.StandardError.ReadToEndAsync(cancellationToken);
+    }
+
+    public Task WaitForExitAsync(CancellationToken cancellationToken)
+    {
+        return _process.WaitForExitAsync(cancellationToken);
+    }
+
+    public void KillEntireProcessTree()
+    {
+        try
+        {
+            if (!_process.HasExited)
+            {
+                _process.Kill(entireProcessTree: true);
+            }
+        }
+        finally
+        {
+            _job.Dispose();
+        }
+    }
+
+    public void Dispose()
+    {
+        _job.Dispose();
+        _process.Dispose();
+    }
+}

--- a/src/WslContainersDesktop.Infrastructure/Cli/CliProcessExecutor.cs
+++ b/src/WslContainersDesktop.Infrastructure/Cli/CliProcessExecutor.cs
@@ -1,0 +1,83 @@
+using System.Diagnostics;
+
+namespace WslContainersDesktop.Infrastructure.Cli;
+
+/// <summary>
+/// 標準出力と標準エラーを収集しながら、外部CLIプロセスを実行する。
+/// </summary>
+public sealed class CliProcessExecutor
+{
+    private readonly Func<ProcessStartInfo, ICliProcess> _processFactory;
+
+    /// <summary>
+    /// <see cref="CliProcessExecutor"/> の新しいインスタンスを初期化する。
+    /// </summary>
+    /// <param name="processFactory">CLIプロセスを生成するファクトリ。省略時は <see cref="Process"/> を使用する。</param>
+    public CliProcessExecutor(Func<ProcessStartInfo, ICliProcess>? processFactory = null)
+    {
+        _processFactory = processFactory ?? (startInfo => new CliProcess(startInfo));
+    }
+
+    /// <summary>
+    /// プロセスを実行し、終了コードと収集した標準出力・標準エラーを返す。
+    /// キャンセル時にはプロセスツリーを終了し、終了と出力読み取りの完了後に破棄する。
+    /// </summary>
+    /// <param name="startInfo">実行するプロセスの開始情報。</param>
+    /// <param name="cancellationToken">実行を中止するトークン。</param>
+    /// <returns>CLIの終了コードと出力。</returns>
+    public async Task<CliResult> ExecuteAsync(ProcessStartInfo startInfo, CancellationToken cancellationToken = default)
+    {
+        var process = _processFactory(startInfo);
+
+        try
+        {
+            process.Start();
+
+            var standardOutputTask = process.ReadStandardOutputAsync(cancellationToken);
+            var standardErrorTask = process.ReadStandardErrorAsync(cancellationToken);
+
+            try
+            {
+                await process.WaitForExitAsync(cancellationToken);
+                await Task.WhenAll(standardOutputTask, standardErrorTask);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    process.KillEntireProcessTree();
+                }
+                catch (InvalidOperationException) when (process.HasExited)
+                {
+                    // The process ended between the exit check and Kill.
+                }
+
+                await process.WaitForExitAsync(CancellationToken.None);
+                await AwaitCancellationCompletionAsync(standardOutputTask, standardErrorTask, cancellationToken);
+                throw new OperationCanceledException(cancellationToken);
+            }
+
+            var standardOutput = await standardOutputTask;
+            var standardError = await standardErrorTask;
+            return new CliResult(process.ExitCode, standardOutput, standardError);
+        }
+        finally
+        {
+            process.Dispose();
+        }
+    }
+
+    private static async Task AwaitCancellationCompletionAsync(
+        Task<string> standardOutputTask,
+        Task<string> standardErrorTask,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await Task.WhenAll(standardOutputTask, standardErrorTask);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+    }
+}

--- a/src/WslContainersDesktop.Infrastructure/Cli/ICliProcess.cs
+++ b/src/WslContainersDesktop.Infrastructure/Cli/ICliProcess.cs
@@ -1,0 +1,47 @@
+using System.Diagnostics;
+
+namespace WslContainersDesktop.Infrastructure.Cli;
+
+/// <summary>
+/// 外部CLIプロセスの実行をテスト可能にするための低レベル抽象。
+/// </summary>
+public interface ICliProcess : IDisposable
+{
+    /// <summary>
+    /// プロセスの終了コードを取得する。
+    /// </summary>
+    int ExitCode { get; }
+
+    /// <summary>
+    /// プロセスが終了したかどうかを取得する。
+    /// </summary>
+    bool HasExited { get; }
+
+    /// <summary>
+    /// プロセスを開始する。
+    /// </summary>
+    void Start();
+
+    /// <summary>
+    /// 標準出力の全内容を非同期に読み取る。
+    /// </summary>
+    /// <param name="cancellationToken">読み取りを中止するトークン。</param>
+    Task<string> ReadStandardOutputAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// 標準エラー出力の全内容を非同期に読み取る。
+    /// </summary>
+    /// <param name="cancellationToken">読み取りを中止するトークン。</param>
+    Task<string> ReadStandardErrorAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// プロセスの終了を待機する。
+    /// </summary>
+    /// <param name="cancellationToken">待機を中止するトークン。</param>
+    Task WaitForExitAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// プロセスツリー全体を終了する。
+    /// </summary>
+    void KillEntireProcessTree();
+}

--- a/src/WslContainersDesktop.Infrastructure/Cli/ProcessJob.cs
+++ b/src/WslContainersDesktop.Infrastructure/Cli/ProcessJob.cs
@@ -1,0 +1,104 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace WslContainersDesktop.Infrastructure.Cli;
+
+internal sealed class ProcessJob : IDisposable
+{
+    private const uint JobObjectLimitKillOnJobClose = 0x00002000;
+    private const int JobObjectExtendedLimitInformationClass = 9;
+    private readonly SafeFileHandle _handle;
+
+    public ProcessJob()
+    {
+        _handle = CreateJobObject(IntPtr.Zero, null);
+        if (_handle.IsInvalid)
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        var limitInformation = new JobObjectExtendedLimitInformation
+        {
+            BasicLimitInformation = new JobObjectBasicLimitInformation
+            {
+                LimitFlags = JobObjectLimitKillOnJobClose,
+            },
+        };
+
+        if (!SetInformationJobObject(
+                _handle,
+                JobObjectExtendedLimitInformationClass,
+                ref limitInformation,
+                (uint)Marshal.SizeOf<JobObjectExtendedLimitInformation>()))
+        {
+            _handle.Dispose();
+            throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+    }
+
+    public void Add(Process process)
+    {
+        if (!AssignProcessToJobObject(_handle, process.Handle))
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+    }
+
+    public void Dispose()
+    {
+        _handle.Dispose();
+    }
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern SafeFileHandle CreateJobObject(IntPtr jobAttributes, string? name);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool SetInformationJobObject(
+        SafeFileHandle job,
+        int jobObjectInfoClass,
+        ref JobObjectExtendedLimitInformation jobObjectInfo,
+        uint jobObjectInfoLength);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool AssignProcessToJobObject(SafeFileHandle job, IntPtr process);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct JobObjectExtendedLimitInformation
+    {
+        public JobObjectBasicLimitInformation BasicLimitInformation;
+        public IoCounters IoInfo;
+        public UIntPtr ProcessMemoryLimit;
+        public UIntPtr JobMemoryLimit;
+        public UIntPtr PeakProcessMemoryUsed;
+        public UIntPtr PeakJobMemoryUsed;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct JobObjectBasicLimitInformation
+    {
+        public long PerProcessUserTimeLimit;
+        public long PerJobUserTimeLimit;
+        public uint LimitFlags;
+        public UIntPtr MinimumWorkingSetSize;
+        public UIntPtr MaximumWorkingSetSize;
+        public uint ActiveProcessLimit;
+        public UIntPtr Affinity;
+        public uint PriorityClass;
+        public uint SchedulingClass;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct IoCounters
+    {
+        public ulong ReadOperationCount;
+        public ulong WriteOperationCount;
+        public ulong OtherOperationCount;
+        public ulong ReadTransferCount;
+        public ulong WriteTransferCount;
+        public ulong OtherTransferCount;
+    }
+}

--- a/src/WslContainersDesktop.Infrastructure/Cli/WslcCliRunner.cs
+++ b/src/WslContainersDesktop.Infrastructure/Cli/WslcCliRunner.cs
@@ -11,6 +11,7 @@ namespace WslContainersDesktop.Infrastructure.Cli;
 public sealed class WslcCliRunner : IWslcCliRunner
 {
     private readonly IWslcProcessFactory _processFactory;
+    private readonly CliProcessExecutor _cliProcessExecutor;
 
     public WslcCliRunner(string executablePath = "wslc")
         : this(new WslcProcessFactory(), executablePath)
@@ -20,6 +21,7 @@ public sealed class WslcCliRunner : IWslcCliRunner
     public WslcCliRunner(IWslcProcessFactory processFactory, string executablePath = "wslc")
     {
         _processFactory = processFactory;
+        _cliProcessExecutor = new CliProcessExecutor();
         ExecutablePath = executablePath;
     }
 
@@ -50,18 +52,7 @@ public sealed class WslcCliRunner : IWslcCliRunner
             startInfo.ArgumentList.Add(argument);
         }
 
-        using var process = new Process { StartInfo = startInfo };
-        process.Start();
-
-        var standardOutputTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
-        var standardErrorTask = process.StandardError.ReadToEndAsync(cancellationToken);
-
-        await process.WaitForExitAsync(cancellationToken);
-
-        var standardOutput = await standardOutputTask;
-        var standardError = await standardErrorTask;
-
-        return new CliResult(process.ExitCode, standardOutput, standardError);
+        return await _cliProcessExecutor.ExecuteAsync(startInfo, cancellationToken);
     }
 
     public async IAsyncEnumerable<string> StreamLinesAsync(

--- a/src/WslContainersDesktop.Infrastructure/Wsl/WslCommandRunner.cs
+++ b/src/WslContainersDesktop.Infrastructure/Wsl/WslCommandRunner.cs
@@ -11,6 +11,7 @@ namespace WslContainersDesktop.Infrastructure.Wsl;
 public sealed class WslCommandRunner : IWslCommandRunner
 {
     private readonly string _executablePath;
+    private readonly CliProcessExecutor _cliProcessExecutor;
 
     /// <summary>
     /// <see cref="WslCommandRunner"/> の新しいインスタンスを初期化する。
@@ -19,6 +20,7 @@ public sealed class WslCommandRunner : IWslCommandRunner
     public WslCommandRunner(string executablePath = "wsl.exe")
     {
         _executablePath = executablePath;
+        _cliProcessExecutor = new CliProcessExecutor();
     }
 
     /// <inheritdoc />
@@ -41,17 +43,6 @@ public sealed class WslCommandRunner : IWslCommandRunner
             startInfo.ArgumentList.Add(argument);
         }
 
-        using var process = new Process { StartInfo = startInfo };
-        process.Start();
-
-        var standardOutputTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
-        var standardErrorTask = process.StandardError.ReadToEndAsync(cancellationToken);
-
-        await process.WaitForExitAsync(cancellationToken);
-
-        var standardOutput = await standardOutputTask;
-        var standardError = await standardErrorTask;
-
-        return new CliResult(process.ExitCode, standardOutput, standardError);
+        return await _cliProcessExecutor.ExecuteAsync(startInfo, cancellationToken);
     }
 }

--- a/tests/WslContainersDesktop.Infrastructure.Tests/Cli/CliProcessExecutorTests.cs
+++ b/tests/WslContainersDesktop.Infrastructure.Tests/Cli/CliProcessExecutorTests.cs
@@ -1,0 +1,389 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using WslContainersDesktop.Infrastructure.Cli;
+
+namespace WslContainersDesktop.Infrastructure.Tests.Cli;
+
+[TestClass]
+public sealed class CliProcessExecutorTests
+{
+    [TestMethod]
+    public async Task WaitForExitAsync_WhenProcessCompletesOnStart_CompletesFirstWaitImmediatelyAndOnlyMarksPostKillFlagForSecondWait()
+    {
+        // Arrange
+        var process = new FakeCliProcess(completeWaitForExitOnStart: true);
+
+        // Act
+        process.Start();
+
+        var firstWaitTask = process.WaitForExitAsync(CancellationToken.None);
+        await Task.WhenAny(firstWaitTask, Task.Delay(TimeSpan.FromMilliseconds(200)));
+
+        // Assert
+        Assert.IsTrue(firstWaitTask.IsCompleted);
+        Assert.IsFalse(process.PostKillWaitForExitCompleted);
+
+        process.KillEntireProcessTree();
+
+        var secondWaitTask = process.WaitForExitAsync(CancellationToken.None);
+        await Task.WhenAny(secondWaitTask, Task.Delay(TimeSpan.FromMilliseconds(200)));
+
+        Assert.IsTrue(secondWaitTask.IsCompleted);
+        Assert.IsTrue(process.PostKillWaitForExitCompleted);
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_CancellationAfterRootExitWhileReadersPending_KillsProcessWaitsForReadersAndRethrowsOperationCanceledException()
+    {
+        // Arrange
+        var process = new FakeCliProcess(completeWaitForExitOnStart: true);
+        var executor = new CliProcessExecutor(_ => process);
+        var startInfo = new ProcessStartInfo("cmd.exe") { Arguments = "/c timeout /t 30" };
+        using var cts = new CancellationTokenSource();
+        var executeTask = executor.ExecuteAsync(startInfo, cts.Token);
+
+        await process.WaitForExitObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await process.ReadersStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Act
+        cts.Cancel();
+
+        // Assert
+        var exception = await Assert.ThrowsExactlyAsync<OperationCanceledException>(async () => await executeTask);
+        Assert.AreEqual(cts.Token, exception.CancellationToken);
+        Assert.IsTrue(process.KillEntireProcessTreeCalled);
+        Assert.IsTrue(process.PostKillWaitForExitCompleted);
+        Assert.IsTrue(process.WaitForExitCancellationObserved);
+        Assert.IsTrue(process.StandardOutputReadCancelled);
+        Assert.IsTrue(process.StandardErrorReadCancelled);
+        Assert.IsTrue(process.DisposeCalled);
+
+        var sequence = process.EventLog.ToArray();
+        Assert.IsGreaterThanOrEqualTo(0, Array.IndexOf(sequence, "canceled"));
+        Assert.IsGreaterThanOrEqualTo(0, Array.IndexOf(sequence, "kill"));
+        Assert.IsGreaterThanOrEqualTo(0, Array.IndexOf(sequence, "output-cancelled"));
+        Assert.IsGreaterThanOrEqualTo(0, Array.IndexOf(sequence, "error-cancelled"));
+        Assert.IsGreaterThanOrEqualTo(0, Array.IndexOf(sequence, "dispose"));
+        Assert.IsGreaterThanOrEqualTo(0, Array.IndexOf(sequence, "wait-for-exit-1"));
+        Assert.IsGreaterThanOrEqualTo(0, Array.IndexOf(sequence, "wait-for-exit-2"));
+        Assert.IsLessThan(Array.IndexOf(sequence, "wait-for-exit-2"), Array.IndexOf(sequence, "kill"));
+        Assert.IsLessThan(Array.IndexOf(sequence, "dispose"), Array.IndexOf(sequence, "output-cancelled"));
+        Assert.IsLessThan(Array.IndexOf(sequence, "dispose"), Array.IndexOf(sequence, "error-cancelled"));
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_CancellationWhileProcessRuns_KillsEntireProcessTreeAwaitsExitAndRethrowsOperationCanceledException()
+    {
+        // Arrange
+        var process = new FakeCliProcess();
+        var executor = new CliProcessExecutor(_ => process);
+        var startInfo = new ProcessStartInfo("cmd.exe") { Arguments = "/c timeout /t 30" };
+        using var cts = new CancellationTokenSource();
+        var executeTask = executor.ExecuteAsync(startInfo, cts.Token);
+
+        await process.WaitForExitObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Act
+        cts.Cancel();
+
+        // Assert
+        var exception = await Assert.ThrowsExactlyAsync<OperationCanceledException>(async () => await executeTask);
+        Assert.AreEqual(cts.Token, exception.CancellationToken);
+        Assert.IsTrue(process.KillEntireProcessTreeCalled);
+        Assert.IsTrue(process.WaitForExitAsyncCalled);
+        Assert.AreEqual(2, process.WaitForExitInvocationCount);
+        CollectionAssert.AreEqual(new[] { 1, 2 }, process.WaitForExitInvocationOrder.ToArray());
+        Assert.IsTrue(process.PostKillWaitForExitCompleted);
+        Assert.IsTrue(process.WaitForExitCancellationObserved);
+        Assert.IsTrue(process.StandardOutputReadCompleted);
+        Assert.IsTrue(process.StandardErrorReadCompleted);
+        Assert.IsTrue(process.DisposeCalled);
+
+        var sequence = process.EventLog.ToArray();
+        Assert.IsGreaterThanOrEqualTo(0, Array.IndexOf(sequence, "canceled"));
+        Assert.IsGreaterThanOrEqualTo(0, Array.IndexOf(sequence, "kill"));
+        Assert.IsGreaterThanOrEqualTo(0, Array.IndexOf(sequence, "output-completed"));
+        Assert.IsGreaterThanOrEqualTo(0, Array.IndexOf(sequence, "error-completed"));
+        Assert.IsGreaterThanOrEqualTo(0, Array.IndexOf(sequence, "dispose"));
+        Assert.IsGreaterThanOrEqualTo(0, Array.IndexOf(sequence, "wait-for-exit-1"));
+        Assert.IsGreaterThanOrEqualTo(0, Array.IndexOf(sequence, "wait-for-exit-2"));
+        Assert.IsLessThan(Array.IndexOf(sequence, "kill"), Array.IndexOf(sequence, "canceled"));
+        Assert.IsLessThan(Array.IndexOf(sequence, "kill"), Array.IndexOf(sequence, "wait-for-exit-1"));
+        Assert.IsGreaterThan(Array.IndexOf(sequence, "kill"), Array.IndexOf(sequence, "wait-for-exit-2"));
+        Assert.IsLessThan(Array.IndexOf(sequence, "dispose"), Array.IndexOf(sequence, "wait-for-exit-2"));
+        Assert.IsLessThan(Array.IndexOf(sequence, "dispose"), Array.IndexOf(sequence, "output-completed"));
+        Assert.IsLessThan(Array.IndexOf(sequence, "dispose"), Array.IndexOf(sequence, "error-completed"));
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_CancellationWhileProcessRuns_WhenKillEntireProcessTreeThrowsBecauseProcessAlreadyExited_StillAwaitsPostKillExitAndStreamsAndRethrowsOriginalOperationCanceledException()
+    {
+        // Arrange
+        var process = new FakeCliProcess(killEntireProcessTreeException: new InvalidOperationException("process already exited"));
+        var executor = new CliProcessExecutor(_ => process);
+        var startInfo = new ProcessStartInfo("cmd.exe") { Arguments = "/c timeout /t 30" };
+        using var cts = new CancellationTokenSource();
+        var executeTask = executor.ExecuteAsync(startInfo, cts.Token);
+
+        await process.WaitForExitObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Act
+        cts.Cancel();
+
+        // Assert
+        var exception = await Assert.ThrowsExactlyAsync<OperationCanceledException>(async () => await executeTask);
+        Assert.AreEqual(cts.Token, exception.CancellationToken);
+        Assert.IsTrue(process.KillEntireProcessTreeCalled);
+        Assert.IsTrue(process.HasExited);
+        Assert.IsTrue(process.WaitForExitAsyncCalled);
+        Assert.AreEqual(2, process.WaitForExitInvocationCount);
+        CollectionAssert.AreEqual(new[] { 1, 2 }, process.WaitForExitInvocationOrder.ToArray());
+        Assert.IsTrue(process.PostKillWaitForExitCompleted);
+        Assert.IsTrue(process.WaitForExitCancellationObserved);
+        Assert.IsTrue(process.StandardOutputReadCompleted);
+        Assert.IsTrue(process.StandardErrorReadCompleted);
+        Assert.IsTrue(process.DisposeCalled);
+
+        var sequence = process.EventLog.ToArray();
+        Assert.IsGreaterThanOrEqualTo(0, Array.IndexOf(sequence, "canceled"));
+        Assert.IsGreaterThanOrEqualTo(0, Array.IndexOf(sequence, "kill"));
+        Assert.IsGreaterThanOrEqualTo(0, Array.IndexOf(sequence, "output-completed"));
+        Assert.IsGreaterThanOrEqualTo(0, Array.IndexOf(sequence, "error-completed"));
+        Assert.IsGreaterThanOrEqualTo(0, Array.IndexOf(sequence, "dispose"));
+        Assert.IsGreaterThanOrEqualTo(0, Array.IndexOf(sequence, "wait-for-exit-1"));
+        Assert.IsGreaterThanOrEqualTo(0, Array.IndexOf(sequence, "wait-for-exit-2"));
+        Assert.IsLessThan(Array.IndexOf(sequence, "kill"), Array.IndexOf(sequence, "canceled"));
+        Assert.IsLessThan(Array.IndexOf(sequence, "kill"), Array.IndexOf(sequence, "wait-for-exit-1"));
+        Assert.IsGreaterThan(Array.IndexOf(sequence, "kill"), Array.IndexOf(sequence, "wait-for-exit-2"));
+        Assert.IsLessThan(Array.IndexOf(sequence, "dispose"), Array.IndexOf(sequence, "wait-for-exit-2"));
+        Assert.IsLessThan(Array.IndexOf(sequence, "dispose"), Array.IndexOf(sequence, "output-completed"));
+        Assert.IsLessThan(Array.IndexOf(sequence, "dispose"), Array.IndexOf(sequence, "error-completed"));
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_ProcessExitsNormally_ReturnsCapturedOutputAndExitCode()
+    {
+        // Arrange
+        var process = new FakeCliProcess("hello-stdout", "hello-stderr", completeStreamsImmediately: true, completeWaitForExitOnStart: true)
+        {
+            ExitCode = 7,
+        };
+        var executor = new CliProcessExecutor(_ => process);
+        var startInfo = new ProcessStartInfo("cmd.exe") { Arguments = "/c echo hello" };
+
+        // Act
+        var result = await executor.ExecuteAsync(startInfo);
+
+        // Assert
+        Assert.AreEqual(7, result.ExitCode);
+        Assert.AreEqual("hello-stdout", result.StandardOutput);
+        Assert.AreEqual("hello-stderr", result.StandardError);
+        Assert.IsFalse(process.KillEntireProcessTreeCalled);
+        Assert.IsTrue(process.DisposeCalled);
+    }
+
+    [TestMethod]
+    public async Task ExecuteAsync_ProcessStartThrows_DisposesProcessWithoutKillAndPropagatesException()
+    {
+        // Arrange
+        var process = new FakeCliProcess(startException: new InvalidOperationException("boom"));
+        var executor = new CliProcessExecutor(_ => process);
+        var startInfo = new ProcessStartInfo("cmd.exe") { Arguments = "/c echo hello" };
+
+        // Act
+        var exception = await Assert.ThrowsExactlyAsync<InvalidOperationException>(async () => await executor.ExecuteAsync(startInfo));
+
+        // Assert
+        Assert.AreEqual("boom", exception.Message);
+        Assert.IsFalse(process.KillEntireProcessTreeCalled);
+        Assert.IsTrue(process.DisposeCalled);
+    }
+
+    private sealed class FakeCliProcess : ICliProcess
+    {
+        private readonly TaskCompletionSource<string> _standardOutputReadTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<string> _standardErrorReadTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly List<TaskCompletionSource<object?>> _waitForExitTcs = new();
+
+        public FakeCliProcess(string standardOutput = "", string standardError = "", Exception? startException = null, bool completeStreamsImmediately = false, bool completeWaitForExitOnStart = false, Exception? killEntireProcessTreeException = null)
+        {
+            StandardOutput = standardOutput;
+            StandardError = standardError;
+            StartException = startException;
+            CompleteWaitForExitOnStart = completeWaitForExitOnStart;
+            KillEntireProcessTreeException = killEntireProcessTreeException;
+            if (completeStreamsImmediately)
+            {
+                CompleteStreams();
+            }
+        }
+
+        public string StandardOutput { get; }
+
+        public string StandardError { get; }
+
+        public Exception? StartException { get; }
+
+        public bool CompleteWaitForExitOnStart { get; }
+
+        public Exception? KillEntireProcessTreeException { get; }
+
+        public int ExitCode { get; set; }
+
+        public bool KillEntireProcessTreeCalled { get; private set; }
+
+        public bool ProcessExited { get; private set; }
+
+        public bool HasExited { get; private set; }
+
+        public bool DisposeCalled { get; private set; }
+
+        public bool WaitForExitAsyncCalled { get; private set; }
+
+        public int WaitForExitInvocationCount { get; private set; }
+
+        public List<int> WaitForExitInvocationOrder { get; } = new();
+
+        public bool PostKillWaitForExitCompleted { get; private set; }
+
+        public bool WaitForExitCancellationObserved { get; private set; }
+
+        public bool StandardOutputReadCompleted { get; private set; }
+
+        public bool StandardErrorReadCompleted { get; private set; }
+
+        public bool StandardOutputReadCancelled { get; private set; }
+
+        public bool StandardErrorReadCancelled { get; private set; }
+
+        public TaskCompletionSource<bool> ReadersStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource<bool> WaitForExitObserved { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public ConcurrentQueue<string> EventLog { get; } = new();
+
+        public void Start()
+        {
+            EventLog.Enqueue("start");
+            if (StartException is not null)
+            {
+                throw StartException;
+            }
+
+            if (CompleteWaitForExitOnStart)
+            {
+                ProcessExited = true;
+                HasExited = true;
+                CompleteWaitForExit();
+            }
+        }
+
+        public Task<string> ReadStandardOutputAsync(CancellationToken cancellationToken)
+        {
+            EventLog.Enqueue("read-output");
+            ReadersStarted.TrySetResult(true);
+
+            cancellationToken.Register(() =>
+            {
+                StandardOutputReadCompleted = true;
+                StandardOutputReadCancelled = true;
+                EventLog.Enqueue("output-cancelled");
+                _standardOutputReadTcs.TrySetCanceled(cancellationToken);
+            });
+
+            return _standardOutputReadTcs.Task;
+        }
+
+        public Task<string> ReadStandardErrorAsync(CancellationToken cancellationToken)
+        {
+            EventLog.Enqueue("read-error");
+            ReadersStarted.TrySetResult(true);
+
+            cancellationToken.Register(() =>
+            {
+                StandardErrorReadCompleted = true;
+                StandardErrorReadCancelled = true;
+                EventLog.Enqueue("error-cancelled");
+                _standardErrorReadTcs.TrySetCanceled(cancellationToken);
+            });
+
+            return _standardErrorReadTcs.Task;
+        }
+
+        public Task WaitForExitAsync(CancellationToken cancellationToken)
+        {
+            WaitForExitAsyncCalled = true;
+            WaitForExitInvocationCount += 1;
+            WaitForExitInvocationOrder.Add(WaitForExitInvocationCount);
+            EventLog.Enqueue($"wait-for-exit-{WaitForExitInvocationCount}");
+            WaitForExitObserved.TrySetResult(true);
+
+            var waitForExitTcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _waitForExitTcs.Add(waitForExitTcs);
+
+            if (ProcessExited && (WaitForExitInvocationCount >= 2 || CompleteWaitForExitOnStart))
+            {
+                if (WaitForExitInvocationCount >= 2)
+                {
+                    PostKillWaitForExitCompleted = true;
+                }
+
+                waitForExitTcs.TrySetResult(null);
+            }
+
+            cancellationToken.Register(() =>
+            {
+                WaitForExitCancellationObserved = true;
+                EventLog.Enqueue("canceled");
+                if (WaitForExitInvocationCount == 1)
+                {
+                    waitForExitTcs.TrySetException(new OperationCanceledException(cancellationToken));
+                }
+            });
+
+            return waitForExitTcs.Task;
+        }
+
+        public void CompleteWaitForExit()
+        {
+            EventLog.Enqueue("exit");
+            ProcessExited = true;
+            HasExited = true;
+            if (_waitForExitTcs.Count > 0)
+            {
+                _waitForExitTcs[0].TrySetResult(null);
+                _waitForExitTcs.RemoveAt(0);
+            }
+        }
+
+        public void KillEntireProcessTree()
+        {
+            KillEntireProcessTreeCalled = true;
+            EventLog.Enqueue("kill");
+            ProcessExited = true;
+            HasExited = true;
+            CompleteStreams();
+            if (KillEntireProcessTreeException is not null)
+            {
+                throw KillEntireProcessTreeException;
+            }
+        }
+
+        public void Dispose()
+        {
+            DisposeCalled = true;
+            EventLog.Enqueue("dispose");
+        }
+
+        private void CompleteStreams()
+        {
+            _standardOutputReadTcs.TrySetResult(StandardOutput);
+            StandardOutputReadCompleted = true;
+            EventLog.Enqueue("output-completed");
+            _standardErrorReadTcs.TrySetResult(StandardError);
+            StandardErrorReadCompleted = true;
+            EventLog.Enqueue("error-completed");
+        }
+    }
+}


### PR DESCRIPTION
CLI cancellation previously disposed the root `wslc` or `wsl.exe` process without ensuring its process tree had exited, leaving operations such as image pulls running in the background.

This centralizes one-shot CLI execution in `CliProcessExecutor`. Cancellation now terminates the process tree, waits for process exit and stdout/stderr completion, then disposes resources while preserving `OperationCanceledException`. A Windows Job Object keeps descendants associated even if the root process exits before output streams close. Both runners retain their existing executable-specific encodings.

Tests cover normal completion, start failures, cancellation during process execution, cancellation during output draining, disposal ordering, and the kill-versus-exit race.

Fixes: #47