### PR TITLE
Auto-hide inline Logs and Shell panels on pop-out

### DIFF
--- a/docs/design/containers-view.md
+++ b/docs/design/containers-view.md
@@ -174,9 +174,10 @@
 
 - 右側の補助ペインは小さいため、ログ・シェルパネルのヘッダーに「Open in window」ボタン
   （`BtnOpenLogsWindow`/`BtnOpenShellWindow`）を追加し、同じ内容を大きな個別ウィンドウ
-  （`Windows/LogsWindow.xaml`・`Windows/ShellWindow.xaml`）としても表示できる。小さい補助ペイン自体は
-  引き続き表示されたままで、どちらからでも同じ状態（`ContainersViewModel`の`LogLines`/`ShellOutput`
-  や各種コマンド）を操作できる。詳細パネルはこの導線の対象外。
+  （`Windows/LogsWindow.xaml`・`Windows/ShellWindow.xaml`）としても表示できる。個別ウィンドウを表示または
+  Activateした直後に、対応する小さい補助ペインを非表示にする。これは表示だけを切り替える処理であり、
+  `ContainersViewModel`の`LogLines`/`ShellOutput`やログ追跡・シェルセッションは維持され、個別ウィンドウから
+  引き続き操作できる。詳細パネルはこの導線の対象外。
 - 各ウィンドウは対象ごとに1つだけ開く。ボタンを押したとき既に開いていれば新規に開かず、既存の
   ウィンドウを`Activate()`するだけにとどめる。この生成/再利用/Closed後の再生成ロジックは
   `Windows/SingleInstanceWindowOpener.cs`（`SingleInstanceWindowOpener<TWindow>`）に切り出されている。
@@ -201,9 +202,10 @@
   ユーザーが`ContainersPage`から離れてポップアウトだけが残っている状態でもセッションを操作できる。
   各ウィンドウ内の`Close`ボタン（`BtnCloseLogs`/`BtnCloseShell`）およびタイトルバーの閉じるボタン
   （×）は、どちらも**このウィンドウを閉じるだけ**で、ログ追跡やシェル接続そのものは停止しない。
-  ログ追跡・シェル接続を終了するには、小さい補助ペイン側の`CloseLogsCommand`/`CloseShellCommand`
-  に配線されたCloseボタンを使う。ウィンドウを閉じる操作とセッションを終了する操作は意図的に
-  分離している（ポップアウトを閉じても小さい補助ペインは影響を受けず動作し続ける）。
+  ポップアウトを閉じても非表示にした小さい補助ペインは自動では再表示しない。ログ追跡・シェル接続を
+  終了するには、ログ/シェルを再度開いてインラインパネルを表示し、小さい補助ペイン側の
+  `CloseLogsCommand`/`CloseShellCommand`に配線されたCloseボタンを使う。ウィンドウを閉じる操作と
+  セッションを終了する操作は意図的に分離している。
 - `LogsWindow`/`ShellWindow`のタイトルバーは`MainWindow`と同じルック＆フィールにしている。
   `ExtendsContentIntoTitleBar = true`とアプリアイコン付きの`TitleBar`コントロール
   （`IsPaneToggleButtonVisible="False"`、`TitleBarHeightOption.Tall`）を各ウィンドウに配置し、

--- a/src/WslContainersDesktop.App/ViewModels/ContainersViewModel.cs
+++ b/src/WslContainersDesktop.App/ViewModels/ContainersViewModel.cs
@@ -363,6 +363,14 @@ public sealed partial class ContainersViewModel(
     }
 
     /// <summary>
+    /// シェルパネルを非表示にする。
+    /// </summary>
+    public void HideShellPanel()
+    {
+        IsShellPanelVisible = false;
+    }
+
+    /// <summary>
     /// 現在のシェルへ入力欄のコマンドを送信する。
     /// </summary>
     [RelayCommand]
