### PR TITLE
Bump package version to 1.2.0.0

### DIFF
--- a/src/WslContainersDesktop.App/Package.appxmanifest
+++ b/src/WslContainersDesktop.App/Package.appxmanifest
@@ -10,7 +10,7 @@
   <Identity
     Name="45014okazuki.Hakonexa-WSLContainersManager"
     Publisher="CN=57A8C5FA-395A-4109-91A0-CF1B93556B5D"
-    Version="1.1.0.0" />
+    Version="1.2.0.0" />
 
   <mp:PhoneIdentity PhoneProductId="4F24CC3B-CE1C-4B87-92A5-48C0A3EB5A98" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 


### PR DESCRIPTION
## Summary
- Update the Microsoft Store package version from 1.1.0.0 to 1.2.0.0.

## Validation
- All tests pass: 725 passed, 0 failed, 0 skipped.
- Store package generated and validated for x64 and ARM64.
- Manifest image validation passed.
- The repository diff contains only the manifest version change.