@@ -463,6 +471,14 @@ public sealed partial class ContainersViewModel(
         ClearPausedLogBuffer();
         UpdateLogEmpty();
         return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// ログパネルを非表示にする。
+    /// </summary>
+    public void HideLogPanel()
+    {
+        IsLogPanelVisible = false;
     }
 
     /// <summary>

--- a/src/WslContainersDesktop.App/Windows/ContainerAuxiliaryWindowManager.cs
+++ b/src/WslContainersDesktop.App/Windows/ContainerAuxiliaryWindowManager.cs
@@ -20,9 +20,11 @@ public sealed class ContainerAuxiliaryWindowManager
 {
     private readonly SingleInstanceWindowOpener<LogsWindow> _logsWindowOpener;
     private readonly SingleInstanceWindowOpener<ShellWindow> _shellWindowOpener;
+    private readonly ContainersViewModel _viewModel;
 
     public ContainerAuxiliaryWindowManager(ContainersViewModel viewModel)
     {
+        _viewModel = viewModel;
         _logsWindowOpener = new SingleInstanceWindowOpener<LogsWindow>(
             createWindow: () => new LogsWindow(viewModel),
             activateWindow: window => window.Activate(),
@@ -35,14 +37,22 @@ public sealed class ContainerAuxiliaryWindowManager
     }
 
     /// <summary>
-    /// ログのポップアウトウィンドウを開く。既に開いていれば新規に開かず、既存ウィンドウを
-    /// Activateするだけにとどめる。
+    /// ログのポップアウトウィンドウを開き、対応するインラインのログパネルを非表示にする。
+    /// 既に開いていれば新規に開かず、既存ウィンドウをActivateしてからパネルを非表示にする。
     /// </summary>
-    public void ShowLogsWindow() => _logsWindowOpener.ShowOrActivate();
+    public void ShowLogsWindow()
+    {
+        _logsWindowOpener.ShowOrActivate();
+        _viewModel.HideLogPanel();
+    }
 
     /// <summary>
-    /// シェルのポップアウトウィンドウを開く。既に開いていれば新規に開かず、既存ウィンドウを
-    /// Activateするだけにとどめる。
+    /// シェルのポップアウトウィンドウを開き、対応するインラインのシェルパネルを非表示にする。
+    /// 既に開いていれば新規に開かず、既存ウィンドウをActivateしてからパネルを非表示にする。
     /// </summary>
-    public void ShowShellWindow() => _shellWindowOpener.ShowOrActivate();
+    public void ShowShellWindow()
+    {
+        _shellWindowOpener.ShowOrActivate();
+        _viewModel.HideShellPanel();
+    }
 }

--- a/tests/WslContainersDesktop.App.Tests/ViewModels/ContainersViewModelTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/ViewModels/ContainersViewModelTests.cs
@@ -1169,6 +1169,33 @@ public sealed class ContainersViewModelTests
     }
 
     [TestMethod]
+    public async Task HideLogPanel_RunningContainerFollowIsActive_HidesPanelWithoutStoppingFollow()
+    {
+        // Arrange
+        var service = new FakeContainerManagementService
+        {
+            DefaultContainers = [CreateContainer("c1", ContainerState.Running)],
+            DefaultLogs = ["old"],
+        };
+        var sut = new ContainersViewModel(service, new RecordingDispatcher());
+        var followChannel = Channel.CreateUnbounded<string>();
+        service.FollowLogsChannel = followChannel;
+        await sut.OpenLogsAsync("c1");
+        Assert.IsTrue(sut.IsLogPanelVisible);
+
+        // Act
+        sut.HideLogPanel();
+        await followChannel.Writer.WriteAsync("new");
+        await WaitForConditionAsync(() => sut.LogLines.Count == 2, TimeSpan.FromSeconds(1));
+
+        // Assert
+        Assert.IsFalse(sut.IsLogPanelVisible);
+        Assert.IsFalse(sut.IsSidePanelVisible);
+        Assert.AreEqual(0, service.FollowCancellationCount);
+        CollectionAssert.AreEqual(new[] { "old", "new" }, sut.LogLines.ToList());
+    }
+
+    [TestMethod]
     public async Task FollowStreamThrowsRuntimeException_SetsLogErrorMessageAndKeepsExistingLines()
     {
         // Arrange
@@ -1509,6 +1536,29 @@ public sealed class ContainersViewModelTests
         Assert.IsFalse(sut.IsShellPanelVisible);
         Assert.IsFalse(sut.IsShellConnected);
         Assert.IsFalse(sut.IsSidePanelVisible);
+    }
+
+    [TestMethod]
+    public async Task HideShellPanel_ConnectedSession_HidesPanelWithoutClosingSession()
+    {
+        // Arrange
+        var session = new FakeContainerExecSession();
+        var service = new FakeContainerManagementService { ExecSession = session };
+        var sut = new ContainersViewModel(service);
+        await sut.OpenShellAsync("c1");
+        sut.ShellCommandText = "pwd";
+        Assert.IsTrue(sut.IsShellPanelVisible);
+
+        // Act
+        sut.HideShellPanel();
+        await sut.SendShellCommandAsync();
+
+        // Assert
+        Assert.IsFalse(sut.IsShellPanelVisible);
+        Assert.IsFalse(sut.IsSidePanelVisible);
+        Assert.IsTrue(sut.IsShellConnected);
+        Assert.IsFalse(session.CloseCalled);
+        CollectionAssert.AreEqual(new[] { "pwd" }, session.Commands);
     }
 
     [TestMethod]

--- a/tests/WslContainersDesktop.App.Tests/Windows/ContainerAuxiliaryWindowManagerSourceTests.cs
+++ b/tests/WslContainersDesktop.App.Tests/Windows/ContainerAuxiliaryWindowManagerSourceTests.cs
@@ -29,8 +29,46 @@ public sealed class ContainerAuxiliaryWindowManagerSourceTests
         // それぞれのopenerを合成するだけであること。
         StringAssert.Contains(sourceText, "new SingleInstanceWindowOpener<LogsWindow>(");
         StringAssert.Contains(sourceText, "new SingleInstanceWindowOpener<ShellWindow>(");
-        StringAssert.Contains(sourceText, "public void ShowLogsWindow() => _logsWindowOpener.ShowOrActivate();");
-        StringAssert.Contains(sourceText, "public void ShowShellWindow() => _shellWindowOpener.ShowOrActivate();");
+    }
+
+    [TestMethod]
+    public void ContainerAuxiliaryWindowManager_ShowLogsAndShellWindows_HidesMatchingInlinePanelsAfterPopOutIsShown()
+    {
+        // Arrange
+        var sourceText = ReadRepositorySourceFile(@"src\WslContainersDesktop.App\Windows\ContainerAuxiliaryWindowManager.cs");
+
+        // Assert: ポップアウトを表示またはActivateした後にだけ、対応するインラインパネルを隠す。
+        AssertShowCallPrecedesHideCall(
+            sourceText,
+            "_logsWindowOpener.ShowOrActivate();",
+            "_viewModel.HideLogPanel();");
+        AssertShowCallPrecedesHideCall(
+            sourceText,
+            "_shellWindowOpener.ShowOrActivate();",
+            "_viewModel.HideShellPanel();");
+    }
+
+    private static void AssertShowCallPrecedesHideCall(string sourceText, string showCall, string hideCall)
+    {
+        Assert.AreEqual(1, CountOccurrences(sourceText, showCall), $"Expected exactly one '{showCall}' call.");
+        Assert.AreEqual(1, CountOccurrences(sourceText, hideCall), $"Expected exactly one '{hideCall}' call.");
+
+        var showIndex = sourceText.IndexOf(showCall, StringComparison.Ordinal);
+        var hideIndex = sourceText.IndexOf(hideCall, StringComparison.Ordinal);
+        Assert.IsGreaterThan(showIndex, hideIndex, $"Expected '{showCall}' to precede '{hideCall}'.");
+    }
+
+    private static int CountOccurrences(string sourceText, string value)
+    {
+        var count = 0;
+        var searchStart = 0;
+        while ((searchStart = sourceText.IndexOf(value, searchStart, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            searchStart += value.Length;
+        }
+
+        return count;
     }
 
     private static string ReadRepositorySourceFile(string relativePath)


### PR DESCRIPTION
## Why

Opening Logs or Shell in a separate window currently leaves the same panel visible in MainWindow, creating duplicate UI and reducing the available list space.

## What changed

- Added display-only `HideLogPanel()` and `HideShellPanel()` methods that preserve log follow and shell sessions.
- Updated the auxiliary window manager to show or activate the pop-out before hiding its matching inline panel.
- Added coverage for state preservation and call ordering, and updated the containers view design snapshot.

## Notes

Closing a pop-out closes only that window; it does not restore the inline panel or terminate the active session. The inline panel can be shown again by reopening Logs or Shell.

Fixes: #57